### PR TITLE
Experiment: compile-time parameter surface for generated code

### DIFF
--- a/bench.cpp
+++ b/bench.cpp
@@ -28,6 +28,10 @@
     Measures throughput of the raw bitpacker (BitWriter/BitReader) with mixed bit widths,
     and of the stream + serialize macro path with a representative packet.
 
+    Also measures matched pairs of the runtime macros against the compile time parameter
+    surface (serialize_*_compile_time), to answer whether moving min/max/bits into template
+    arguments buys anything the optimizer wasn't already doing.
+
     Each benchmark runs several trials and reports the best, to shave off scheduler noise.
     Only release build numbers are meaningful.
 */
@@ -289,6 +293,273 @@ void bench_stream()
 
 // ------------------------------------------------------------------------------------------
 
+// Matched pairs: the same packet serialized through the runtime macros and through the compile
+// time parameter surface. Same data, same serially dependent LCG variation pattern, same escape
+// barriers, same trial structure, so any difference is the forms themselves, not the harness.
+// Each shape derives its two packet forms from one fields struct, so a single vary function
+// drives both sides of a pair with identical values.
+
+template <typename Fields, typename Packet> void bench_packet_shape( const char * label, uint64_t (*vary)( Fields &, uint64_t ) )
+{
+    uint8_t buffer[256];
+    memset( buffer, 0, sizeof( buffer ) );
+
+    Packet packet = Packet();
+
+    // pre-write variant packets for the read benchmark, using the same LCG sequence as the write loop
+    uint8_t variant_buffers[NumVariants][256];
+    int bytes_per_packet = 0;
+    {
+        uint64_t rng = 1;
+        for ( int k = 0; k < NumVariants; k++ )
+        {
+            memset( variant_buffers[k], 0, sizeof( variant_buffers[k] ) );
+            rng = vary( packet, rng );
+            serialize::WriteStream stream( variant_buffers[k], (int) sizeof( variant_buffers[k] ) );
+            if ( !packet.Serialize( stream ) )
+                exit( 1 );
+            stream.Flush();
+            bytes_per_packet = stream.GetBytesProcessed();
+        }
+    }
+
+    double best_write = 1e30;
+    double best_read = 1e30;
+
+    for ( int trial = 0; trial < NumTrials; trial++ )
+    {
+        uint64_t rng = 1;
+
+        double start = time_now();
+        for ( int i = 0; i < StreamNumPackets; i++ )
+        {
+            rng = vary( packet, rng );
+            serialize::WriteStream stream( buffer, (int) sizeof( buffer ) );
+            if ( !packet.Serialize( stream ) )
+                exit( 1 );
+            stream.Flush();
+            bench_escape( buffer );
+            g_sink = g_sink + (uint64_t) stream.GetBytesProcessed();
+        }
+        double time = time_now() - start;
+        if ( time < best_write )
+            best_write = time;
+
+        start = time_now();
+        for ( int i = 0; i < StreamNumPackets; i++ )
+        {
+            serialize::ReadStream stream( variant_buffers[i & ( NumVariants - 1 )], bytes_per_packet );
+            Packet read_packet;
+            if ( !read_packet.Serialize( stream ) )
+                exit( 1 );
+            bench_escape( &read_packet );               // every decoded field is observed, so the full decode must happen
+            g_sink = g_sink + (uint64_t) *(const uint8_t*) &read_packet;
+        }
+        time = time_now() - start;
+        if ( time < best_read )
+            best_read = time;
+    }
+
+    const double packets = double( StreamNumPackets ) / 1000000.0;
+
+    printf( "%s  write: %6.1f M packets/s   read: %6.1f M packets/s\n", label, packets / best_write, packets / best_read );
+}
+
+// pair 1: a realistic packet of ~10 bounded ints, runtime serialize_int vs serialize_int_compile_time
+
+struct BenchIntFields
+{
+    int32_t f0, f1, f2, f3, f4, f5, f6, f7, f8, f9;
+};
+
+inline uint64_t bench_vary_int_fields( BenchIntFields & f, uint64_t rng )
+{
+    rng = rng * 6364136223846793005ULL + 1442695040888963407ULL;
+    f.f0 = int32_t( ( rng >> 8 ) & 63 ) - 32;                       // within [-100,+100]
+    f.f1 = int32_t( uint32_t( rng >> 16 ) & 65535 );                // [0,65535]
+    f.f2 = int32_t( ( rng >> 24 ) & 0xFFFFF ) - 500000;             // within [-1000000,+1000000]
+    f.f3 = int32_t( uint32_t( rng >> 2 ) & 3 );                     // [0,3]
+    f.f4 = int32_t( ( rng >> 11 ) & 15 ) - 8;                       // within [-15,+15]
+    f.f5 = int32_t( uint32_t( rng >> 22 ) & 511 );                  // within [0,1000]
+    f.f6 = int32_t( ( rng >> 33 ) & 2047 ) - 1024;                  // within [-2048,+2047]
+    f.f7 = int32_t( uint32_t( rng >> 40 ) & 255 );                  // [0,255]
+    f.f8 = int32_t( ( rng >> 30 ) & 0xFFFFF ) - 500000;             // within [-600000,+600000]
+    f.f9 = int32_t( uint32_t( rng >> 57 ) & 63 );                   // within [0,100]
+    return rng;
+}
+
+struct BenchIntPacketRuntime : public BenchIntFields
+{
+    template <typename Stream> bool Serialize( Stream & stream )
+    {
+        serialize_int( stream, f0, -100, +100 );
+        serialize_int( stream, f1, 0, 65535 );
+        serialize_int( stream, f2, -1000000, +1000000 );
+        serialize_int( stream, f3, 0, 3 );
+        serialize_int( stream, f4, -15, +15 );
+        serialize_int( stream, f5, 0, 1000 );
+        serialize_int( stream, f6, -2048, +2047 );
+        serialize_int( stream, f7, 0, 255 );
+        serialize_int( stream, f8, -600000, +600000 );
+        serialize_int( stream, f9, 0, 100 );
+        return true;
+    }
+};
+
+struct BenchIntPacketCompileTime : public BenchIntFields
+{
+    template <typename Stream> bool Serialize( Stream & stream )
+    {
+        serialize_int_compile_time( stream, f0, -100, +100 );
+        serialize_int_compile_time( stream, f1, 0, 65535 );
+        serialize_int_compile_time( stream, f2, -1000000, +1000000 );
+        serialize_int_compile_time( stream, f3, 0, 3 );
+        serialize_int_compile_time( stream, f4, -15, +15 );
+        serialize_int_compile_time( stream, f5, 0, 1000 );
+        serialize_int_compile_time( stream, f6, -2048, +2047 );
+        serialize_int_compile_time( stream, f7, 0, 255 );
+        serialize_int_compile_time( stream, f8, -600000, +600000 );
+        serialize_int_compile_time( stream, f9, 0, 100 );
+        return true;
+    }
+};
+
+// pair 2: mixed bit widths including one wider than 32 bits, runtime serialize_bits vs serialize_bits_compile_time
+
+struct BenchBitsFields
+{
+    uint32_t b7, b13, b23, b3, b32, b11, b19;
+    uint64_t b48;
+};
+
+inline uint64_t bench_vary_bits_fields( BenchBitsFields & f, uint64_t rng )
+{
+    rng = rng * 6364136223846793005ULL + 1442695040888963407ULL;
+    f.b7 = uint32_t( rng ) & 127;
+    f.b13 = uint32_t( rng >> 3 ) & 8191;
+    f.b23 = uint32_t( rng >> 5 ) & 8388607;
+    f.b3 = uint32_t( rng >> 29 ) & 7;
+    f.b32 = uint32_t( rng >> 16 );
+    f.b11 = uint32_t( rng >> 37 ) & 2047;
+    f.b19 = uint32_t( rng >> 44 ) & 524287;
+    f.b48 = rng & 0xFFFFFFFFFFFFULL;
+    return rng;
+}
+
+struct BenchBitsPacketRuntime : public BenchBitsFields
+{
+    template <typename Stream> bool Serialize( Stream & stream )
+    {
+        serialize_bits( stream, b7, 7 );
+        serialize_bits( stream, b13, 13 );
+        serialize_bits( stream, b23, 23 );
+        serialize_bits( stream, b3, 3 );
+        serialize_bits( stream, b32, 32 );
+        serialize_bits( stream, b11, 11 );
+        serialize_bits( stream, b19, 19 );
+        serialize_bits( stream, b48, 48 );
+        return true;
+    }
+};
+
+struct BenchBitsPacketCompileTime : public BenchBitsFields
+{
+    template <typename Stream> bool Serialize( Stream & stream )
+    {
+        serialize_bits_compile_time( stream, b7, 7 );
+        serialize_bits_compile_time( stream, b13, 13 );
+        serialize_bits_compile_time( stream, b23, 23 );
+        serialize_bits_compile_time( stream, b3, 3 );
+        serialize_bits_compile_time( stream, b32, 32 );
+        serialize_bits_compile_time( stream, b11, 11 );
+        serialize_bits_compile_time( stream, b19, 19 );
+        serialize_bits64_compile_time( stream, b48, 48 );
+        return true;
+    }
+};
+
+// pair 3: a "generated packet" shape mixing bounded ints, bits and bools, the way schema generated code looks
+
+struct BenchGenFields
+{
+    int32_t sequence;       // [0,65535]
+    uint32_t ack_bits;      // 32 bits
+    uint32_t entity_id;     // 12 bits
+    int32_t pos_x, pos_y, pos_z;    // [-16384,+16383]
+    uint32_t yaw;           // 9 bits
+    bool moving;
+    bool firing;
+    uint64_t timestamp;     // 48 bits
+    int32_t weapon;         // [0,15]
+};
+
+inline uint64_t bench_vary_gen_fields( BenchGenFields & f, uint64_t rng )
+{
+    rng = rng * 6364136223846793005ULL + 1442695040888963407ULL;
+    f.sequence = int32_t( uint32_t( rng >> 8 ) & 65535 );
+    f.ack_bits = uint32_t( rng >> 16 );
+    f.entity_id = uint32_t( rng ) & 4095;
+    f.pos_x = int32_t( ( rng >> 20 ) & 32767 ) - 16384;
+    f.pos_y = int32_t( ( rng >> 25 ) & 32767 ) - 16384;
+    f.pos_z = int32_t( ( rng >> 30 ) & 32767 ) - 16384;
+    f.yaw = uint32_t( rng >> 3 ) & 511;
+    f.moving = ( rng & 1 ) != 0;
+    f.firing = ( rng & 2 ) != 0;
+    f.timestamp = rng & 0xFFFFFFFFFFFFULL;
+    f.weapon = int32_t( uint32_t( rng >> 60 ) & 15 );
+    return rng;
+}
+
+struct BenchGenPacketRuntime : public BenchGenFields
+{
+    template <typename Stream> bool Serialize( Stream & stream )
+    {
+        serialize_int( stream, sequence, 0, 65535 );
+        serialize_bits( stream, ack_bits, 32 );
+        serialize_bits( stream, entity_id, 12 );
+        serialize_int( stream, pos_x, -16384, +16383 );
+        serialize_int( stream, pos_y, -16384, +16383 );
+        serialize_int( stream, pos_z, -16384, +16383 );
+        serialize_bits( stream, yaw, 9 );
+        serialize_bool( stream, moving );
+        serialize_bool( stream, firing );
+        serialize_bits( stream, timestamp, 48 );
+        serialize_int( stream, weapon, 0, 15 );
+        return true;
+    }
+};
+
+struct BenchGenPacketCompileTime : public BenchGenFields
+{
+    template <typename Stream> bool Serialize( Stream & stream )
+    {
+        serialize_int_compile_time( stream, sequence, 0, 65535 );
+        serialize_bits_compile_time( stream, ack_bits, 32 );
+        serialize_bits_compile_time( stream, entity_id, 12 );
+        serialize_int_compile_time( stream, pos_x, -16384, +16383 );
+        serialize_int_compile_time( stream, pos_y, -16384, +16383 );
+        serialize_int_compile_time( stream, pos_z, -16384, +16383 );
+        serialize_bits_compile_time( stream, yaw, 9 );
+        serialize_bool_compile_time( stream, moving );
+        serialize_bool_compile_time( stream, firing );
+        serialize_bits64_compile_time( stream, timestamp, 48 );
+        serialize_int_compile_time( stream, weapon, 0, 15 );
+        return true;
+    }
+};
+
+void bench_compile_time_pairs()
+{
+    bench_packet_shape<BenchIntFields, BenchIntPacketRuntime>          ( "int packet   (runtime):     ", bench_vary_int_fields );
+    bench_packet_shape<BenchIntFields, BenchIntPacketCompileTime>      ( "int packet   (compile time):", bench_vary_int_fields );
+    bench_packet_shape<BenchBitsFields, BenchBitsPacketRuntime>        ( "bits packet  (runtime):     ", bench_vary_bits_fields );
+    bench_packet_shape<BenchBitsFields, BenchBitsPacketCompileTime>    ( "bits packet  (compile time):", bench_vary_bits_fields );
+    bench_packet_shape<BenchGenFields, BenchGenPacketRuntime>          ( "mixed packet (runtime):     ", bench_vary_gen_fields );
+    bench_packet_shape<BenchGenFields, BenchGenPacketCompileTime>      ( "mixed packet (compile time):", bench_vary_gen_fields );
+}
+
+// ------------------------------------------------------------------------------------------
+
 int main()
 {
     printf( "\n[serialize benchmark]\n\n" );
@@ -302,6 +573,10 @@ int main()
     bench_bitpacker( buffer );
 
     bench_stream();
+
+    printf( "\n" );
+
+    bench_compile_time_pairs();
 
     free( buffer );
 

--- a/serialize.h
+++ b/serialize.h
@@ -2183,6 +2183,357 @@ namespace serialize
             int current_value = (int) ( current );                                          \
             serialize::serialize_int_relative_internal( stream, previous, current_value );  \
         } while (0)
