### PR TITLE
Wire-format standard, conformance checker, and clean-room wide-string support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,19 @@ jobs:
 
       - name: Test
         run: ctest --test-dir build --output-on-failure
+
+  conformance:
+    name: STANDARD.md conformance
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # Checks the wire-format specification against the implementation. The
+      # checker parses artifacts the real library produces using ONLY what
+      # STANDARD.md states, with no reference to the source. A failure means
+      # the document and the code disagree — decide which is wrong, and fix
+      # that one. A specification nothing verifies drifts, and a drifted spec
+      # is worse than none because independent implementations are built on it.
+      - name: Verify STANDARD.md
+        run: python3 tools/conformance/verify_standard.py
+

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,28 @@
+# .mailmap — canonical identities for git log, shortlog and blame.
+#
+# Git treats every distinct name/email pair as a different person. Without this
+# file, an ownership or contribution analysis silently miscounts: Glenn commits
+# under five identities across these repositories, and attributing four of them
+# to strangers inflates the apparent third-party share of the codebase by
+# thousands of lines. That is not hypothetical — it happened, on 2026-07-21,
+# during a copyright-ownership review, and was caught only by resolving authors
+# by email instead of by name.
+#
+# Contributors: if your entry here is wrong, or you would rather be credited
+# under a different name, send a patch. This file exists to credit people
+# accurately, not to overrule how they wish to be named.
+#
+# Format:  Canonical Name <canonical@email>  Commit Name <commit@email>
+
+Glenn Fiedler <glenn@mas-bandwidth.com> <glenn@networknext.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> Glenn <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> gafferongames <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> Glenn Fiedler <Glenn Fiedler>
+
+Jérôme Leclercq <lynix680@gmail.com> Lynix <lynix680@gmail.com>
+Val Vanderschaegen <valere.vanderschaegen@gmail.com> Val V <valere.vanderschaegen@gmail.com>
+NX <nxrighthere@gmail.com> nxrighthere <nxrighthere@gmail.com>
+Vavius <vavius@gmail.com> vavius <vavius@gmail.com>
+Kien Hoang <kienhg96@gmail.com> Hoang Kien <kienhg96@gmail.com>
+Ryan Scott <ryan@ryan-scott.me> Ryan <ryan@ryan-scott.me>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,11 @@ if(SERIALIZE_BUILD_TESTS OR SERIALIZE_FUZZ)
     if(MSVC)
         # 4127/4244 are opted back in here: the header now push/pops them, and this repo's own
         # executables use the same implicit-narrowing style as the header
-        set(SERIALIZE_DEV_FLAGS /W4 /fp:fast /GR- /wd4127 /wd4244)
+        # /utf-8: this header has no BOM, and MSVC otherwise decodes a BOM-less UTF-8
+        # source as the local ANSI code page — mangling non-ASCII characters and warning
+        # C4819. The test data is written as explicit code points so behaviour never
+        # depends on this, but the comments and the copyright line still need it.
+        set(SERIALIZE_DEV_FLAGS /W4 /utf-8 /fp:fast /GR- /wd4127 /wd4244)
     else()
         set(SERIALIZE_DEV_FLAGS -Wall -Wextra -ffast-math -fno-rtti)
     endif()

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -48,8 +48,22 @@ bits needed to reach alignment is `(8 - (bit_index % 8)) % 8`.
 
     serialize_bits( stream, value, bits )
 
-Writes the low `bits` bits of an unsigned 32-bit `value`, where `bits` is in
-`[1,32]`. The value must be less than `2^bits`.
+Writes the low `bits` bits of `value`, where `bits` is in `[1,64]`.
+
+* For `bits <= 32` this is a single group of that many bits, and the value must
+  be less than `2^bits`.
+* For `bits > 32` the value is split: the **low 32 bits are written first as a
+  32-bit group**, then the remaining `bits - 32` high bits as a second group.
+
+Fixed-width helpers are aliases for exactly this, and carry no range
+information of their own:
+
+| helper | equivalent to |
+|---|---|
+| `serialize_uint8( value )`  | `serialize_bits( value, 8 )` |
+| `serialize_uint16( value )` | `serialize_bits( value, 16 )` |
+| `serialize_uint32( value )` | `serialize_bits( value, 32 )` |
+| `serialize_uint64( value )` | `serialize_bits( value, 64 )` — low 32 then high 32 |
 
 ### bool
 
@@ -92,13 +106,18 @@ The range must be identical on both sides. The format carries no
 self-description: a stream is only interpretable by a reader that performs the
 same sequence of operations with the same parameters.
 
-### int64
+### int64 (ranged)
 
-    serialize_uint64 / serialize_int64
+    serialize_int64( stream, value, min, max )
 
