### PR TITLE
[Bug Fix] Fix buffer overflow as a result of overflowed assert

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -453,7 +453,7 @@ namespace serialize
         void WriteBytes( const uint8_t * serialize_restrict data, int bytes )
         {
             serialize_assert( GetAlignBits() == 0 );
-            serialize_assert( m_bitsWritten + uint64_t(bytes) * 8 <= m_numBits );
+            serialize_assert( uint64_t(m_bitsWritten) + uint64_t(bytes) * 8 <= uint64_t(m_numBits) );
             serialize_assert( ( m_bitsWritten % 32 ) == 0 || ( m_bitsWritten % 32 ) == 8 || ( m_bitsWritten % 32 ) == 16 || ( m_bitsWritten % 32 ) == 24 );
 
             int headBytes = ( 4 - ( m_bitsWritten % 32 ) / 8 ) % 4;
@@ -715,7 +715,7 @@ namespace serialize
         void ReadBytes( uint8_t * serialize_restrict data, int bytes )
         {
             serialize_assert( GetAlignBits() == 0 );
-            serialize_assert( m_bitsRead + uint64_t(bytes) * 8 <= m_numBits );
+            serialize_assert( uint64_t(m_bitsRead) + uint64_t(bytes) * 8 <= uint64_t(m_numBits) );
             serialize_assert( ( m_bitsRead % 32 ) == 0 || ( m_bitsRead % 32 ) == 8 || ( m_bitsRead % 32 ) == 16 || ( m_bitsRead % 32 ) == 24 );
 
             int headBytes = ( 4 - ( m_bitsRead % 32 ) / 8 ) % 4;

--- a/serialize.h
+++ b/serialize.h
@@ -453,7 +453,7 @@ namespace serialize
         void WriteBytes( const uint8_t * serialize_restrict data, int bytes )
         {
             serialize_assert( GetAlignBits() == 0 );
-            serialize_assert( m_bitsWritten + bytes * 8 <= m_numBits );
+            serialize_assert( m_bitsWritten + uint64_t(bytes) * 8 <= m_numBits );
             serialize_assert( ( m_bitsWritten % 32 ) == 0 || ( m_bitsWritten % 32 ) == 8 || ( m_bitsWritten % 32 ) == 16 || ( m_bitsWritten % 32 ) == 24 );
 
             int headBytes = ( 4 - ( m_bitsWritten % 32 ) / 8 ) % 4;
@@ -715,7 +715,7 @@ namespace serialize
         void ReadBytes( uint8_t * serialize_restrict data, int bytes )
         {
             serialize_assert( GetAlignBits() == 0 );
-            serialize_assert( m_bitsRead + bytes * 8 <= m_numBits );
+            serialize_assert( m_bitsRead + uint64_t(bytes) * 8 <= m_numBits );
             serialize_assert( ( m_bitsRead % 32 ) == 0 || ( m_bitsRead % 32 ) == 8 || ( m_bitsRead % 32 ) == 16 || ( m_bitsRead % 32 ) == 24 );
 
             int headBytes = ( 4 - ( m_bitsRead % 32 ) / 8 ) % 4;


### PR DESCRIPTION
These bytes checks can be skipped by putting an integer value for bytes that's large enough to cause the assertion to overflow, resulting in a buffer overflow later in the call. This change always just widens it to make sure the check occurs. Tested on Visual Studio 2022 in Debug and Release.

## PoC Reader
```cpp
#include "serialize.h"
#include <stdio.h>
#include <stdlib.h>
#include <limits.h>

int main()
{
    const int BUFFER_SIZE = 64;
    uint8_t buffer[BUFFER_SIZE];
    memset(buffer, 0xAA, BUFFER_SIZE);

    // Initialize ReadStream with the small buffer
    serialize::ReadStream stream(buffer, BUFFER_SIZE);

    // Attack: INT_MAX causes bytes * 8 to overflow
    const int ATTACK_SIZE = INT_MAX;

    printf("Testing ReadStream with ATTACK_SIZE = %d\n", ATTACK_SIZE);
    printf("Expected: Should not read beyond buffer bounds\n");

    uint8_t output[BUFFER_SIZE];
    stream.SerializeBytes(output, ATTACK_SIZE);

    printf("Test completed\n");
    return 0;
}
```

## PoC Writer
```cpp
#include "serialize.h"
#include <stdio.h>
#include <stdlib.h>

int main()
{
    const int BUFFER_SIZE = 64;  
    uint8_t buffer[BUFFER_SIZE];
    memset(buffer, 0xAA, BUFFER_SIZE);

    // Initialize WriteStream with the small buffer
    serialize::WriteStream stream(buffer, BUFFER_SIZE);

    const int ATTACK_SIZE = INT_MAX;  

    stream.SerializeBytes(buffer, ATTACK_SIZE);

    return 0;
}
```