### PR TITLE
ci: filter the push trigger to main, like the other three C libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
+    branches: [ main ]
   pull_request:
+  # Filtering push to main means a feature branch no longer runs CI on push -- its PR
+  # does. workflow_dispatch keeps a deliberate way to run the matrix on a branch, which
+  # is the capability the filter would otherwise silently remove.
+  workflow_dispatch:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
`ci.yml` used a bare `on: push:` with no filter, so the full matrix fired on **every branch and every tag**. A branch push plus its pull request ran the whole thing twice, and every release tag ran it a third time.

netcode, reliable and yojimbo all filter to `main`. `serialize` was the odd one out.

Not a correctness problem — just duplicated spend. But CI spend is real money here, and the steady state is meant to be deliberate rather than accidental.

**Safe to drop the tag runs:** `release-check.yml` already handles tags explicitly with `tags: [ 'v*' ]`, so tag coverage does not depend on `ci.yml`'s unfiltered trigger. Checked before changing it, not after.

`workflow_dispatch` added deliberately: filtering push to main removes the ability to run CI on a feature branch by pushing to it. That capability should be *replaced* rather than quietly dropped.