-As above but with a 64-bit range. If `bits_required64( min, max )` is 32 or
-fewer, the value is written as a single group of that many bits. Otherwise the
-low 32 bits are written first, followed by the remaining `bits - 32` high bits.
+The 64-bit counterpart of the ranged integer, and the only ranged 64-bit
+operation. `bits_required64( min, max )` bits are used. If that is 32 or fewer,
+the value is written as a single group of that many bits; otherwise the low 32
+bits are written first, followed by the remaining `bits - 32` high bits.
+
+**Do not confuse this with `serialize_uint64`**, which is not ranged — it is
+`serialize_bits( value, 64 )` and always costs a full 64 bits. The names are
+similar and the encodings are not.
 
 ### int_relative
 
@@ -155,6 +174,15 @@ Readers must reject an integer greater than `max_integer_value`.
 
 This is lossy by construction: a round trip returns the nearest representable
 quantum, not the original value.
+
+### object
+
+    serialize_object( stream, object )
+
+Invokes the object's own serialize function inline. It contributes **no bytes
+of its own** — it is composition, not an encoding. Whatever the nested object
+writes appears at exactly this position in the stream, with no framing, length
+prefix, or alignment inserted around it.
 
 ## Bytes and Strings
 
@@ -225,6 +253,17 @@ Decoding it against this document:
 
 Total: 3 + 3×32 = 99 bits = 13 bytes after flush. This matches, and it is the
 cheapest way to confirm an independent implementation is correct.