+
+    // ------------------------------------------------------------------------------------------
+    //
+    //      Compile time parameter surface (experimental, for generated code)
+    //
+    //      When serialize calls are generated from a schema, min/max/bits are known at code
+    //      generation time. The templates below move them into template argument position, so
+    //      the bit count is a compile time constant: no runtime bits_required call, no runtime
+    //      min/max parameter plumbing, and the 32/64 bit split resolves on a constant condition.
+    //      The wire bytes are identical to the runtime forms given identical inputs, so a code
+    //      generator can switch between forms without a wire change.
+    //
+    //      Humans keep the serialize_* macros above. Generated code calls these templates
+    //      directly and emits its own `if ( !... ) return false;`, or uses the thin
+    //      serialize_*_compile_time macro wrappers below.
+    //
+    // ------------------------------------------------------------------------------------------
+
+    /**
+        Calculates the number of bits required to serialize an integer in range [min,max], as a constant expression.
+        The constexpr companion to serialize::bits_required and serialize::bits_required64, for use in template argument position.
+        C++14 relaxed constexpr, matching the oldest standard this header is compiled at in practice (compilers' defaults: this project configures no -std flag).
+        @param min The minimum value, converted to the unsigned domain (sign extended for signed ranges).
+        @param max The maximum value, converted to the unsigned domain (sign extended for signed ranges).
+        @returns The number of bits required to serialize the integer in [0,64].
+     */
+
+    constexpr int bits_required64_constexpr( uint64_t min, uint64_t max )
+    {
+        // subtract in the unsigned domain: max - min overflows signed arithmetic when the range is wider than 2^63.
+        // sign extended int32 bounds wrap to the same difference, so this one function covers both integer domains.
+        int bits = 0;
+        for ( uint64_t diff = max - min; diff != 0; diff >>= 1 )
+        {
+            bits++;
+        }
+        return bits;
+    }
+
+    /**
+        Serialize an integer with compile time bounds (read/write/measure).
+        The compile time companion to WriteStream::SerializeInteger and ReadStream::SerializeInteger: the bit count is a constant, so there is no runtime bits_required call and no min/max parameter traffic.
+        Wire bytes are identical to the runtime form given identical inputs.
+        On write, the value is checked by debug asserts only, matching the runtime form. On read, the value off the wire is validated against the constant bounds and the function returns false on out of range data.
+        @tparam Min The minimum value. Must be less than Max (enforced at compile time).
+        @tparam Max The maximum value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The integer value in [Min,Max]. Written on write/measure, filled in on read.
+        @returns True if the serialize succeeded, false if the read data is truncated or out of range.
+     */
+
+    template <int32_t Min, int32_t Max, typename Stream> bool SerializeIntConst( Stream & stream, int32_t & value )
+    {
+        static_assert( Min < Max, "serialize: min must be less than max" );
+        constexpr int bits = bits_required64_constexpr( uint64_t( int64_t( Min ) ), uint64_t( int64_t( Max ) ) );
+        uint32_t unsigned_value = 0;
+        if ( Stream::IsWriting )
+        {
+            serialize_assert( value >= Min );
+            serialize_assert( value <= Max );
+            // subtract in the unsigned domain: value - min overflows signed arithmetic when the range is wider than 2^31
+            unsigned_value = uint32_t( value ) - uint32_t( Min );
+        }
+        if ( !stream.SerializeBits( unsigned_value, bits ) )
+        {
+            return false;
+        }
+        if ( Stream::IsReading )
+        {
+            if ( unsigned_value > uint32_t( Max ) - uint32_t( Min ) )
+            {
+                return false;
+            }
+            // add in the unsigned domain: unsigned_value + min overflows signed arithmetic when the range is wider than 2^31
+            value = int32_t( unsigned_value + uint32_t( Min ) );
+        }
+        return true;
+    }
+
+    /**
+        Serialize a 64 bit integer with compile time bounds (read/write/measure).
+        The compile time companion to WriteStream::SerializeInteger64 and ReadStream::SerializeInteger64: the bit count is a constant, and the one dword vs two dword split resolves on a constant condition, so the dead branch folds.
+        Wire bytes are identical to the runtime form given identical inputs: low dword first, then the high remainder, same convention as serialize_bits and serialize_uint64.
+        On write, the value is checked by debug asserts only, matching the runtime form. On read, the value off the wire is validated against the constant bounds and the function returns false on out of range data.
+        @tparam Min The minimum value. Must be less than Max (enforced at compile time).
+        @tparam Max The maximum value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The integer value in [Min,Max]. Written on write/measure, filled in on read.
+        @returns True if the serialize succeeded, false if the read data is truncated or out of range.
+     */
+
+    template <int64_t Min, int64_t Max, typename Stream> bool SerializeInt64Const( Stream & stream, int64_t & value )
+    {
+        static_assert( Min < Max, "serialize: min must be less than max" );
+        constexpr int bits = bits_required64_constexpr( uint64_t( Min ), uint64_t( Max ) );
+        uint64_t unsigned_value = 0;
+        if ( Stream::IsWriting )
+        {
+            serialize_assert( value >= Min );
+            serialize_assert( value <= Max );
+            // subtract in the unsigned domain: value - min overflows signed arithmetic when the range is wider than 2^63
+            unsigned_value = uint64_t( value ) - uint64_t( Min );
+        }
+        if ( bits <= 32 )       // constant condition: the dead branch folds at compile time
+        {
+            uint32_t unsigned_value32 = uint32_t( unsigned_value );
+            if ( !stream.SerializeBits( unsigned_value32, bits ) )
+            {
+                return false;
+            }
+            if ( Stream::IsReading )
+            {
+                unsigned_value = unsigned_value32;
+            }
+        }
+        else
+        {
+            // low dword first, then the high remainder: same convention as serialize_bits and serialize_uint64
+            uint32_t lo = uint32_t( unsigned_value & 0xFFFFFFFF );
+            uint32_t hi = uint32_t( unsigned_value >> 32 );
+            if ( !stream.SerializeBits( lo, 32 ) )
+            {
+                return false;
+            }
+            if ( !stream.SerializeBits( hi, bits - 32 ) )
+            {
+                return false;
+            }
+            if ( Stream::IsReading )
+            {
+                unsigned_value = ( uint64_t( hi ) << 32 ) | lo;
+            }
+        }
+        if ( Stream::IsReading )
+        {
+            if ( unsigned_value > uint64_t( Max ) - uint64_t( Min ) )
+            {
+                return false;
+            }
+            // add in the unsigned domain: unsigned_value + min overflows signed arithmetic when the range is wider than 2^63
+            value = int64_t( unsigned_value + uint64_t( Min ) );
+        }
+        return true;
+    }
+
+    /**
+        Serialize a compile time number of bits (read/write/measure).
+        The compile time companion to WriteStream::SerializeBits and ReadStream::SerializeBits for widths up to 32: the width is a constant, so there is no runtime bits parameter traffic.
+        Wire bytes are identical to the runtime form given identical inputs.
+        On write, the value is checked by debug asserts only, matching the runtime form (it must be in [0,(1<<Bits)-1]).
+        @tparam Bits The number of bits to serialize, in [1,32] (enforced at compile time).
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The unsigned integer value. Written on write/measure, filled in on read.
+        @returns True if the serialize succeeded, false if the read data is truncated.
+     */
+
+    template <int Bits, typename Stream> bool SerializeBitsConst( Stream & stream, uint32_t & value )
+    {
+        static_assert( Bits > 0, "serialize: bits must be greater than zero" );
+        static_assert( Bits <= 32, "serialize: bits must be less than or equal to 32. use SerializeBits64Const for wider values" );
+        return stream.SerializeBits( value, Bits );
+    }
+
+    /**
+        Serialize a compile time number of bits from a 64 bit value (read/write/measure).
+        The compile time companion to the serialize_bits macro for widths up to 64: the width is a constant, and the one dword vs two dword split resolves on a constant condition, so the dead branch folds.
+        Wire bytes are identical to the runtime form given identical inputs: low dword first, then the high remainder.
+        On write, the value is checked by debug asserts only, matching the runtime form (it must be in [0,(1<<Bits)-1]).
+        @tparam Bits The number of bits to serialize, in [1,64] (enforced at compile time).
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The unsigned 64 bit integer value. Written on write/measure, filled in on read.
+        @returns True if the serialize succeeded, false if the read data is truncated.
+     */
+
+    template <int Bits, typename Stream> bool SerializeBits64Const( Stream & stream, uint64_t & value )
+    {
+        static_assert( Bits > 0, "serialize: bits must be greater than zero" );
+        static_assert( Bits <= 64, "serialize: bits must be less than or equal to 64" );
+        if ( Bits <= 32 )       // constant condition: the dead branch folds at compile time
+        {
+            uint32_t value32 = uint32_t( value );
+            if ( !stream.SerializeBits( value32, Bits ) )
+            {
+                return false;
+            }
+            if ( Stream::IsReading )
+            {
+                value = value32;
+            }
+        }
+        else
+        {
+            // low dword first, then the high remainder: same convention as serialize_bits and serialize_uint64
+            uint32_t lo = uint32_t( value & 0xFFFFFFFF );
+            uint32_t hi = uint32_t( value >> 32 );
+            if ( !stream.SerializeBits( lo, 32 ) )
+            {
+                return false;
+            }
+            if ( !stream.SerializeBits( hi, Bits - 32 ) )
+            {
+                return false;
+            }
+            if ( Stream::IsReading )
+            {
+                value = ( uint64_t( hi ) << 32 ) | lo;
+            }
+        }
+        return true;
+    }
+
+    /**
+        Serialize integer value with compile time bounds (read/write/measure).
+        The compile time companion to serialize_int. min and max are expanded into template argument position, so they must be constant expressions: a runtime value fails to compile, deliberately.
+        Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The integer value to serialize in [min,max].
+        @param min The minimum value. Must be a constant expression.
+        @param max The maximum value. Must be a constant expression.
+     */
+
+    #define serialize_int_compile_time( stream, value, min, max )                           \
+        do                                                                                  \
+        {                                                                                   \
+            int32_t int32_value = 0;                                                        \
+            if ( Stream::IsWriting )                                                        \
+            {                                                                               \
+                int32_value = (int32_t) ( value );                                          \
+            }                                                                               \
+            if ( !serialize::SerializeIntConst<(min), (max)>( stream, int32_value ) )       \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+            if ( Stream::IsReading )                                                        \
+            {                                                                               \
+                value = int32_value;                                                        \
+            }                                                                               \
+        } while (0)
+
+    /**
+        Serialize a 64 bit integer value with compile time bounds (read/write/measure).
+        The compile time companion to serialize_int64. min and max are expanded into template argument position, so they must be constant expressions: a runtime value fails to compile, deliberately.
+        Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The 64 bit integer value to serialize in [min,max].
+        @param min The minimum value. Must be a constant expression.
+        @param max The maximum value. Must be a constant expression.
+     */
+
+    #define serialize_int64_compile_time( stream, value, min, max )                         \
+        do                                                                                  \
+        {                                                                                   \
+            int64_t int64_value = 0;                                                        \
+            if ( Stream::IsWriting )                                                        \
+            {                                                                               \
+                int64_value = (int64_t) ( value );                                          \
+            }                                                                               \
+            if ( !serialize::SerializeInt64Const<(min), (max)>( stream, int64_value ) )     \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+            if ( Stream::IsReading )                                                        \
+            {                                                                               \
+                value = int64_value;                                                        \
+            }                                                                               \
+        } while (0)
+
+    /**
+        Serialize a compile time number of bits to the stream (read/write/measure).
+        The compile time companion to serialize_bits for widths up to 32. bits is expanded into template argument position, so it must be a constant expression: a runtime value fails to compile, deliberately.
+        Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The unsigned integer value to serialize.
+        @param bits The number of bits to serialize in [1,32]. Must be a constant expression.
+     */
+
+    #define serialize_bits_compile_time( stream, value, bits )                              \
+        do                                                                                  \
+        {                                                                                   \
+            uint32_t uint32_value = 0;                                                      \
+            if ( Stream::IsWriting )                                                        \
+            {                                                                               \
+                uint32_value = (uint32_t) ( value );                                        \
+            }                                                                               \
+            if ( !serialize::SerializeBitsConst<(bits)>( stream, uint32_value ) )           \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+            if ( Stream::IsReading )                                                        \
+            {                                                                               \
+                value = uint32_value;                                                       \
+            }                                                                               \
+        } while (0)
+
+    /**
+        Serialize a compile time number of bits from a 64 bit value to the stream (read/write/measure).
+        The compile time companion to serialize_bits for widths up to 64. bits is expanded into template argument position, so it must be a constant expression: a runtime value fails to compile, deliberately.
+        Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The unsigned 64 bit integer value to serialize.
+        @param bits The number of bits to serialize in [1,64]. Must be a constant expression.
+     */
+
+    #define serialize_bits64_compile_time( stream, value, bits )                            \
+        do                                                                                  \
+        {                                                                                   \
+            uint64_t uint64_value = 0;                                                      \
+            if ( Stream::IsWriting )                                                        \
+            {                                                                               \
+                uint64_value = (uint64_t) ( value );                                        \
+            }                                                                               \
+            if ( !serialize::SerializeBits64Const<(bits)>( stream, uint64_value ) )         \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+            if ( Stream::IsReading )                                                        \
+            {                                                                               \
+                value = uint64_value;                                                       \
+            }                                                                               \
+        } while (0)
+
+    /**
+        Serialize a boolean value to the stream through the compile time surface (read/write/measure).
+        The compile time companion to serialize_bool: one bit, width resolved at compile time.
+        Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The boolean value to serialize.
+     */
+
+    #define serialize_bool_compile_time( stream, value )                                    \
+        do                                                                                  \
+        {                                                                                   \
+            uint32_t uint32_bool_value = 0;                                                 \
+            if ( Stream::IsWriting )                                                        \
+            {                                                                               \
+                uint32_bool_value = ( value ) ? 1 : 0;                                      \
+            }                                                                               \
+            if ( !serialize::SerializeBitsConst<1>( stream, uint32_bool_value ) )           \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+            if ( Stream::IsReading )                                                        \
+            {                                                                               \
+                value = uint32_bool_value ? true : false;                                   \
+            }                                                                               \
+        } while (0)
 }
 
 inline void serialize_copy_string( char * dest, const char * source, size_t dest_size )
