### PR TITLE
Clear the dirty part of the buffer, not the clean part

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -1895,7 +1895,7 @@ inline void test_bitpacker()
 
     serialize_check( bytesWritten == 10 );
 
-    memset( buffer + bytesWritten, 0, BufferSize - bytesWritten );
+    memset( buffer, 0, bytesWritten );
 
     serialize::BitReader reader( buffer, bytesWritten );
 


### PR DESCRIPTION
Isn't this supposed to clear the beginning of the buffer, where we just wrote things?