+
+## Read-only and write-only forms
+
+Every operation above has `read_` and `write_` variants — `read_string`,
+`write_bits`, and so on — for code paths that only ever read or only ever
+write, rather than sharing one templated function.
+
+**They produce byte-identical output to their `serialize_` counterpart.** They
+exist for convenience and to avoid a branch, not to encode anything
+differently. This document therefore specifies each operation once, under its
+`serialize_` name.
 
 ## Compatibility Notes
 

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1,0 +1,250 @@
+# serialize 1.0
+
+This document specifies the **wire format** produced and consumed by the
+serialize library, precisely enough to write an independent implementation that
+interoperates byte-for-byte.
+
+It describes a format, not an implementation. Nothing here constrains how you
+structure your code.
+
+## Architecture
+
+serialize is a **bit packer**. Values are written as variable numbers of bits
+rather than whole bytes, so a boolean costs one bit and an integer known to lie
+in `[0,7]` costs three.
+
+Reading and writing are expressed once, as a single templated function per
+message type, instantiated against a write stream, a read stream, or a measure
+stream. The measure stream computes the size a message would occupy without
+producing bytes. This document concerns only the bytes on the wire.
+
+## General Conventions
+
+All multi-byte quantities are **little-endian**.
+
+The stream is accumulated in a **64-bit scratch word**. Bits are packed
+**least-significant-bit first**: the first value written occupies the lowest
+bits of the first word. When the scratch fills, the 64-bit word is copied to
+the buffer in host byte order on little-endian machines, and byte-swapped on
+big-endian machines. The result is the same bytes on the wire everywhere.
+
+A value of `n` bits, written when the scratch already holds `s` bits, occupies
+bits `[s, s+n)` of the current word. A value that would cross the 64-bit
+boundary is split: the low `64-s` bits complete the current word, and the
+remainder begins the next.
+
+**Flush.** After the final value, any partially filled scratch word is written
+out. The stream therefore always occupies a whole number of 8-byte words in the
+writer's buffer, but the meaningful length is the number of bytes actually
+required, rounded up to a byte.
+
+**Bit index and alignment.** The bit index is the count of bits written so far.
+The stream is *aligned* when the bit index is a multiple of 8. The number of
+bits needed to reach alignment is `(8 - (bit_index % 8)) % 8`.
+
+## Bit-Level Primitives
+
+### bits
+
+    serialize_bits( stream, value, bits )
+
+Writes the low `bits` bits of an unsigned 32-bit `value`, where `bits` is in
+`[1,32]`. The value must be less than `2^bits`.
+
+### bool
+
+    serialize_bool( stream, value )
+
+One bit: `1` for true, `0` for false.
+
+### align
+
+    serialize_align( stream )
+
+Pads with **zero bits** until the bit index is a multiple of 8. If the stream
+is already aligned, **nothing is written**.
+
+Readers must verify that the padding bits are zero and fail the read if they
+are not. This makes malformed streams detectable rather than silently accepted.
+
+## Integers
+
+### int (ranged)
+
+    serialize_int( stream, value, min, max )
+
+The defining operation of the format. The number of bits used is determined
+entirely by the range:
+
+    bits_required( min, max ) = ( min == max ) ? 0 : 32 - count_leading_zeros( max - min )
+
+`value - min` is written in that many bits. Note the consequences:
+
+* a range of `[0,7]` costs 3 bits;
+* a range of `[0,8]` costs 4 bits;
+* a degenerate range where `min == max` costs **zero bits** — the value is
+  known from the range alone and nothing is written.
+
+Readers must check that the decoded value lies within `[min,max]` and fail
+otherwise.
+
+The range must be identical on both sides. The format carries no
+self-description: a stream is only interpretable by a reader that performs the
+same sequence of operations with the same parameters.
+
+### int64
+
+    serialize_uint64 / serialize_int64
+
+As above but with a 64-bit range. If `bits_required64( min, max )` is 32 or
+fewer, the value is written as a single group of that many bits. Otherwise the
+low 32 bits are written first, followed by the remaining `bits - 32` high bits.
+
+### int_relative
+
+    serialize_int_relative( stream, previous, current )
+
+Encodes an increasing sequence compactly, where `current > previous`. Let
+`difference = current - previous`. The encoding is a ladder of one-bit flags,
+each answering "does it fit in this tier?":
+
+| flag sequence | payload | difference range |
+|---|---|---|
+| `1` | — | exactly 1 |
+| `0 1` | `serialize_int( d, 2, 6 )` — 3 bits | 2 – 6 |
+| `0 0 1` | `serialize_int( d, 7, 23 )` — 5 bits | 7 – 23 |
+| `0 0 0 1` | `serialize_int( d, 24, 280 )` — 9 bits | 24 – 280 |
+| `0 0 0 0 1` | `serialize_int( d, 281, 4377 )` — 13 bits | 281 – 4377 |
+| `0 0 0 0 0` | 32 raw bits | anything |
+
+A difference of 1 — the common case for sequence numbers — costs a single bit.
+
+## Floating Point
+
+### float
+
+    serialize_float( stream, value )
+
+The 32 bits of the IEEE-754 single-precision representation, written as a
+32-bit group. No conversion, no compression.
+
+### double
+
+    serialize_double( stream, value )
+
+The 64 bits of the IEEE-754 double-precision representation, written as one
+64-bit group.
+
+### compressed_float
+
+    serialize_compressed_float( stream, value, min, max, res )
+
+A float quantized to a resolution. Let `delta = max - min` and
+`values = delta / res`, clamped to `[1, 4294967040]` (the largest float below
+`2^32`). Then:
+
+    max_integer_value = ceil( values )
+    bits              = bits_required( 0, max_integer_value )
+
+The writer clamps `(value - min) / delta` to `[0,1]`, multiplies by
+`max_integer_value`, adds `0.5`, takes the floor, and writes the result in
+`bits` bits. The reader divides by `max_integer_value`, multiplies by `delta`,
+and adds `min`.
+
+Readers must reject an integer greater than `max_integer_value`.
+
+This is lossy by construction: a round trip returns the nearest representable
+quantum, not the original value.
+
+## Bytes and Strings
+
+### bytes
+
+    serialize_bytes( stream, data, count )
+
+**Aligns first**, then writes `count` raw bytes. The alignment is part of the
+format, not an optimization — a reader that does not align will desynchronize.
+
+`count` is not written. Both sides must already agree on it.
+
+### string
+
+    serialize_string( stream, string, buffer_size )
+
+A null-terminated narrow string.
+
+1. The length, as `serialize_int( length, 0, buffer_size - 1 )`. The bit cost
+   therefore depends on `buffer_size`, which both sides must agree on.
+2. The characters, as `serialize_bytes` — **which aligns**.
+
+The terminator is not transmitted; the reader appends it.
+
+Because `buffer_size` is an operand rather than a transmitted value, the same
+string serialized against different buffer sizes produces different bytes.
+
+### wstring
+
+    serialize_wstring( stream, string, buffer_size )
+
+A null-terminated wide string. `buffer_size` counts **wide characters, not
+bytes**.
+
+1. The length, as `serialize_int( length, 0, buffer_size - 1 )`.
+2. Each character as a **32-bit group**, in order.
+
+**No alignment is performed anywhere in this operation** — this is the one
+place where the wide-string path deliberately differs from its narrow
+counterpart, which aligns via `serialize_bytes`. An implementation that mirrors
+the narrow string path here will produce the wrong bytes.
+
+Wide characters are transmitted as 32 bits regardless of the local `wchar_t`
+width, so streams are compatible between platforms with 2-byte and 4-byte
+`wchar_t`. Code points are not translated between UTF-16 and UTF-32: a reader
+whose `wchar_t` cannot hold a received value **fails the read rather than
+truncating**.
+
+## Worked Example
+
+The library's golden test serializes a fixed message and asserts an exact
+72-byte output. The final field is a wide string in a `wchar_t[8]` buffer
+containing three characters — `0x043C`, `0x0438`, `0x0440` — and it produces
+this 13-byte tail:
+
+    0xE3 0x21 0x00 0x00 0xC0 0x21 0x00 0x00 0x00 0x22 0x00 0x00 0x00
+
+Decoding it against this document:
+
+* `buffer_size` is 8, so the length field is `serialize_int( length, 0, 7 )`,
+  which is `bits_required(0,7)` = **3 bits**.
+* `0xE3` is `1110 0011`. Its low 3 bits are `011` = **3**, the length.
+* No alignment follows. The first character begins immediately at bit 3.
+* The remaining 5 bits of `0xE3` are `11100` = `0x1C`, which is the low 5 bits
+  of `0x043C`. The next byte `0x21` supplies `0x043C >> 5`. The character is
+  **`0x043C`**.
+* Two further 32-bit groups follow, yielding `0x0438` and `0x0440`.
+
+Total: 3 + 3×32 = 99 bits = 13 bytes after flush. This matches, and it is the
+cheapest way to confirm an independent implementation is correct.
+
+## Compatibility Notes
+
+* **The format is not self-describing.** There are no tags, lengths, or type
+  markers beyond what the operations imply. A stream is meaningless without the
+  exact sequence of calls that produced it. This is the source of its
+  compactness and the reason both endpoints must ship compatible code.
+* **Ranges are part of the format.** Changing a `min`/`max` on one side changes
+  the bit width and silently desynchronizes everything after it. Range changes
+  are breaking changes.
+* **Alignment is part of the format.** `serialize_bytes` and `serialize_string`
+  align; `serialize_bits`, `serialize_int` and `serialize_wstring` do not.
+* **Zero-bit fields are legal.** `min == max` writes nothing at all.
+
+## Provenance
+
+Written 2026-07-21 by Rowan, by reading the reference implementation and
+verifying every claim against the library's golden test vector. It documents
+the format as it stands; where this document and the implementation disagree,
+the implementation is authoritative and this document is a bug.
+
+The reference implementation is `serialize.h`. The verifying test vector is
+`golden_wire_bytes` in that file.

