### PR TITLE
Add release version check workflow

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,51 @@
+name: Release Check
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  version-check:
+    name: version consistency
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check versions
+        run: |
+          cmake_version=$(sed -nE 's/^project\(serialize VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' CMakeLists.txt)
+          header_full=$(sed -nE 's/^#define SERIALIZE_VERSION[[:space:]]+"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' serialize.h)
+          major=$(sed -nE 's/^#define SERIALIZE_VERSION_MAJOR[[:space:]]+([0-9]+).*/\1/p' serialize.h)
+          minor=$(sed -nE 's/^#define SERIALIZE_VERSION_MINOR[[:space:]]+([0-9]+).*/\1/p' serialize.h)
+          patch=$(sed -nE 's/^#define SERIALIZE_VERSION_PATCH[[:space:]]+([0-9]+).*/\1/p' serialize.h)
+          if [ -z "$cmake_version" ] || [ -z "$header_full" ] || [ -z "$major" ] || [ -z "$minor" ] || [ -z "$patch" ]; then
+            echo "::error::Could not extract versions (CMakeLists.txt: '$cmake_version', SERIALIZE_VERSION: '$header_full', MAJOR/MINOR/PATCH: '$major.$minor.$patch')"
+            exit 1
+          fi
+          echo "CMakeLists.txt project version: $cmake_version"
+          echo "serialize.h SERIALIZE_VERSION:  $header_full"
+          echo "serialize.h MAJOR.MINOR.PATCH:  $major.$minor.$patch"
+          if [ "$header_full" != "$major.$minor.$patch" ]; then
+            echo "::error::SERIALIZE_VERSION ($header_full) does not match SERIALIZE_VERSION_MAJOR/MINOR/PATCH ($major.$minor.$patch) in serialize.h"
+            exit 1
+          fi
+          if [ "$cmake_version" != "$header_full" ]; then
+            echo "::error::project(serialize VERSION $cmake_version) in CMakeLists.txt does not match SERIALIZE_VERSION ($header_full) in serialize.h"
+            exit 1
+          fi
+          case "$GITHUB_REF" in
+            refs/tags/*)
+              tag_version="${GITHUB_REF_NAME#v}"
+              echo "Release tag version:            $tag_version"
+              if [ "$tag_version" != "$cmake_version" ]; then
+                echo "::error::Tag $GITHUB_REF_NAME does not match version $cmake_version in CMakeLists.txt and serialize.h — bump both as part of the release."
+                exit 1
+              fi
+              ;;
+          esac


### PR DESCRIPTION
Adds a small `Release Check` workflow that fails the tag build if a release tag (`vX.Y.Z`) does not match the version recorded in the repo, so a release cannot ship with stale version metadata. Motivated by netcode v1.3.2, which shipped with its CMake `project()` version still at 1.3.1 and needed a follow-up v1.3.3 release to fix.

Where the repo records the version in more than one place, the workflow also cross-checks them on every push and pull request, so drift is caught at PR time rather than release time. Verified locally against the current tree: matching tag passes, mismatched tag fails, non-tag refs run only the consistency checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)