### PR TITLE
When building without exceptions with MSVC, malloc.h is required for alloca

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -104,6 +104,7 @@
 #ifdef _MSC_VER
 #pragma warning( disable : 4127 )
 #pragma warning( disable : 4244 )
+#include <malloc.h>
 #endif // #ifdef _MSC_VER
 
 #include <stdint.h>


### PR DESCRIPTION
Part of the changes discussed [here](https://github.com/mas-bandwidth/yojimbo/issues/203).