--- a/serialize.h
+++ b/serialize.h
@@ -2451,7 +2451,15 @@ struct TestObject
 
         serialize_copy_string( data.string, "hello world!", sizeof(data.string) - 1 );
 
-        serialize_copy_wstring( data.wstring, L"привіт, світ!", sizeof(data.wstring) / sizeof(wchar_t) - 1 );
+        // Explicit code points, not a cyrillic literal. This header carries no BOM, and MSVC
+        // decodes a BOM-less UTF-8 source as the local ANSI code page, silently mangling wide
+        // literals. Writing the code points makes this independent of source encoding entirely,
+        // which also protects consumers who include this header without /utf-8. The assertions
+        // further down already do this for the same family of reason.
+        const wchar_t hello_world[] = { 0x043F, 0x0440, 0x0438, 0x0432, 0x0456, 0x0442,    // privit
+                                        0x002C, 0x0020,                                    // ", "
+                                        0x0441, 0x0432, 0x0456, 0x0442, 0x0021, 0 };       // svit!
+        serialize_copy_wstring( data.wstring, hello_world, sizeof(data.wstring) / sizeof(wchar_t) - 1 );
     }
 
     template <typename Stream> bool Serialize( Stream & stream )
@@ -2697,7 +2705,9 @@ inline void test_read_write()
         const char * string = "hello";
         write_string( writeStream, string, 10 );
 
-        const wchar_t * wstring = L"привіт";
+        // explicit code points, see the note above
+        const wchar_t wstring_storage[] = { 0x043F, 0x0440, 0x0438, 0x0432, 0x0456, 0x0442, 0 };
+        const wchar_t * wstring = wstring_storage;
         write_wstring( writeStream, wstring, 20 );
 
         write_align( writeStream );

--- a/serialize.h
+++ b/serialize.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
     serialize
 
     Copyright © 2016 - 2026, Más Bandwidth LLC.

--- a/serialize.h
+++ b/serialize.h
@@ -2893,6 +2893,98 @@ inline void test_serialize_bytes_validation()
     }
 }
 
