### PR TITLE
silence unintialized warning

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -1400,7 +1400,7 @@ namespace serialize
 
     template <typename Stream> bool serialize_float_internal( Stream & stream, float & value )
     {
-        uint32_t int_value;
+        uint32_t int_value = 0;
         if ( Stream::IsWriting )
         {
             memcpy( (char*) &int_value, &value, 4 );


### PR DESCRIPTION
When compiling with source fortification gcc complains about uninitialized `int_value` in `serialize_float_internal` function. I see that other serializing functions initialize the value to `0` so I hope it's ok to make it also the case for this one.

```
$ gcc -Wall -Wextra -O2 -D_FORTIFY_SOURCE=3 test.cpp 
In file included from /nix/store/pz6jgrfqyl2il2785a75vmwdp9vypv0j-glibc-2.40-66-dev/include/string.h:548,
                 from serialize.h:120,
                 from test.cpp:26:
In function ‘void* memcpy(void*, const void*, size_t)’,
    inlined from ‘bool serialize::serialize_float_internal(Stream&, float&) [with Stream = ReadStream]’ at serialize.h:1411:19:
/nix/store/pz6jgrfqyl2il2785a75vmwdp9vypv0j-glibc-2.40-66-dev/include/bits/string_fortified.h:29:33: warning: ‘int_value’ may be used uninitialized [-Wmaybe-uninitialized]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
serialize.h: In function ‘bool serialize::serialize_float_internal(Stream&, float&) [with Stream = ReadStream]’:
serialize.h:1403:18: note: ‘int_value’ was declared here
 1403 |         uint32_t int_value;
      |                  ^~~~~~~~~
```