@@ -3111,6 +3462,643 @@ inline void test_compressed_float_validation()
     }
 }
 
+// Compile time surface tests. Every compile time form is held to the coverage of its runtime twin
+// (round trip, boundary values, read side rejection, measure agreement), and to the wire identity
+// property: given identical inputs, the compile time form must produce byte identical wire data to
+// the runtime form. That property is what lets a code generator switch forms without a wire change.
+
+// each helper drives the actual macro form under test, so the tests cover the macros as well as the templates
+
+template <typename Stream> bool serialize_int_runtime_form( Stream & stream, int32_t & value, int32_t min, int32_t max )
+{
+    serialize_int( stream, value, min, max );
+    return true;
+}
+
+template <typename Stream> bool serialize_int64_runtime_form( Stream & stream, int64_t & value, int64_t min, int64_t max )
+{
+    serialize_int64( stream, value, min, max );
+    return true;
+}
+
+template <typename Stream> bool serialize_bits64_runtime_form( Stream & stream, uint64_t & value, int bits )
+{
+    serialize_bits( stream, value, bits );
+    return true;
+}
+
+template <int32_t Min, int32_t Max, typename Stream> bool serialize_int_compile_time_form( Stream & stream, int32_t & value )
+{
+    serialize_int_compile_time( stream, value, Min, Max );
+    return true;
+}
+
+template <int64_t Min, int64_t Max, typename Stream> bool serialize_int64_compile_time_form( Stream & stream, int64_t & value )
+{
+    serialize_int64_compile_time( stream, value, Min, Max );
+    return true;
+}
+
+template <int Bits, typename Stream> bool serialize_bits_compile_time_form( Stream & stream, uint32_t & value )
+{
+    serialize_bits_compile_time( stream, value, Bits );
+    return true;
+}
+
+template <int Bits, typename Stream> bool serialize_bits64_compile_time_form( Stream & stream, uint64_t & value )
+{
+    serialize_bits64_compile_time( stream, value, Bits );
+    return true;
+}
+
+inline void test_compile_time_bits_required()
+{
+    // usable in template argument position by construction
+    static_assert( serialize::bits_required64_constexpr( 0, 255 ) == 8, "must be a constant expression" );
+
+    // agrees with the runtime bits_required across the 32 bit table
+    serialize_check( serialize::bits_required64_constexpr( 0, 0 ) == 0 );
+    serialize_check( serialize::bits_required64_constexpr( 0, 1 ) == 1 );
+    serialize_check( serialize::bits_required64_constexpr( 0, 2 ) == 2 );
+    serialize_check( serialize::bits_required64_constexpr( 0, 3 ) == 2 );
+    serialize_check( serialize::bits_required64_constexpr( 0, 4 ) == 3 );
+    serialize_check( serialize::bits_required64_constexpr( 0, 7 ) == 3 );
+    serialize_check( serialize::bits_required64_constexpr( 0, 8 ) == 4 );
+    serialize_check( serialize::bits_required64_constexpr( 0, 255 ) == 8 );
+    serialize_check( serialize::bits_required64_constexpr( 0, 65535 ) == 16 );
+    serialize_check( serialize::bits_required64_constexpr( 0, 4294967295ULL ) == 32 );
+
+    // agrees with the runtime bits_required64 on 64 bit ranges
+    serialize_check( serialize::bits_required64_constexpr( 0, 4294967296ULL ) == 33 );
+    serialize_check( serialize::bits_required64_constexpr( 0, ( 1ULL << 40 ) ) == 41 );
+    serialize_check( serialize::bits_required64_constexpr( 0, 0xFFFFFFFFFFFFFFFFULL ) == 64 );
+    serialize_check( serialize::bits_required64_constexpr( uint64_t(INT64_MIN), uint64_t(INT64_MAX) ) == 64 );
+    serialize_check( serialize::bits_required64_constexpr( uint64_t(-5000000000LL), uint64_t(+5000000000LL) ) == 34 );
+
+    // sign extended int32 bounds wrap to the same difference as the uint32 runtime path
+    serialize_check( serialize::bits_required64_constexpr( uint64_t( int64_t( -100 ) ), uint64_t( int64_t( +100 ) ) ) == serialize::bits_required( uint32_t( -100 ), uint32_t( +100 ) ) );
+    serialize_check( serialize::bits_required64_constexpr( uint64_t( int64_t( INT32_MIN ) ), uint64_t( int64_t( INT32_MAX ) ) ) == 32 );
+
+    // sweep agreement with the runtime form
+    for ( uint32_t max = 0; max <= 1000; max++ )
+    {
+        serialize_check( serialize::bits_required64_constexpr( 0, max ) == serialize::bits_required( 0, max ) );
+    }
+}
+
+template <int32_t Min, int32_t Max> inline void check_compile_time_int_range( const int32_t * values, int num_values )
+{
+    for ( int i = 0; i < num_values; i++ )
+    {
+        const int32_t value = values[i];
+
+        // measure: both forms agree on cost
+        serialize::MeasureStream measureRuntime;
+        int32_t measure_value = value;
+        serialize_check( serialize_int_runtime_form( measureRuntime, measure_value, Min, Max ) == true );
+        serialize::MeasureStream measureCompileTime;
+        measure_value = value;
+        serialize_check( ( serialize_int_compile_time_form<Min, Max>( measureCompileTime, measure_value ) == true ) );
+        serialize_check( measureRuntime.GetBitsProcessed() == measureCompileTime.GetBitsProcessed() );
+
+        // write: the wire identity property, byte for byte
+        uint8_t buffer_runtime[8 + 8] = { 0 };              // + 8: read buffer allocations extend 8 bytes past the data
+        uint8_t buffer_compile_time[8 + 8] = { 0 };         // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::WriteStream writeRuntime( buffer_runtime, 8 );
+        int32_t write_value = value;
+        serialize_check( serialize_int_runtime_form( writeRuntime, write_value, Min, Max ) == true );
+        writeRuntime.Flush();
+
+        serialize::WriteStream writeCompileTime( buffer_compile_time, 8 );
+        write_value = value;
+        serialize_check( ( serialize_int_compile_time_form<Min, Max>( writeCompileTime, write_value ) == true ) );
+        writeCompileTime.Flush();
+
+        serialize_check( writeRuntime.GetBitsProcessed() == writeCompileTime.GetBitsProcessed() );
+        serialize_check( memcmp( buffer_runtime, buffer_compile_time, 8 ) == 0 );
+
+        // round trip through the compile time form
+        serialize::ReadStream readStream( buffer_compile_time, (int) writeCompileTime.GetBytesProcessed() );
+        int32_t read_value = 0;
+        serialize_check( ( serialize_int_compile_time_form<Min, Max>( readStream, read_value ) == true ) );
+        serialize_check( read_value == value );
+
+        // cross decode: runtime written bytes through the compile time form
+        serialize::ReadStream crossStream( buffer_runtime, (int) writeRuntime.GetBytesProcessed() );
+        read_value = 0;
+        serialize_check( ( serialize_int_compile_time_form<Min, Max>( crossStream, read_value ) == true ) );
+        serialize_check( read_value == value );
+    }
+}
+
+inline void test_compile_time_int()
+{
+    {
+        const int32_t values[] = { -100, -99, -37, 0, +1, +99, +100 };
+        check_compile_time_int_range<-100, +100>( values, (int) ( sizeof(values) / sizeof(values[0]) ) );
+    }
+
+    {
+        const int32_t values[] = { 0, 1, 255, 32768, 65534, 65535 };
+        check_compile_time_int_range<0, 65535>( values, (int) ( sizeof(values) / sizeof(values[0]) ) );
+    }
+
+    // ranges wider than 2^31 overflow if [min,max] arithmetic is done signed (undefined behavior)
+    {
+        const int32_t values[] = { INT32_MIN, INT32_MIN + 1, -1, 0, +1, INT32_MAX - 1, INT32_MAX };
+        check_compile_time_int_range<INT32_MIN, INT32_MAX>( values, (int) ( sizeof(values) / sizeof(values[0]) ) );
+    }
+
+    {
+        const int32_t values[] = { -2000000000, -1, 0, +1000000000, +2000000000 };
+        check_compile_time_int_range<-2000000000, +2000000000>( values, (int) ( sizeof(values) / sizeof(values[0]) ) );
+    }
+}
+
+template <int64_t Min, int64_t Max> inline void check_compile_time_int64_range( const int64_t * values, int num_values )
+{
+    for ( int i = 0; i < num_values; i++ )
+    {
+        const int64_t value = values[i];
+
+        // measure: both forms agree on cost
+        serialize::MeasureStream measureRuntime;
+        int64_t measure_value = value;
+        serialize_check( serialize_int64_runtime_form( measureRuntime, measure_value, Min, Max ) == true );
+        serialize::MeasureStream measureCompileTime;
+        measure_value = value;
+        serialize_check( ( serialize_int64_compile_time_form<Min, Max>( measureCompileTime, measure_value ) == true ) );
+        serialize_check( measureRuntime.GetBitsProcessed() == measureCompileTime.GetBitsProcessed() );
+
+        // write: the wire identity property, byte for byte
+        uint8_t buffer_runtime[8 + 8] = { 0 };              // + 8: read buffer allocations extend 8 bytes past the data
+        uint8_t buffer_compile_time[8 + 8] = { 0 };         // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::WriteStream writeRuntime( buffer_runtime, 8 );
+        int64_t write_value = value;
+        serialize_check( serialize_int64_runtime_form( writeRuntime, write_value, Min, Max ) == true );
+        writeRuntime.Flush();
+
+        serialize::WriteStream writeCompileTime( buffer_compile_time, 8 );
+        write_value = value;
+        serialize_check( ( serialize_int64_compile_time_form<Min, Max>( writeCompileTime, write_value ) == true ) );
+        writeCompileTime.Flush();
+
+        serialize_check( writeRuntime.GetBitsProcessed() == writeCompileTime.GetBitsProcessed() );
+        serialize_check( memcmp( buffer_runtime, buffer_compile_time, 8 ) == 0 );
+
+        // round trip through the compile time form
+        serialize::ReadStream readStream( buffer_compile_time, (int) writeCompileTime.GetBytesProcessed() );
+        int64_t read_value = 0;
+        serialize_check( ( serialize_int64_compile_time_form<Min, Max>( readStream, read_value ) == true ) );
+        serialize_check( read_value == value );
+
+        // cross decode: runtime written bytes through the compile time form
+        serialize::ReadStream crossStream( buffer_runtime, (int) writeRuntime.GetBytesProcessed() );
+        read_value = 0;
+        serialize_check( ( serialize_int64_compile_time_form<Min, Max>( crossStream, read_value ) == true ) );
+        serialize_check( read_value == value );
+    }
+}
+
+inline void test_compile_time_int64()
+{
+    // small ranges use the single dword path
+    {
+        const int64_t values[] = { -100, -99, -1, 0, +1, +55, +99, +100 };
+        check_compile_time_int64_range<-100, +100>( values, (int) ( sizeof(values) / sizeof(values[0]) ) );
+    }
+
+    // ranges spanning more than 32 bits use the two dword path
+    {
+        const int64_t values[] = { -5000000000LL, -5000000000LL + 1, -1, 0, +1, 4123456789LL, +5000000000LL - 1, +5000000000LL };
+        check_compile_time_int64_range<-5000000000LL, +5000000000LL>( values, (int) ( sizeof(values) / sizeof(values[0]) ) );
+    }
+
+    // ranges wider than 2^63 overflow if [min,max] arithmetic is done signed (undefined behavior)
+    {
+        const int64_t values[] = { INT64_MIN, INT64_MIN + 1, -1, 0, +1, INT64_MAX - 1, INT64_MAX };
+        check_compile_time_int64_range<INT64_MIN, INT64_MAX>( values, (int) ( sizeof(values) / sizeof(values[0]) ) );
+    }
+
+    // the single dword path uses the minimal number of bits, same as the runtime form
+    {
+        uint8_t buffer[8 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::WriteStream writeStream( buffer, 8 );
+        int64_t value = 55;
+        serialize_check( ( serialize::SerializeInt64Const<-100, +100>( writeStream, value ) == true ) );
+        writeStream.Flush();
+        serialize_check( writeStream.GetBitsProcessed() == 8 );        // bits_required64(-100,100) == 8, same as the 32 bit path
+    }
+}
+
+template <int Bits> inline void check_compile_time_bits_width()
+{
+    // ( ( 1 << ( Bits - 1 ) ) << 1 ) - 1 is the all ones value without shifting by the full width (undefined behavior at Bits == 32)
+    const uint32_t max_value = uint32_t( ( ( uint64_t(1) << ( Bits - 1 ) ) << 1 ) - 1 );
+    const uint32_t values[] = { 0, 1, max_value >> 1, max_value };
+
+    for ( int i = 0; i < (int) ( sizeof(values) / sizeof(values[0]) ); i++ )
+    {
+        const uint32_t value = values[i];
+
+        // measure: both forms agree on cost
+        serialize::MeasureStream measureRuntime;
+        uint64_t measure_value64 = value;
+        serialize_check( serialize_bits64_runtime_form( measureRuntime, measure_value64, Bits ) == true );
+        serialize::MeasureStream measureCompileTime;
+        uint32_t measure_value = value;
+        serialize_check( serialize_bits_compile_time_form<Bits>( measureCompileTime, measure_value ) == true );
+        serialize_check( measureRuntime.GetBitsProcessed() == measureCompileTime.GetBitsProcessed() );
+
+        // write: the wire identity property, byte for byte
+        uint8_t buffer_runtime[8 + 8] = { 0 };              // + 8: read buffer allocations extend 8 bytes past the data
+        uint8_t buffer_compile_time[8 + 8] = { 0 };         // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::WriteStream writeRuntime( buffer_runtime, 8 );
+        uint64_t write_value64 = value;
+        serialize_check( serialize_bits64_runtime_form( writeRuntime, write_value64, Bits ) == true );
+        writeRuntime.Flush();
+
+        serialize::WriteStream writeCompileTime( buffer_compile_time, 8 );
+        uint32_t write_value = value;
+        serialize_check( serialize_bits_compile_time_form<Bits>( writeCompileTime, write_value ) == true );
+        writeCompileTime.Flush();
+
+        serialize_check( writeRuntime.GetBitsProcessed() == writeCompileTime.GetBitsProcessed() );
+        serialize_check( memcmp( buffer_runtime, buffer_compile_time, 8 ) == 0 );
+
+        // round trip through the compile time form
+        serialize::ReadStream readStream( buffer_compile_time, (int) writeCompileTime.GetBytesProcessed() );
+        uint32_t read_value = 0;
+        serialize_check( serialize_bits_compile_time_form<Bits>( readStream, read_value ) == true );
+        serialize_check( read_value == value );
+
+        // cross decode: runtime written bytes through the compile time form
+        serialize::ReadStream crossStream( buffer_runtime, (int) writeRuntime.GetBytesProcessed() );
+        read_value = 0;
+        serialize_check( serialize_bits_compile_time_form<Bits>( crossStream, read_value ) == true );
+        serialize_check( read_value == value );
+    }
+}
+
+template <int Bits> inline void check_compile_time_bits64_width()
+{
+    // ( ( 1 << ( Bits - 1 ) ) << 1 ) - 1 is the all ones value without shifting by the full width (undefined behavior at Bits == 64)
+    const uint64_t max_value = ( ( uint64_t(1) << ( Bits - 1 ) ) << 1 ) - 1;
+    const uint64_t values[] = { 0, 1, max_value >> 1, max_value };
+
+    for ( int i = 0; i < (int) ( sizeof(values) / sizeof(values[0]) ); i++ )
+    {
+        const uint64_t value = values[i];
+
+        // measure: both forms agree on cost
+        serialize::MeasureStream measureRuntime;
+        uint64_t measure_value = value;
+        serialize_check( serialize_bits64_runtime_form( measureRuntime, measure_value, Bits ) == true );
+        serialize::MeasureStream measureCompileTime;
+        measure_value = value;
+        serialize_check( serialize_bits64_compile_time_form<Bits>( measureCompileTime, measure_value ) == true );
+        serialize_check( measureRuntime.GetBitsProcessed() == measureCompileTime.GetBitsProcessed() );
+
+        // write: the wire identity property, byte for byte
+        uint8_t buffer_runtime[8 + 8] = { 0 };              // + 8: read buffer allocations extend 8 bytes past the data
+        uint8_t buffer_compile_time[8 + 8] = { 0 };         // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::WriteStream writeRuntime( buffer_runtime, 8 );
+        uint64_t write_value = value;
+        serialize_check( serialize_bits64_runtime_form( writeRuntime, write_value, Bits ) == true );
+        writeRuntime.Flush();
+
+        serialize::WriteStream writeCompileTime( buffer_compile_time, 8 );
+        write_value = value;
+        serialize_check( serialize_bits64_compile_time_form<Bits>( writeCompileTime, write_value ) == true );
+        writeCompileTime.Flush();
+
+        serialize_check( writeRuntime.GetBitsProcessed() == writeCompileTime.GetBitsProcessed() );
+        serialize_check( memcmp( buffer_runtime, buffer_compile_time, 8 ) == 0 );
+
+        // round trip through the compile time form
+        serialize::ReadStream readStream( buffer_compile_time, (int) writeCompileTime.GetBytesProcessed() );
+        uint64_t read_value = 0;
+        serialize_check( serialize_bits64_compile_time_form<Bits>( readStream, read_value ) == true );
+        serialize_check( read_value == value );
+
+        // cross decode: runtime written bytes through the compile time form
+        serialize::ReadStream crossStream( buffer_runtime, (int) writeRuntime.GetBytesProcessed() );
+        read_value = 0;
+        serialize_check( serialize_bits64_compile_time_form<Bits>( crossStream, read_value ) == true );
+        serialize_check( read_value == value );
+    }
+}
+
+inline void test_compile_time_bits()
+{
+    check_compile_time_bits_width<1>();
+    check_compile_time_bits_width<2>();
+    check_compile_time_bits_width<7>();
+    check_compile_time_bits_width<8>();
+    check_compile_time_bits_width<13>();
+    check_compile_time_bits_width<23>();
+    check_compile_time_bits_width<31>();
+    check_compile_time_bits_width<32>();
+
+    check_compile_time_bits64_width<1>();
+    check_compile_time_bits64_width<20>();
+    check_compile_time_bits64_width<32>();
+    check_compile_time_bits64_width<33>();
+    check_compile_time_bits64_width<48>();
+    check_compile_time_bits64_width<63>();
+    check_compile_time_bits64_width<64>();
+}
+
+inline void test_compile_time_int_validation()
+{
+    // bits_required(0,5) is 3 bits, so a malicious packet can encode 6 or 7. reads must reject values above max.
+    {
+        uint8_t buffer[4 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::WriteStream writeStream( buffer, 8 );
+        uint32_t out_of_range = 7;
+        writeStream.SerializeBits( out_of_range, 3 );
+        writeStream.Flush();
+
+        serialize::ReadStream readStream( buffer, 4 );
+        int32_t value = 0;
+        serialize_check( ( serialize::SerializeIntConst<0, 5>( readStream, value ) == false ) );
+    }
+
+    // reads past the end of the buffer must fail cleanly
+    {
+        uint8_t buffer[8 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::ReadStream readStream( buffer, 1 );
+        int32_t value = 0;
+        serialize_check( ( serialize::SerializeIntConst<0, 65535>( readStream, value ) == false ) );
+    }
+}
+
+inline void test_compile_time_int64_validation()
+{
+    // a malicious packet can smuggle an out of range value into the bit headroom of the two dword path. reads must reject it.
+    {
+        uint8_t buffer[16 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::WriteStream writeStream( buffer, 16 );
+        const uint64_t out_of_range = ( 1ULL << 34 ) + 5;               // range [0, 2^34] is 35 bits, so values above 2^34 fit in the headroom
+        uint32_t lo = uint32_t( out_of_range & 0xFFFFFFFF );
+        uint32_t hi = uint32_t( out_of_range >> 32 );
+        writeStream.SerializeBits( lo, 32 );
+        writeStream.SerializeBits( hi, 3 );
+        writeStream.Flush();
+
+        serialize::ReadStream readStream( buffer, 16 );
+        int64_t value = 0;
+        serialize_check( ( serialize::SerializeInt64Const<0, ( int64_t(1) << 34 )>( readStream, value ) ) == false );
+    }
+
+    // reads past the end of the buffer must fail cleanly (the low dword fits, the high remainder does not)
+    {
+        uint8_t buffer[4 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::ReadStream readStream( buffer, 4 );
+        int64_t value = 0;
+        serialize_check( ( serialize::SerializeInt64Const<INT64_MIN, INT64_MAX>( readStream, value ) ) == false );
+    }
+}
+
+inline void test_compile_time_bits_validation()
+{
+    // reads past the end of the buffer must fail cleanly
+    {
+        uint8_t buffer[8 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::ReadStream readStream( buffer, 1 );
+        uint32_t value = 0;
+        serialize_check( serialize::SerializeBitsConst<13>( readStream, value ) == false );
+    }
+
+    // the two dword path: the low dword fits, the high remainder does not
+    {
+        uint8_t buffer[4 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::ReadStream readStream( buffer, 4 );
+        uint64_t value = 0;
+        serialize_check( serialize::SerializeBits64Const<48>( readStream, value ) == false );
+    }
+}
+
+// a packet exercising every compile time form next to its runtime twin, field for field
+
+struct CompileTimeTestPacket
+{
+    CompileTimeTestPacket()
+    {
+        memset( (void*) this, 0, sizeof( CompileTimeTestPacket ) );
+    }
+
+    int32_t int_a;          // [-100,+100]
+    int32_t int_b;          // [0,65535]
+    int32_t int_c;          // [INT32_MIN,INT32_MAX]
+    int64_t int64_small;    // [-100,+100]: single dword path
+    int64_t int64_wide;     // [-5000000000,+5000000000]: two dword path
+    int64_t int64_full;     // [INT64_MIN,INT64_MAX]
+    uint32_t bits1;
+    uint32_t bits7;
+    uint32_t bits13;
+    uint32_t bits23;
+    uint32_t bits32;
+    uint64_t bits48;        // the >32 bit serialize_bits case
+    uint64_t bits64;
+    bool flag_a;
+    bool flag_b;
+
+    void InitTypical()
+    {
+        int_a = -37;
+        int_b = 12345;
+        int_c = -123456789;
+        int64_small = 55;
+        int64_wide = 4123456789LL;
+        int64_full = -123456789012345LL;
+        bits1 = 1;
+        bits7 = 97;
+        bits13 = 5000;
+        bits23 = 1234567;
+        bits32 = 0xDEADBEEF;
+        bits48 = 0x123456789ABCULL;
+        bits64 = 0x123456789ABCDEF0ULL;
+        flag_a = true;
+        flag_b = false;
+    }
+
+    void InitLow()          // every field at its minimum legal value
+    {
+        int_a = -100;
+        int_b = 0;
+        int_c = INT32_MIN;
+        int64_small = -100;
+        int64_wide = -5000000000LL;
+        int64_full = INT64_MIN;
+        bits1 = 0;
+        bits7 = 0;
+        bits13 = 0;
+        bits23 = 0;
+        bits32 = 0;
+        bits48 = 0;
+        bits64 = 0;
+        flag_a = false;
+        flag_b = false;
+    }
+
+    void InitHigh()         // every field at its maximum legal value
+    {
+        int_a = +100;
+        int_b = 65535;
+        int_c = INT32_MAX;
+        int64_small = +100;
+        int64_wide = +5000000000LL;
+        int64_full = INT64_MAX;
+        bits1 = 1;
+        bits7 = 127;
+        bits13 = 8191;
+        bits23 = 8388607;
+        bits32 = 0xFFFFFFFF;
+        bits48 = ( 1ULL << 48 ) - 1;
+        bits64 = 0xFFFFFFFFFFFFFFFFULL;
+        flag_a = true;
+        flag_b = true;
+    }
+
+    template <typename Stream> bool SerializeRuntime( Stream & stream )
+    {
+        serialize_int( stream, int_a, -100, +100 );
+        serialize_int( stream, int_b, 0, 65535 );
+        serialize_int( stream, int_c, INT32_MIN, INT32_MAX );
+        serialize_int64( stream, int64_small, -100, +100 );
+        serialize_int64( stream, int64_wide, -5000000000LL, +5000000000LL );
+        serialize_int64( stream, int64_full, INT64_MIN, INT64_MAX );
+        serialize_bits( stream, bits1, 1 );
+        serialize_bits( stream, bits7, 7 );
+        serialize_bits( stream, bits13, 13 );
+        serialize_bits( stream, bits23, 23 );
+        serialize_bits( stream, bits32, 32 );
+        serialize_bits( stream, bits48, 48 );
+        serialize_bits( stream, bits64, 64 );
+        serialize_bool( stream, flag_a );
+        serialize_bool( stream, flag_b );
+        return true;
+    }
+
+    template <typename Stream> bool SerializeCompileTime( Stream & stream )
+    {
+        serialize_int_compile_time( stream, int_a, -100, +100 );
+        serialize_int_compile_time( stream, int_b, 0, 65535 );
+        serialize_int_compile_time( stream, int_c, INT32_MIN, INT32_MAX );
+        serialize_int64_compile_time( stream, int64_small, -100, +100 );
+        serialize_int64_compile_time( stream, int64_wide, -5000000000LL, +5000000000LL );
+        serialize_int64_compile_time( stream, int64_full, INT64_MIN, INT64_MAX );
+        serialize_bits_compile_time( stream, bits1, 1 );
+        serialize_bits_compile_time( stream, bits7, 7 );
+        serialize_bits_compile_time( stream, bits13, 13 );
+        serialize_bits_compile_time( stream, bits23, 23 );
+        serialize_bits_compile_time( stream, bits32, 32 );
+        serialize_bits64_compile_time( stream, bits48, 48 );
+        serialize_bits64_compile_time( stream, bits64, 64 );
+        serialize_bool_compile_time( stream, flag_a );
+        serialize_bool_compile_time( stream, flag_b );
+        return true;
+    }
+
+    bool operator == ( const CompileTimeTestPacket & other ) const
+    {
+        return int_a == other.int_a &&
+               int_b == other.int_b &&
+               int_c == other.int_c &&
+               int64_small == other.int64_small &&
+               int64_wide == other.int64_wide &&
+               int64_full == other.int64_full &&
+               bits1 == other.bits1 &&
+               bits7 == other.bits7 &&
+               bits13 == other.bits13 &&
+               bits23 == other.bits23 &&
+               bits32 == other.bits32 &&
+               bits48 == other.bits48 &&
+               bits64 == other.bits64 &&
+               flag_a == other.flag_a &&
+               flag_b == other.flag_b;
+    }
+
+    bool operator != ( const CompileTimeTestPacket & other ) const
+    {
+        return ! ( *this == other );
+    }
+};
+
+inline void check_compile_time_packet( CompileTimeTestPacket & packet )
+{
+    const int BufferSize = 64;
+
+    uint8_t buffer_runtime[BufferSize + 8];             // + 8: read buffer allocations extend 8 bytes past the data
+    uint8_t buffer_compile_time[BufferSize + 8];        // + 8: read buffer allocations extend 8 bytes past the data
+    memset( buffer_runtime, 0, sizeof( buffer_runtime ) );
+    memset( buffer_compile_time, 0, sizeof( buffer_compile_time ) );
+
+    serialize::WriteStream writeRuntime( buffer_runtime, BufferSize );
+    serialize_check( packet.SerializeRuntime( writeRuntime ) == true );
+    writeRuntime.Flush();
+
+    serialize::WriteStream writeCompileTime( buffer_compile_time, BufferSize );
+    serialize_check( packet.SerializeCompileTime( writeCompileTime ) == true );
+    writeCompileTime.Flush();
+
+    // the wire identity property: byte identical, so a code generator can switch forms without a wire change
+    serialize_check( writeRuntime.GetBitsProcessed() == writeCompileTime.GetBitsProcessed() );
+    serialize_check( memcmp( buffer_runtime, buffer_compile_time, BufferSize ) == 0 );
+
+    // measure streams agree with the write streams (no aligns in this packet, so the measure is exact)
+    serialize::MeasureStream measureRuntime;
+    serialize_check( packet.SerializeRuntime( measureRuntime ) == true );
+    serialize::MeasureStream measureCompileTime;
+    serialize_check( packet.SerializeCompileTime( measureCompileTime ) == true );
+    serialize_check( measureRuntime.GetBitsProcessed() == writeRuntime.GetBitsProcessed() );
+    serialize_check( measureCompileTime.GetBitsProcessed() == writeCompileTime.GetBitsProcessed() );
+
+    const int bytesWritten = (int) writeRuntime.GetBytesProcessed();
+
+    // cross decode: runtime written bytes through the compile time form...
+    {
+        serialize::ReadStream readStream( buffer_runtime, bytesWritten );
+        CompileTimeTestPacket read_packet;
+        serialize_check( read_packet.SerializeCompileTime( readStream ) == true );
+        serialize_check( read_packet == packet );
+    }
+
+    // ...and compile time written bytes through the runtime form
+    {
+        serialize::ReadStream readStream( buffer_compile_time, bytesWritten );
+        CompileTimeTestPacket read_packet;
+        serialize_check( read_packet.SerializeRuntime( readStream ) == true );
+        serialize_check( read_packet == packet );
+    }
+}
+
+inline void test_compile_time_packet()
+{
+    CompileTimeTestPacket packet;
+
+    packet.InitTypical();
+    check_compile_time_packet( packet );
+
+    packet.InitLow();
+    check_compile_time_packet( packet );
+
+    packet.InitHigh();
+    check_compile_time_packet( packet );
+}
+
 // Golden wire format test. The exact bytes produced by the serializer are pinned down here and must never change.
 // If this test fails, the wire format has changed and previously written data no longer decodes: a breaking change.
 // The values below are chosen so every platform quantizes identically (see the compressed float: 5.0 in [0,10]
@@ -3374,6 +4362,14 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_wstring_validation );
         SERIALIZE_RUN_TEST( test_int_relative_validation );
         SERIALIZE_RUN_TEST( test_compressed_float_validation );
+        SERIALIZE_RUN_TEST( test_compile_time_bits_required );
+        SERIALIZE_RUN_TEST( test_compile_time_int );
+        SERIALIZE_RUN_TEST( test_compile_time_int64 );
+        SERIALIZE_RUN_TEST( test_compile_time_bits );
+        SERIALIZE_RUN_TEST( test_compile_time_int_validation );
+        SERIALIZE_RUN_TEST( test_compile_time_int64_validation );
+        SERIALIZE_RUN_TEST( test_compile_time_bits_validation );
+        SERIALIZE_RUN_TEST( test_compile_time_packet );
         SERIALIZE_RUN_TEST( test_golden_wire_format );
         SERIALIZE_RUN_TEST( test_unaligned_writer );
         SERIALIZE_RUN_TEST( test_large_buffer );


### PR DESCRIPTION
Experiment branch: an additive compile-time-parameter surface intended for schema-generated C++. The existing macros and stream methods are untouched; generated code calls the template forms directly, humans keep the runtime-arg macros.

## What's here

- `SerializeIntConst<Min,Max>` / `SerializeInt64Const<Min,Max>` / `SerializeBitsConst<Bits>` / `SerializeBits64Const<Bits>` — bounds and widths as non-type template parameters: `static_assert(Min < Max)`, constexpr bit counts, no runtime branch on width.
- Macro wrappers `serialize_int_compile_time`, `serialize_int64_compile_time`, `serialize_bits_compile_time`, `serialize_bits64_compile_time`, `serialize_bool_compile_time` — same call shapes, arguments expand into template-argument position (runtime values refuse to compile, deliberately).
- 8 new test functions (26 total): value sweeps against runtime `bits_required`, boundary and rejection cases mirroring the runtime twins, and the load-bearing property — **wire identity**: const forms produce byte-identical wire to the runtime forms (memcmp + bit-count per value, plus cross-decode in both directions), so a generator can switch forms without a wire change.
- Matched bench pairs in bench.cpp (same LCG variation, same escape barriers as the existing rows).

## Local measurements (Apple Silicon, clang, gnu++14 default)

Release writes: bits packet **+27%**, mixed generated-shape packet **+13%**, bounded ints −3–6%, reads **flat** (disassembly: the branchless reader compiles both forms byte-identical; the win is confined to inliner-spill sites, which land in constant-specialized instantiations instead of the generic runtime functions). Debug: slightly **slower** across the board — the extra template frame outweighs the parameter math at -O0.

## What CI adds

Correctness across the matrix — most importantly that the C++14-constexpr surface compiles and passes on MSVC, GCC, and big-endian s390x. Note CI does not run bench.cpp, so MSVC performance numbers (where folding is weakest and the upside plausibly largest) remain unmeasured until benched on a Windows box.

Experiment status: not for merge until the author calls it; the wire-identity tests ride along with any promotion out of experiment status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