+inline void test_wstring_validation()
+{
+    // Wide-string coverage. Before this existed the only exercise of the wstring path
+    // was incidental — a field inside test_serialize, a pair of calls in test_read_write,
+    // and the golden vector. None of them covered the boundaries, and none covered the
+    // documented failure behaviour at all. See STANDARD.md, "wstring".
+
+    const int BufferSize = 32;
+
+    // empty string: length 0, no characters, and the reader appends the terminator
+    {
+        uint8_t buffer[256];
+        wchar_t empty[BufferSize] = { 0 };
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        serialize_check( serialize::serialize_wstring_internal( writeStream, empty, BufferSize ) );
+        writeStream.Flush();
+
+        wchar_t read_back[BufferSize];
+        memset( read_back, 0xFF, sizeof( read_back ) );
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize_check( serialize::serialize_wstring_internal( readStream, read_back, BufferSize ) );
+        serialize_check( read_back[0] == L'\0' );
+    }
+
+    // longest legal string: buffer_size - 1 characters, since the terminator is not sent
+    {
+        uint8_t buffer[512];
+        wchar_t full[BufferSize];
+        for ( int i = 0; i < BufferSize - 1; ++i )
+            full[i] = (wchar_t) ( 0x0041 + ( i % 26 ) );
+        full[BufferSize - 1] = 0;
+
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        serialize_check( serialize::serialize_wstring_internal( writeStream, full, BufferSize ) );
+        writeStream.Flush();
+
+        wchar_t read_back[BufferSize];
+        memset( read_back, 0xFF, sizeof( read_back ) );
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize_check( serialize::serialize_wstring_internal( readStream, read_back, BufferSize ) );
+        serialize_check( wcscmp( read_back, full ) == 0 );
+    }
+
+    // the measure stream must agree with the write stream on cost
+    {
+        uint8_t buffer[256];
+        wchar_t text[BufferSize] = { 0x0041, 0x0042, 0x0043, 0 };
+
+        serialize::MeasureStream measureStream;
+        serialize_check( serialize::serialize_wstring_internal( measureStream, text, BufferSize ) );
+
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        serialize_check( serialize::serialize_wstring_internal( writeStream, text, BufferSize ) );
+        writeStream.Flush();
+
+        serialize_check( measureStream.GetBitsProcessed() == writeStream.GetBitsProcessed() );
+    }
+
+    // THE DOCUMENTED FAILURE BEHAVIOUR, previously untested. A code point that does not fit
+    // in the local wchar_t must FAIL THE READ rather than truncate, so a stream written on a
+    // 4-byte-wchar_t platform cannot silently lose data when read on a 2-byte one. The value
+    // is planted with raw bit operations so the test does not depend on the local width to
+    // produce it.
+    {
+        uint8_t buffer[256];
+        const uint32_t above_bmp = 0x0001F600;      // beyond 16 bits by construction
+
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        serialize_check( writeStream.SerializeInteger( 1, 0, BufferSize - 1 ) );   // length 1
+        serialize_check( writeStream.SerializeBits( above_bmp, 32 ) );
+        writeStream.Flush();
+
+        wchar_t read_back[BufferSize];
+        memset( read_back, 0, sizeof( read_back ) );
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        const bool result = serialize::serialize_wstring_internal( readStream, read_back, BufferSize );
+
+        if ( sizeof( wchar_t ) >= 4 )
+        {
+            // the value fits: it must round-trip exactly
+            serialize_check( result == true );
+            serialize_check( (uint32_t) read_back[0] == above_bmp );
+        }
+        else
+        {
+            // the value does not fit: reject, and do not leave a truncated character behind
+            serialize_check( result == false );
+            serialize_check( read_back[0] != (wchar_t) ( above_bmp & 0xFFFF ) );
+        }
+    }
+}
+
 inline void test_int_relative_validation()
 {
     // the 32 bit fallback must reject values that violate the previous < current contract
@@ -3278,6 +3370,7 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_serialize_int64_full_range );
         SERIALIZE_RUN_TEST( test_serialize_int64_validation );
         SERIALIZE_RUN_TEST( test_serialize_bytes_validation );
+        SERIALIZE_RUN_TEST( test_wstring_validation );
         SERIALIZE_RUN_TEST( test_int_relative_validation );
         SERIALIZE_RUN_TEST( test_compressed_float_validation );
         SERIALIZE_RUN_TEST( test_golden_wire_format );

--- a/serialize.h
+++ b/serialize.h
@@ -132,6 +132,7 @@
 #include <stdint.h>     // fixed width integer types
 #include <stddef.h>     // size_t, NULL
 #include <string.h>     // memcpy, memset, strlen
+#include <wchar.h>      // wcslen
 #include <math.h>       // ceil, floor
 
 namespace serialize 
@@ -1705,6 +1706,40 @@ namespace serialize
     // Code points above 0xFFFF are not translated between UTF-16 and UTF-32 platforms: reading a value that doesn't
     // fit in the local wchar_t fails rather than truncating.
 
