### PR TITLE
serialize 1.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.4.4 LANGUAGES CXX)
+project(serialize VERSION 1.5.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -34,9 +34,9 @@
 /** @file */
 
 #define SERIALIZE_VERSION_MAJOR 1
-#define SERIALIZE_VERSION_MINOR 4
-#define SERIALIZE_VERSION_PATCH 4
-#define SERIALIZE_VERSION "1.4.4"
+#define SERIALIZE_VERSION_MINOR 5
+#define SERIALIZE_VERSION_PATCH 0
+#define SERIALIZE_VERSION "1.5.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
Version bump for the 1.5.0 release. CMakeLists.txt and serialize.h move together for `release-check.yml` (note serialize uses `SERIALIZE_VERSION`, not `_VERSION_FULL`).

**MINOR, not MAJOR** — the wire format is byte-identical and no public macro or function was added, removed or resignatured.

What 1.5.0 ships:
- **Wide-string support reimplemented from specification** (clean-room step 2).
- **UTF-8 BOM stripped from `serialize.h`**, plus the follow-up fixing the Windows build that removal broke.
- **A new normative `STANDARD.md`** specifying the serialize wire format, plus a fix for one error and three omissions found by the coverage audit.

No security content.