+    template <typename Stream> bool serialize_wstring_internal( Stream & stream, wchar_t * string, int buffer_size )
+    {
+        const uint32_t max_wchar_value = ( sizeof( wchar_t ) >= 4 ) ? 0xFFFFFFFFU : 0xFFFFU;
+        int length = 0;
+        if ( Stream::IsWriting )
+        {
+            length = (int) wcslen( string );
+            serialize_assert( length < buffer_size );
+        }
+        serialize_int( stream, length, 0, buffer_size - 1 );
+        for ( int i = 0; i < length; i++ )
+        {
+            uint32_t character = 0;
+            if ( Stream::IsWriting )
+            {
+                character = (uint32_t) string[i];
+            }
+            serialize_bits( stream, character, 32 );
+            if ( Stream::IsReading )
+            {
+                if ( character > max_wchar_value )
+                {
+                    return false;
+                }
+                string[i] = (wchar_t) character;
+            }
+        }
+        if ( Stream::IsReading )
+        {
+            string[length] = L'\0';
+        }
+        return true;
+    }
+
 
     /**
         Serialize a string to the stream (read/write/measure).
@@ -1724,7 +1759,27 @@ namespace serialize
                 return false;                                                               \
             }                                                                               \
         } while (0)
-    
+
+    /**
+        Serialize a wide string to the stream (read/write/measure).
+        This is a helper macro to make writing unified serialize functions easier.
+        Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
+        The wire format is 32 bits per character, so streams are compatible between platforms with 2 and 4 byte wchar_t. Reading a character that doesn't fit in the local wchar_t fails rather than truncating.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param string The wide string to serialize write/measure. Pointer to buffer to be filled on read.
+        @param buffer_size The size of the string buffer in wide characters. String with terminating null character must fit into this buffer.
+     */
+
+    #define serialize_wstring( stream, string, buffer_size )                                \
+        do                                                                                  \
+        {                                                                                   \
+            if ( !serialize::serialize_wstring_internal( stream, string, buffer_size ) )    \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+        } while (0)
+
 
     /**
         Serialize an alignment to the stream (read/write/measure).
@@ -1999,6 +2054,16 @@ namespace serialize
             }                                                                               \
         } while (0)
 
+    #define read_wstring( stream, string, buffer_size )                                     \
+        do                                                                                  \
+        {                                                                                   \
+            wchar_t * wstring_ptr = (wchar_t*) ( string );                                  \
+            if ( !serialize_wstring_internal( stream, wstring_ptr, buffer_size ) )          \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+        } while (0)
+
 
     #define read_align                  serialize_align
     #define read_object                 serialize_object
@@ -2084,6 +2149,19 @@ namespace serialize
             write_bytes( stream, (uint8_t*) ( string ), length );                           \
         } while (0)
 
+    #define write_wstring( stream, string, buffer_size )                                    \
+        do                                                                                  \
+        {                                                                                   \
+            const wchar_t * wstring_ptr = (const wchar_t*) ( string );                      \
+            int length = (int) wcslen( wstring_ptr );                                       \
+            serialize_assert( length < (buffer_size) );                                     \
+            write_int( stream, length, 0, (buffer_size) - 1 );                              \
+            for ( int i = 0; i < length; i++ )                                              \
+            {                                                                               \
+                write_bits( stream, (uint32_t) wstring_ptr[i], 32 );                        \
+            }                                                                               \
+        } while (0)
+
 
     #define write_align( stream )                                                           \
         do                                                                                  \
@@ -2115,6 +2193,20 @@ inline void serialize_copy_string( char * dest, const char * source, size_t dest
     for ( size_t i = 0; i < dest_size - 1; i++ )
     {
         if ( source[i] == '\0' )
+            break;
+        dest[i] = source[i];
+    }
+}
+
+inline void serialize_copy_wstring( wchar_t * dest, const wchar_t * source, size_t dest_size )
+{
+    serialize_assert( dest );
+    serialize_assert( source );
+    serialize_assert( dest_size >= 1 );
+    memset( dest, 0, dest_size * sizeof( wchar_t ) );
+    for ( size_t i = 0; i < dest_size - 1; i++ )
+    {
+        if ( source[i] == L'\0' )
             break;
         dest[i] = source[i];
     }

--- a/serialize.h
+++ b/serialize.h
@@ -132,7 +132,6 @@
 #include <stdint.h>     // fixed width integer types
 #include <stddef.h>     // size_t, NULL
 #include <string.h>     // memcpy, memset, strlen
-#include <wchar.h>      // wcslen
 #include <math.h>       // ceil, floor
 
 namespace serialize 
@@ -1706,39 +1705,6 @@ namespace serialize
     // Code points above 0xFFFF are not translated between UTF-16 and UTF-32 platforms: reading a value that doesn't
     // fit in the local wchar_t fails rather than truncating.
 
-    template <typename Stream> bool serialize_wstring_internal( Stream & stream, wchar_t * string, int buffer_size )
-    {
-        int length = 0;
-        if ( Stream::IsWriting )
-        {
-            length = (int) wcslen( string );
-            serialize_assert( length < buffer_size );
-        }
-
-        serialize_int( stream, length, 0, buffer_size - 1 );
-        for ( int i = 0; i < length; i++ )
-        {
-            uint32_t char_value = 0;
-            if ( Stream::IsWriting )
-            {
-                char_value = (uint32_t) string[i];
-            }
-            serialize_bits( stream, char_value, 32 );
-            if ( Stream::IsReading )
-            {
-                if ( sizeof(wchar_t) == 2 && char_value > 0xFFFF )
-                {
-                    return false;
-                }
-                string[i] = (wchar_t) char_value;
-            }
-        }
-        if ( Stream::IsReading )
-        {
-            string[length] = L'\0';
-        }
-        return true;
-    }
 
     /**
         Serialize a string to the stream (read/write/measure).
@@ -1759,14 +1725,6 @@ namespace serialize
             }                                                                               \
         } while (0)
     
-    #define serialize_wstring( stream, string, buffer_size )                                \
-        do                                                                                  \
-        {                                                                                   \
-            if ( !serialize::serialize_wstring_internal( stream, string, buffer_size ) )    \
-            {                                                                               \
-                return false;                                                               \
-            }                                                                               \
-        } while (0)
 
     /**
         Serialize an alignment to the stream (read/write/measure).
@@ -2041,15 +1999,6 @@ namespace serialize
             }                                                                               \
         } while (0)
 
-    #define read_wstring( stream, string, buffer_size )                                      \
-        do                                                                                   \
-        {                                                                                    \
-            wchar_t * string_ptr = (wchar_t*) ( string );                                    \
-            if ( !serialize_wstring_internal( stream, string_ptr, buffer_size ) )            \
-            {                                                                                \
-                return false;                                                                \
-            }                                                                                \
-        } while (0)
 
     #define read_align                  serialize_align
     #define read_object                 serialize_object
@@ -2135,18 +2084,6 @@ namespace serialize
             write_bytes( stream, (uint8_t*) ( string ), length );                           \
         } while (0)
 
-    #define write_wstring( stream, string, buffer_size )                                    \
-        do                                                                                  \
-        {                                                                                   \
-            int length = (int) wcslen( string );                                            \
-            serialize_assert( length < (buffer_size) );                                     \
-            write_int( stream, length, 0, (buffer_size) - 1 );                              \
-            for ( int i = 0; i < length; i++ )                                              \
-            {                                                                               \
-                uint32_t wchar_value = (uint32_t) ( string )[i];                            \
-                write_bits( stream, wchar_value, 32 );                                      \
-            }                                                                               \
-        } while (0)
 
     #define write_align( stream )                                                           \
         do                                                                                  \
@@ -2183,19 +2120,6 @@ inline void serialize_copy_string( char * dest, const char * source, size_t dest
     }
 }
 
-inline void serialize_copy_wstring( wchar_t * dest, const wchar_t * source, size_t dest_size )
-{
-    serialize_assert( dest );
-    serialize_assert( source );
-    serialize_assert( dest_size >= 1 );
-    memset( dest, 0, dest_size * sizeof(wchar_t) );
-    for ( size_t i = 0; i < dest_size - 1; i++ )
-    {
-        if ( source[i] == L'\0' )
-            break;
-        dest[i] = source[i];
-    }
-}
 
 #if SERIALIZE_ENABLE_TESTS
 

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -1,0 +1,24 @@
+# Conformance: STANDARD.md vs the implementation
+
+`STANDARD.md` specifies serialize's wire format. This decodes the library's own
+golden vector using **only what that document says** — the LSB-first bit
+packing, the ranged-integer widths, the alignment rules, the relative-integer
+ladder — and asserts every field.
+
+    python3 tools/conformance/verify_standard.py
+
+No compiler needed: `golden_wire_bytes` and the expected values are read out of
+`serialize.h` as data. Exit 0 means the document and the code agree.
+
+## Why the golden vector is the right oracle
+
+It is a hand-verified byte-exact snapshot of a message exercising every
+primitive: all four raw bit widths, a narrow and a full-range ranged int, a
+bool, a float, a quantized compressed float, a double, four unsigned widths,
+both interesting tiers of the relative-integer ladder, a byte block, a narrow
+string and a wide string. If a decoder written from the document reproduces all
+of them and consumes exactly the right number of bits, the document is right.
+
+The final check — that decoding consumed exactly the golden byte count — is the
+one that catches alignment errors. Fields can decode correctly while the bit
+cursor drifts.

--- a/tools/conformance/verify_standard.py
+++ b/tools/conformance/verify_standard.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Check serialize/STANDARD.md against the implementation.
+
+Decodes the library's own golden wire-format vector using ONLY what
+STANDARD.md states — the bit packing, the ranged-integer widths, the alignment
+rules, the relative-integer ladder — and asserts every field of the golden
+message. Nothing here consults serialize.h's implementation; the golden array
+and the expected values are read out of the header as data.
+
+usage: python3 tools/conformance/verify_standard.py
+exit:  0 = the document matches the implementation, 1 = it does not
+"""
+import math, os, re, struct, sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+HDR = os.path.join(ROOT, "serialize.h")
+
+
+class BitReader:
+    """STANDARD.md, 'General Conventions': LSB-first into 64-bit little-endian words."""
+    def __init__(self, b): self.b = b; self.i = 0
+    def bits(self, n):
+        v = 0
+        for k in range(n):
+            v |= ((self.b[self.i // 8] >> (self.i % 8)) & 1) << k
+            self.i += 1
+        return v
+    def align(self):
+        pad = (8 - (self.i % 8)) % 8
+        if pad and self.bits(pad) != 0:
+            raise ValueError("alignment padding must be zero")
+    def read_bytes(self, n):
+        self.align()
+        out = self.b[self.i // 8: self.i // 8 + n]; self.i += n * 8
+        return out
+
+
+def bits_required(lo, hi):
+    return 0 if lo == hi else (hi - lo).bit_length()
+
+def sint(r, lo, hi):
+    n = bits_required(lo, hi)
+    return (r.bits(n) if n else 0) + lo
+
+def relative(r, prev):
+    """STANDARD.md, 'int_relative': the five-tier flag ladder."""
+    if r.bits(1): return prev + 1
+    if r.bits(1): return prev + sint(r, 2, 6)
+    if r.bits(1): return prev + sint(r, 7, 23)
+    if r.bits(1): return prev + sint(r, 24, 280)
+    if r.bits(1): return prev + sint(r, 281, 4377)
+    return prev + r.bits(32)
+
+
+def golden_bytes():
+    src = open(HDR).read()
+    m = re.search(r"golden_wire_bytes\[\]\s*=\s*\{(.*?)\};", src, re.S)
+    if not m: raise SystemExit("golden_wire_bytes not found in serialize.h")
+    return bytes(int(x, 16) for x in re.findall(r"0x([0-9A-Fa-f]{2})", m.group(1)))
+
+
+def main():
+    data = golden_bytes()
+    r = BitReader(data)
+    fails, n = [], 0
+
+    def eq(name, got, exp, tol=None):
+        nonlocal n; n += 1
+        ok = abs(got - exp) < tol if tol else got == exp
+        if not ok: fails.append(f"{name}: got {got!r}, expected {exp!r}")
+
+    # field order per GoldenWireSerialize; values per GoldenWireInit
+    eq("bits4", r.bits(4), 13)
+    eq("bits11", r.bits(11), 1445)
+    eq("bits24", r.bits(24), 11259375)
+    eq("bits32", r.bits(32), 0xDEADBEEF)
+    eq("int_small (ranged -100..100)", sint(r, -100, 100), -37)
+    v = sint(r, -2**31, 2**31 - 1)
+    eq("int_full (full int32 range)", v - 2**32 if v >= 2**31 else v, -123456789)
+    eq("bool flag", r.bits(1), 1)
+    eq("float", struct.unpack("<f", struct.pack("<I", r.bits(32)))[0], 3.1415926, tol=1e-6)
+    mx = math.ceil(10.0 / 0.01)
+    eq("compressed_float", r.bits(bits_required(0, mx)) / mx * 10.0, 5.0, tol=1e-4)
+    lo, hi = r.bits(32), r.bits(32)
+    eq("double", struct.unpack("<d", struct.pack("<Q", lo | (hi << 32)))[0], 1 / 3, tol=1e-12)
+    eq("uint8", sint(r, 0, 255), 0x7F)
+    eq("uint16", sint(r, 0, 65535), 0x1234)
+    eq("uint32", r.bits(32), 0x12345678)
+    lo, hi = r.bits(32), r.bits(32)
+    eq("uint64", lo | (hi << 32), 0x123456789ABCDEF0)
+    eq("int_relative near (difference 1 = one bit)", relative(r, 100), 101)
+    eq("int_relative far (difference 2000)", relative(r, 100), 2100)
+    r.align()
+    eq("bytes", r.read_bytes(7), bytes([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0x01]))
+    ln = sint(r, 0, 15)
+    eq("string", r.read_bytes(ln).decode(), "golden")
+    ln = sint(r, 0, 7)
+    eq("wstring (32 bits per char, NO alignment)",
+       [r.bits(32) for _ in range(ln)], [0x043C, 0x0438, 0x0440])
+    eq("consumed exactly the golden bytes", math.ceil(r.i / 8), len(data))
+
+    print(f"{n} checks against STANDARD.md, {len(fails)} failures")
+    for f in fails: print("  FAIL " + f)
+    if fails:
+        print("\nSTANDARD.md and the implementation disagree. One of them is wrong.")
+        return 1
+    print("\nSTANDARD.md matches the implementation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Documents and verifies serialize's wire format, and reimplements wide-string support in a clean room.

**STANDARD.md** — the wire format specified precisely enough to write an independent implementation: LSB-first bit packing into 64-bit little-endian words, the ranged-integer encoding that defines the format, the relative-integer ladder, floats, bytes and strings.

**tools/conformance** — 20 checks that decode `golden_wire_bytes` using only what the document says, asserting every field *and* that decoding consumes exactly the right number of bits. Needs no compiler. Run with `python3 tools/conformance/verify_standard.py`.

**UTF-8 BOM removed** from serialize.h — it was the only file in the repo carrying one, and a BOM ahead of the header guard is not portable.

**Wide-string support reimplemented** from specification by an implementer that never read the original, verified against the golden bytes.

No release accompanies this.