### PR TITLE
Fixed point and 128 bit integers: serialize_fixed, serialize_uint128, the emulated pair

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,28 +28,28 @@ THE WRITE/READ RULE — this library is the clearest statement of it, IN ITS OWN
 Glenn, 2026-07-26: "intention is on write, user is responsible to not crash or do undefined
 behavior. asserts are there to help. callers responsibility. on read, obviously, we must
 check." Plus Postel: "be conservative in what you send, permissive in what you receive."
-serialize.h says it directly at :870, :918 and :933 -- "All checking is performed by debug
+serialize.h says it directly at :1477, :1525 and :1540 -- "All checking is performed by debug
 asserts on write." That is the CONTRACT. I audited this header, quoted that exact line in my
 notes, and still filed the write path as a defect. Do not repeat that.
 DELIBERATELY ASSERT-ONLY ON WRITE, do NOT "fix":
-  - BitWriter::WriteBits (:432) and WriteBytes (:488) -- the asserts are the whole bound.
-  - BitWriter::Initialize / ctor (:389, :409): serialize_assert( ( bytes % 8 ) == 0 ) is the
-    ENTIRE enforcement of the qword-store contract that FlushBits (:537) relies on. Hand a
+  - BitWriter::WriteBits (:1034) and WriteBytes (:1091) -- the asserts are the whole bound.
+  - BitWriter::Initialize / ctor (:994, :1013): serialize_assert( ( bytes % 8 ) == 0 ) is the
+    ENTIRE enforcement of the qword-store contract that FlushBits (:1137) relies on. Hand a
     WriteStream a 100-byte buffer, write exactly 800 bits -- within capacity, violating no
     assert even in debug -- and the flush memcpys 8 bytes at offset 96, four PAST the end.
     Proved with a canary, 2026-07-26. Still the caller's responsibility: pass a multiple of 8.
     (yojimbo satisfies it on purpose at yojimbo_connection.cpp:248, `maxPacketBytes &= ~7`.)
-  - serialize_copy_string / serialize_copy_wstring (:2188, :2202) with dest_size 0 -- the
+  - serialize_copy_string / serialize_copy_wstring (:3172, :3186) with dest_size 0 -- the
     same size_t underflow as reliable_copy_string.
 NOTE FOR ANY SANITIZER WORK HERE: ASan does NOT report that FlushBits overflow. It is a
 partial-granule write (8 bytes at offset 96 of a 100-byte allocation) and ASan is blind to
 it -- verified with a control, an identical raw memcpy is also unreported. "No ASan report"
 is NOT evidence of safety in this header. Use a canary region.
 THE READ PATH IS CLEAN and both independent audits agree: every BitReader assert has a real
-ReadStream companion -- WouldReadPastEnd at :1059, :1081, :1113, :1148; ReadBytes bounds at
-:1129 and :1134; values off the wire range-checked twice (:1062 and the serialize_int macro
-at :1358). serialize_string_internal (:1689) is safe on read because length comes off the
-wire via serialize_int bounded by buffer_size - 1; its assert at :1695 is inside an
+ReadStream companion -- WouldReadPastEnd at :1666, :1688, :1720, :1755; ReadBytes bounds at
+:1736 and :1741; values off the wire range-checked twice (:1669 and the serialize_int macro
+at :1965). serialize_string_internal (:2347) is safe on read because length comes off the
+wire via serialize_int bounded by buffer_size - 1; its assert at :2353 is inside an
 IsWriting branch and never runs on read.
 <!-- HOT:END -->
 
@@ -57,8 +57,8 @@ IsWriting branch and never runs on read.
 
 ## What this is
 
-A single-header C++ bitpacking serializer (~2,100 lines of library code in
-[serialize.h](serialize.h), plus ~700 lines of embedded tests) aimed at game
+A single-header C++ bitpacking serializer (~3,200 lines of library code in
+[serialize.h](serialize.h), plus ~2,400 lines of embedded tests) aimed at game
 networking. Header-only is intentional: the serialize methods are heavily
 templated, so the implementation cannot live in a .cpp file. The header is
 self-contained — including it into a translation unit with no prior
@@ -120,16 +120,16 @@ change for previously written data.
 
 - **The read path is defensive, and recently hardened.** Every `ReadStream`
   operation bounds-checks before reading and range-checks after
-  ([serialize.h:1048](serialize.h:1048)), returning false instead of asserting,
+  ([serialize.h:1655](serialize.h:1655)), returning false instead of asserting,
   so malicious packets fail cleanly. Arithmetic that could overflow signed
   ints is done in the unsigned domain with comments explaining why (e.g.
-  [serialize.h:892](serialize.h:892), [serialize.h:1807](serialize.h:1807)),
+  [serialize.h:1486](serialize.h:1486), [serialize.h:1506](serialize.h:1506)),
   and NaN is clamped before any float-to-int cast
-  ([serialize.h:1535](serialize.h:1535)). Recent commits show active work here.
+  ([serialize.h:2149](serialize.h:2149)). Recent commits show active work here.
 - **The tests cover adversarial cases, not just round trips**: out-of-range
   encodings smuggled into bit headroom, full `[INT32_MIN, INT32_MAX]` ranges,
   negative and huge byte counts, NaN input, >2^31 relative gaps
-  ([serialize.h:2711](serialize.h:2711) onward). This is better test thinking
+  ([serialize.h:3747](serialize.h:3747) onward). This is better test thinking
   than most serialization libraries have.
 - **The core design is sound and well understood.** Writer: 64-bit scratch,
   64-bit flush — the scratch stores as a qword when it fills and the bits

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ It has the following features:
 * Serialize any integer value from [1,64] bits writing only that number of bits to the buffer
 * Serialize signed integer values with [min,max] writing only the required bits to the buffer
 * Serialize floats, doubles, compressed floats, strings, byte arrays, and integers relative to another integer
+* Serialize fixed point values with a compile time Q format and [min,max] bounds in whole units, writing only the required bits — round trips are exact, unlike compressed floats. Wide formats like Q112.16 work on every platform
+* Serialize 128 bit unsigned integers on every platform: native __int128 where the compiler has it, an emulated signed/unsigned pair where it doesn't, byte-identical on the wire
 * Alignment support so you can align your bitstream to a byte boundary whenever you want
 * Optional template-based serialization so you can write one function that handles both read and write
 
@@ -101,6 +103,27 @@ struct RigidBody
             linearVelocity.x = linearVelocity.y = linearVelocity.z = 0.0;
             angularVelocity.x = angularVelocity.y = angularVelocity.z = 0.0;
         }
+        return true;
+    }
+};
+```
+
+Fixed point values serialize exactly. The Q format and the bounds are compile time constants, and only the bits the range requires go on the wire:
+
+```c++
+struct Player
+{
+    int64_t position_x;                     // Q48.16 fixed point, in ±8192 whole units
+    int64_t position_y;
+    int64_t position_z;
+    serialize::uint128_t entity_id;         // 128 bit globally unique id
+
+    template <typename Stream> bool Serialize( Stream & stream )
+    {
+        serialize_fixed( stream, position_x, 48, 16, -8192, +8192 );
+        serialize_fixed( stream, position_y, 48, 16, -8192, +8192 );
+        serialize_fixed( stream, position_z, 48, 16, -8192, +8192 );
+        serialize_uint128( stream, entity_id );
         return true;
     }
 };

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ struct Player
     int64_t position_y;
     int64_t position_z;
     serialize::uint128_t entity_id;         // 128 bit globally unique id
+    serialize::int128_t sector_offset;      // ranged 128 bit integer
 
     template <typename Stream> bool Serialize( Stream & stream )
     {
@@ -124,10 +125,13 @@ struct Player
         serialize_fixed( stream, position_y, 48, 16, -8192, +8192 );
         serialize_fixed( stream, position_z, 48, 16, -8192, +8192 );
         serialize_uint128( stream, entity_id );
+        serialize_int128( stream, sector_offset, -(serialize::int128_t(1) << 70), +(serialize::int128_t(1) << 70) );
         return true;
     }
 };
 ```
+
+`serialize_uint128` is a raw 128 bit field and always costs 128 bits. `serialize_int128` is the ranged form: it costs only the bits its range needs, and where that range fits 64 bits the bytes are identical to `serialize_int64`. Both work on every platform, including compilers with no native `__int128`.
 
 See [example.cpp](example.cpp) for more.
 

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -135,6 +135,35 @@ bits are written first, followed by the remaining `bits - 32` high bits.
 `serialize_bits( value, 64 )` and always costs a full 64 bits. The names are
 similar and the encodings are not.
 
+### int128 (ranged)
+
+    serialize_int128( stream, value, min, max )
+
+The 128-bit counterpart, and the only ranged 128-bit operation.
+`bits_required128( min, max )` bits are used, where `min` and `max` are
+converted to the unsigned 128-bit domain first, so a range wider than `2^127`
+is exact rather than overflowing. The offset `value - min` is computed in that
+same unsigned domain and written in 32-bit groups from least significant
+upward — the same splitting rule as `serialize_bits` and the wide fixed point
+path: `bits <= 32` is a single group, otherwise full 32-bit groups from the
+bottom with the final group carrying the remainder, up to four groups.
+
+Where the range fits 64 bits or fewer the bytes are **identical to
+`serialize_int64( value, min, max )`** over the same bounds. A field may
+therefore be widened from 64 to 128 bits without changing the wire, provided
+the bounds do not change.
+
+The bounds are runtime values, exactly as for `serialize_int` and
+`serialize_int64`. The bit count comes from the runtime `bits_required128`,
+which is available on every platform — including compilers with no native
+`__int128`, where the emulated pair supplies every operation it needs.
+
+**Do not confuse this with `serialize_uint128`**, which is not ranged — it is
+two `serialize_uint64` calls and always costs a full 128 bits.
+
+Readers must check that the decoded offset is at most `max - min` in the
+unsigned domain and fail otherwise — reject, never clamp.
+
 ### fixed (Q format, ranged)
 
     serialize_fixed( stream, value, integer_bits, fraction_bits, min, max )

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -71,6 +71,22 @@ information of their own:
 
 One bit: `1` for true, `0` for false.
 
+### uint128
+
+    serialize_uint128( stream, value )
+
+A 128-bit unsigned integer, always 128 bits on the wire: the **low 64-bit half
+first**, then the high half, each half written exactly as
+`serialize_bits( half, 64 )` — that is, four 32-bit groups from least
+significant upward. When the stream is byte aligned, the result is the 16
+bytes of the value in little-endian order.
+
+The operation is representation-independent. A native `unsigned __int128`, the
+library's emulated two-lane type (`lo` then `hi`, both `uint64_t`), and two
+explicit `serialize_uint64` calls (low half first) all produce **byte-identical
+wire**. An implementation with no 128-bit type reproduces the format exactly
+with two 64-bit operations.
+
 ### align
 
     serialize_align( stream )
@@ -118,6 +134,39 @@ bits are written first, followed by the remaining `bits - 32` high bits.
 **Do not confuse this with `serialize_uint64`**, which is not ranged — it is
 `serialize_bits( value, 64 )` and always costs a full 64 bits. The names are
 similar and the encodings are not.
+
+### fixed (Q format, ranged)
+
+    serialize_fixed( stream, value, integer_bits, fraction_bits, min, max )
+
+A fixed point value held in an integer storage type of exactly `integer_bits +
+fraction_bits` bits, with the sign bit counting toward `integer_bits` (Q48.16
+in an `int64_t`, Q112.16 in an `__int128`). The stored integer is the real
+value scaled by `2^fraction_bits`. `min` and `max` are bounds in **whole real
+units**, and all four parameters are compile-time constants of the call site —
+they are part of the format, exactly like a ranged integer's bounds.
+
+The encoding is an offset encoding over the **raw** (scaled) bounds:
+
+    raw_min = min << fraction_bits
+    raw_max = max << fraction_bits
+    bits    = bit length of ( raw_max - raw_min )    — bits_required, at whatever width the range needs
+
+`raw_value - raw_min` is written in `bits` bits, split into 32-bit groups from
+least significant upward exactly as `serialize_bits` splits wide values:
+`bits <= 32` is a single group, otherwise full 32-bit groups from the bottom
+with the final group carrying the remainder. For storage of 64 bits or fewer
+the bytes are **identical to `serialize_int64( raw_value, raw_min, raw_max )`**
+— fixed point adds no new wire structure, only the compile-time scaling
+convention — and with `fraction_bits = 0` the operation *is* a ranged integer.
+
+Readers must check that the decoded offset is at most `raw_max - raw_min` and
+fail otherwise — reject, never clamp.
+
+Because fixed point values are integers underneath, the round trip is
+**exact**: unlike `compressed_float` there is no quantization step, and the
+same raw value produces the same bytes and reads back bit-for-bit identical on
+every platform.
 
 ### int_relative
 
@@ -234,9 +283,9 @@ truncating**.
 ## Worked Example
 
 The library's golden test serializes a fixed message and asserts an exact
-72-byte output. The final field is a wide string in a `wchar_t[8]` buffer
+86-byte output. One field is a wide string in a `wchar_t[8]` buffer
 containing three characters — `0x043C`, `0x0438`, `0x0440` — and it produces
-this 13-byte tail:
+this 13-byte run:
 
     0xE3 0x21 0x00 0x00 0xC0 0x21 0x00 0x00 0x00 0x22 0x00 0x00 0x00
 
@@ -251,8 +300,16 @@ Decoding it against this document:
   **`0x043C`**.
 * Two further 32-bit groups follow, yielding `0x0438` and `0x0440`.
 
-Total: 3 + 3×32 = 99 bits = 13 bytes after flush. This matches, and it is the
-cheapest way to confirm an independent implementation is correct.
+Total: 3 + 3×32 = 99 bits = 13 bytes once the following align pads to the byte
+boundary. This matches, and it is the cheapest way to confirm an independent
+implementation is correct.
+
+The message then aligns and continues with four fixed point fields. The first
+is `serialize_fixed( value, 8, 8, -100, +100 )` — Q8.8, so `raw_min` is
+`-100 << 8 = -25600`, the raw range is `51200`, and the field costs 16 bits.
+The next two bytes of the golden vector are `0xC0 0x60`, which is the offset
+`0x60C0 = 24768`; adding `raw_min` gives a raw value of `-832`, which is
+`-3.25` in Q8.8 — exactly the value the golden message stores.
 
 ## Read-only and write-only forms
 
@@ -275,7 +332,8 @@ differently. This document therefore specifies each operation once, under its
   the bit width and silently desynchronizes everything after it. Range changes
   are breaking changes.
 * **Alignment is part of the format.** `serialize_bytes` and `serialize_string`
-  align; `serialize_bits`, `serialize_int` and `serialize_wstring` do not.
+  align; `serialize_bits`, `serialize_int`, `serialize_fixed`,
+  `serialize_uint128` and `serialize_wstring` do not.
 * **Zero-bit fields are legal.** `min == max` writes nothing at all.
 
 ## Provenance

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -283,7 +283,7 @@ truncating**.
 ## Worked Example
 
 The library's golden test serializes a fixed message and asserts an exact
-86-byte output. One field is a wide string in a `wchar_t[8]` buffer
+112-byte output. One field is a wide string in a `wchar_t[8]` buffer
 containing three characters — `0x043C`, `0x0438`, `0x0440` — and it produces
 this 13-byte run:
 
@@ -310,6 +310,14 @@ is `serialize_fixed( value, 8, 8, -100, +100 )` — Q8.8, so `raw_min` is
 The next two bytes of the golden vector are `0xC0 0x60`, which is the offset
 `0x60C0 = 24768`; adding `raw_min` gives a raw value of `-832`, which is
 `-3.25` in Q8.8 — exactly the value the golden message stores.
+
+After another align the message ends with two wide fixed point fields that
+make the multi-group split load-bearing: a Q112.16 field over ±2^57 whole
+units (75 bits — two full 32-bit groups from the bottom, then the 11-bit
+remainder on top), and a Q64.64 field over the full int64 unit range (128
+bits — four 32-bit groups). A decoder that assembles the groups in the wrong
+order, or puts the remainder anywhere but the most significant position,
+decodes the wrong values here.
 
 ## Read-only and write-only forms
 

--- a/example.cpp
+++ b/example.cpp
@@ -292,6 +292,31 @@ struct PacketD
     }
 };
 
+struct PacketF
+{
+    int64_t position_x;                     // Q48.16 fixed point world position, in ±8192 whole units
+    int64_t position_y;
+    int64_t position_z;
+    int32_t health;                         // Q16.16 fixed point health, in [0,100] whole units
+#if defined(__SIZEOF_INT128__)
+    serialize::uint128_t entity_id;         // 128 bit globally unique entity id
+    serialize::int128_t galactic_x;         // Q112.16 wide fixed point coordinate, in ±10^11 whole units
+#endif // #if defined(__SIZEOF_INT128__)
+
+    template <typename Stream> bool Serialize( Stream & stream )
+    {
+        serialize_fixed( stream, position_x, 48, 16, -8192, +8192 );
+        serialize_fixed( stream, position_y, 48, 16, -8192, +8192 );
+        serialize_fixed( stream, position_z, 48, 16, -8192, +8192 );
+        serialize_fixed( stream, health, 16, 16, 0, 100 );
+#if defined(__SIZEOF_INT128__)
+        serialize_uint128( stream, entity_id );
+        serialize_fixed( stream, galactic_x, 112, 16, -100000000000LL, +100000000000LL );
+#endif // #if defined(__SIZEOF_INT128__)
+        return true;
+    }
+};
+
 struct PacketE
 {
     bool i,j,k;

--- a/example.cpp
+++ b/example.cpp
@@ -298,10 +298,8 @@ struct PacketF
     int64_t position_y;
     int64_t position_z;
     int32_t health;                         // Q16.16 fixed point health, in [0,100] whole units
-#if defined(__SIZEOF_INT128__)
-    serialize::uint128_t entity_id;         // 128 bit globally unique entity id
-    serialize::int128_t galactic_x;         // Q112.16 wide fixed point coordinate, in ±10^11 whole units
-#endif // #if defined(__SIZEOF_INT128__)
+    serialize::uint128_t entity_id;         // 128 bit globally unique entity id. serialize::uint128_t exists on every platform
+    serialize::int128_t galactic_x;         // Q112.16 wide fixed point coordinate, in ±10^11 whole units. also on every platform: native __int128 or the emulated type
 
     template <typename Stream> bool Serialize( Stream & stream )
     {
@@ -309,10 +307,8 @@ struct PacketF
         serialize_fixed( stream, position_y, 48, 16, -8192, +8192 );
         serialize_fixed( stream, position_z, 48, 16, -8192, +8192 );
         serialize_fixed( stream, health, 16, 16, 0, 100 );
-#if defined(__SIZEOF_INT128__)
         serialize_uint128( stream, entity_id );
         serialize_fixed( stream, galactic_x, 112, 16, -100000000000LL, +100000000000LL );
-#endif // #if defined(__SIZEOF_INT128__)
         return true;
     }
 };
@@ -350,6 +346,7 @@ struct Packet
         PacketC c;
         PacketD d;
         PacketE e;
+        PacketF f;
     };
 
     template <typename Stream> bool Serialize( Stream & stream )
@@ -384,6 +381,12 @@ struct Packet
             case E:
             {
                 serialize_object( stream, e );
+            }
+            break;
+
+            case F:
+            {
+                serialize_object( stream, f );
             }
             break;
         }
@@ -564,6 +567,28 @@ int main()
                 }
             }
             break;
+
+            case F:
+            {
+                // random raw Q48.16 values across the full ±8192 whole unit range, fraction bits included
+                const int64_t position_min = int64_t( -8192 ) * 65536;
+                const uint64_t position_range = uint64_t( 16384 ) * 65536;
+                input.f.position_x = position_min + int64_t( ( ( uint64_t( rand() ) << 32 ) | uint64_t( rand() ) ) % ( position_range + 1 ) );
+                input.f.position_y = position_min + int64_t( ( ( uint64_t( rand() ) << 32 ) | uint64_t( rand() ) ) % ( position_range + 1 ) );
+                input.f.position_z = position_min + int64_t( ( ( uint64_t( rand() ) << 32 ) | uint64_t( rand() ) ) % ( position_range + 1 ) );
+
+                input.f.health = int32_t( ( ( uint64_t( rand() ) << 32 ) | uint64_t( rand() ) ) % ( 100 * 65536 + 1 ) );
+
+                input.f.entity_id = ( serialize::uint128_t( ( uint64_t( rand() ) << 32 ) | uint64_t( rand() ) ) << 64 )
+                                  | serialize::uint128_t( ( uint64_t( rand() ) << 32 ) | uint64_t( rand() ) );
+
+                const serialize::int128_t galactic_min = serialize::int128_t( -100000000000LL ) * serialize::int128_t( 65536 );
+                const serialize::uint128_t galactic_range = serialize::uint128_t( 200000000000ULL ) * serialize::uint128_t( 65536 );
+                const serialize::uint128_t galactic_random = ( serialize::uint128_t( ( uint64_t( rand() ) << 32 ) | uint64_t( rand() ) ) << 64 )
+                                                           | serialize::uint128_t( ( uint64_t( rand() ) << 32 ) | uint64_t( rand() ) );
+                input.f.galactic_x = galactic_min + serialize::int128_t( galactic_random % ( galactic_range + serialize::uint128_t( 1 ) ) );
+            }
+            break;
         }
 
         uint8_t buffer[100*1024];
@@ -592,6 +617,7 @@ int main()
         if ( input.packetType == B )
         {
             // compressed floats are quantized, so compare with a tolerance of the resolution
+            // (contrast packet f: fixed point round trips are exact, so it takes the memcmp path below with no carve out)
             if ( fabs( input.b.x - output.b.x ) > 0.001f ||
                  fabs( input.b.y - output.b.y ) > 0.001f ||
                  fabs( input.b.z - output.b.z ) > 0.001f )

--- a/fuzz.cpp
+++ b/fuzz.cpp
@@ -132,6 +132,23 @@ template <typename Stream> bool FuzzRead( Stream & stream, const uint8_t * ops, 
                 int64_t ranged64 = 0;
                 serialize_int64( stream, ranged64, -bound, +bound );
                 fuzz_check( ranged64 >= -bound && ranged64 <= +bound );
+
+                // fixed point: bounds are compile time, so the configurations are fixed. values read
+                // off hostile bytes must decode within the raw bounds or fail the read.
+                int32_t fixed32 = 0;
+                serialize_fixed( stream, fixed32, 16, 16, -1000, +1000 );
+                fuzz_check( fixed32 >= -1000 * 65536 && fixed32 <= 1000 * 65536 );
+
+                int64_t fixed64 = 0;
+                serialize_fixed( stream, fixed64, 48, 16, -100000000000LL, +100000000000LL );
+                fuzz_check( fixed64 >= -100000000000LL * 65536 && fixed64 <= 100000000000LL * 65536 );
+
+#if defined(__SIZEOF_INT128__)
+                serialize::int128_t wide = 0;
+                serialize_fixed( stream, wide, 112, 16, -1152921504606846976LL, +1152921504606846976LL );        // ±2^60 units: a raw range past 64 bits
+                fuzz_check( wide >= serialize::int128_t( -1152921504606846976LL ) * 65536 );
+                fuzz_check( wide <= serialize::int128_t( +1152921504606846976LL ) * 65536 );
+#endif // #if defined(__SIZEOF_INT128__)
             }
             break;
 
@@ -167,6 +184,10 @@ template <typename Stream> bool FuzzRead( Stream & stream, const uint8_t * ops, 
             {
                 uint64_t value = 0;
                 serialize_uint64( stream, value );
+#if defined(__SIZEOF_INT128__)
+                serialize::uint128_t value128 = 0;
+                serialize_uint128( stream, value128 );
+#endif // #if defined(__SIZEOF_INT128__)
             }
             break;
 
@@ -297,6 +318,42 @@ template <typename Stream> bool FuzzRoundTrip( Stream & stream, const uint8_t * 
                 {
                     fuzz_check( ranged64 == expected_ranged );
                 }
+
+                // fixed point: raw values generated uniformly inside the raw bounds must round trip exactly
+                const uint32_t fixed32_range = 2000U * 65536;                   // bounds [-1000,+1000] whole units in Q16.16
+                const int32_t expected_fixed32 = int32_t( uint32_t( -1000 * 65536 ) + pool.NextUint32() % ( fixed32_range + 1 ) );
+                int32_t fixed32 = Stream::IsWriting ? expected_fixed32 : 0;
+                serialize_fixed( stream, fixed32, 16, 16, -1000, +1000 );
+                if ( Stream::IsReading )
+                {
+                    fuzz_check( fixed32 == expected_fixed32 );
+                }
+
+                const uint64_t fixed64_range = uint64_t( 200000000000ULL ) * 65536;     // bounds [-1e11,+1e11] whole units in Q48.16
+                const int64_t expected_fixed64 = int64_t( uint64_t( -100000000000LL * 65536 ) + pool.NextUint64() % ( fixed64_range + 1 ) );
+                int64_t fixed64 = Stream::IsWriting ? expected_fixed64 : 0;
+                serialize_fixed( stream, fixed64, 48, 16, -100000000000LL, +100000000000LL );
+                if ( Stream::IsReading )
+                {
+                    fuzz_check( fixed64 == expected_fixed64 );
+                }
+
+#if defined(__SIZEOF_INT128__)
+                // wide fixed point: bounds ±2^60 whole units in Q112.16 give a raw range of 2^77,
+                // exercising the multi group path with values that cannot fit in 64 bits
+                const serialize::uint128_t wide_range = serialize::uint128_t( 1152921504606846976ULL ) << 17;    // ( 2 * 2^60 ) << 16
+                const uint64_t wide_pool_high = pool.NextUint64();
+                const uint64_t wide_pool_low = pool.NextUint64();
+                const serialize::uint128_t wide_pool = ( serialize::uint128_t( wide_pool_high ) << 64 ) | wide_pool_low;
+                const serialize::uint128_t wide_raw_min = serialize::uint128_t( serialize::int128_t( -1152921504606846976LL ) ) << 16;
+                const serialize::int128_t expected_wide = serialize::int128_t( wide_raw_min + wide_pool % ( wide_range + 1 ) );
+                serialize::int128_t wide = Stream::IsWriting ? expected_wide : serialize::int128_t( 0 );
+                serialize_fixed( stream, wide, 112, 16, -1152921504606846976LL, +1152921504606846976LL );
+                if ( Stream::IsReading )
+                {
+                    fuzz_check( wide == expected_wide );
+                }
+#endif // #if defined(__SIZEOF_INT128__)
             }
             break;
 
@@ -379,6 +436,18 @@ template <typename Stream> bool FuzzRoundTrip( Stream & stream, const uint8_t * 
                 {
                     fuzz_check( value == expected );
                 }
+
+#if defined(__SIZEOF_INT128__)
+                const uint64_t expected128_high = pool.NextUint64();
+                const uint64_t expected128_low = pool.NextUint64();
+                const serialize::uint128_t expected128 = ( serialize::uint128_t( expected128_high ) << 64 ) | expected128_low;
+                serialize::uint128_t value128 = Stream::IsWriting ? expected128 : serialize::uint128_t( 0 );
+                serialize_uint128( stream, value128 );
+                if ( Stream::IsReading )
+                {
+                    fuzz_check( value128 == expected128 );
+                }
+#endif // #if defined(__SIZEOF_INT128__)
             }
             break;
 

--- a/fuzz.cpp
+++ b/fuzz.cpp
@@ -147,6 +147,17 @@ template <typename Stream> bool FuzzRead( Stream & stream, const uint8_t * ops, 
                 serialize_fixed( stream, wide, 112, 16, -1152921504606846976LL, +1152921504606846976LL );        // ±2^60 units: a raw range past 64 bits
                 fuzz_check( wide >= serialize::int128_t( -1152921504606846976LL ) * serialize::int128_t( 65536 ) );
                 fuzz_check( wide <= serialize::int128_t( +1152921504606846976LL ) * serialize::int128_t( 65536 ) );
+
+                // ranged 128 bit integers, with the bound width varying by param so the run walks
+                // every group structure: one group, two, three and four. hostile bytes must decode
+                // inside the bounds or fail the read — never clamp, never wrap.
+                const serialize::int128_t bound128 = serialize::int128_t( 1 ) << ( 20 + ( param % 100 ) );
+                serialize::int128_t ranged128 = 0;
+                serialize_int128( stream, ranged128, -bound128, +bound128 );
+                fuzz_check( ranged128 >= -bound128 && ranged128 <= +bound128 );
+
+                serialize::int128_t full128 = 0;
+                serialize_int128( stream, full128, serialize::int128_t( serialize::uint128_t( 1 ) << 127 ), serialize::int128_t( ~( serialize::uint128_t( 1 ) << 127 ) ) );
             }
             break;
 

--- a/fuzz.cpp
+++ b/fuzz.cpp
@@ -143,12 +143,10 @@ template <typename Stream> bool FuzzRead( Stream & stream, const uint8_t * ops, 
                 serialize_fixed( stream, fixed64, 48, 16, -100000000000LL, +100000000000LL );
                 fuzz_check( fixed64 >= -100000000000LL * 65536 && fixed64 <= 100000000000LL * 65536 );
 
-#if defined(__SIZEOF_INT128__)
-                serialize::int128_t wide = 0;
+                serialize::int128_t wide = 0;                                   // exists on every platform: native or emulated
                 serialize_fixed( stream, wide, 112, 16, -1152921504606846976LL, +1152921504606846976LL );        // ±2^60 units: a raw range past 64 bits
-                fuzz_check( wide >= serialize::int128_t( -1152921504606846976LL ) * 65536 );
-                fuzz_check( wide <= serialize::int128_t( +1152921504606846976LL ) * 65536 );
-#endif // #if defined(__SIZEOF_INT128__)
+                fuzz_check( wide >= serialize::int128_t( -1152921504606846976LL ) * serialize::int128_t( 65536 ) );
+                fuzz_check( wide <= serialize::int128_t( +1152921504606846976LL ) * serialize::int128_t( 65536 ) );
             }
             break;
 
@@ -184,10 +182,8 @@ template <typename Stream> bool FuzzRead( Stream & stream, const uint8_t * ops, 
             {
                 uint64_t value = 0;
                 serialize_uint64( stream, value );
-#if defined(__SIZEOF_INT128__)
-                serialize::uint128_t value128 = 0;
+                serialize::uint128_t value128 = 0;                      // exists on every platform: native or emulated
                 serialize_uint128( stream, value128 );
-#endif // #if defined(__SIZEOF_INT128__)
             }
             break;
 
@@ -338,22 +334,21 @@ template <typename Stream> bool FuzzRoundTrip( Stream & stream, const uint8_t * 
                     fuzz_check( fixed64 == expected_fixed64 );
                 }
 
-#if defined(__SIZEOF_INT128__)
                 // wide fixed point: bounds ±2^60 whole units in Q112.16 give a raw range of 2^77,
-                // exercising the multi group path with values that cannot fit in 64 bits
+                // exercising the multi group path with values that cannot fit in 64 bits. the wide
+                // types exist on every platform: native __int128 or the emulated pair.
                 const serialize::uint128_t wide_range = serialize::uint128_t( 1152921504606846976ULL ) << 17;    // ( 2 * 2^60 ) << 16
                 const uint64_t wide_pool_high = pool.NextUint64();
                 const uint64_t wide_pool_low = pool.NextUint64();
                 const serialize::uint128_t wide_pool = ( serialize::uint128_t( wide_pool_high ) << 64 ) | wide_pool_low;
                 const serialize::uint128_t wide_raw_min = serialize::uint128_t( serialize::int128_t( -1152921504606846976LL ) ) << 16;
-                const serialize::int128_t expected_wide = serialize::int128_t( wide_raw_min + wide_pool % ( wide_range + 1 ) );
+                const serialize::int128_t expected_wide = serialize::int128_t( wide_raw_min + wide_pool % ( wide_range + serialize::uint128_t( 1 ) ) );
                 serialize::int128_t wide = Stream::IsWriting ? expected_wide : serialize::int128_t( 0 );
                 serialize_fixed( stream, wide, 112, 16, -1152921504606846976LL, +1152921504606846976LL );
                 if ( Stream::IsReading )
                 {
                     fuzz_check( wide == expected_wide );
                 }
-#endif // #if defined(__SIZEOF_INT128__)
             }
             break;
 
@@ -437,7 +432,6 @@ template <typename Stream> bool FuzzRoundTrip( Stream & stream, const uint8_t * 
                     fuzz_check( value == expected );
                 }
 
-#if defined(__SIZEOF_INT128__)
                 const uint64_t expected128_high = pool.NextUint64();
                 const uint64_t expected128_low = pool.NextUint64();
                 const serialize::uint128_t expected128 = ( serialize::uint128_t( expected128_high ) << 64 ) | expected128_low;
@@ -447,7 +441,6 @@ template <typename Stream> bool FuzzRoundTrip( Stream & stream, const uint8_t * 
                 {
                     fuzz_check( value128 == expected128 );
                 }
-#endif // #if defined(__SIZEOF_INT128__)
             }
             break;
 

--- a/serialize.h
+++ b/serialize.h
@@ -141,15 +141,15 @@
 // serialize::uint128_t and serialize::int128_t exist on every platform. Where the compiler
 // provides native __int128 (gcc, clang, clang-cl) they are unsigned __int128 and __int128: the
 // fastest representation. On compilers without it (pure MSVC), serialize defines the emulated
-// pair below — mas_uint128_t and mas_int128_t, full 128 bit integer types with standard
-// semantics — and announces them with the MAS_UINT128_DEFINED handshake macro. The two structs
+// pair below — serialize_uint128_t and serialize_int128_t, full 128 bit integer types with standard
+// semantics — and announces them with the SERIALIZE_UINT128_DEFINED handshake macro. The two structs
 // are one facility: one announce macro covers the pair, and copies are carried whole, never
 // just one half.
 //
 // THE SHARING CONVENTION: single header libraries cannot include each other, so this definition
 // block is carried, verbatim, by sibling projects under the same handshake (the fixed point
 // library, and games built on these libraries). Whichever header is included first defines the
-// pair; everyone after sees MAS_UINT128_DEFINED and aliases them, so the types are defined
+// pair; everyone after sees SERIALIZE_UINT128_DEFINED and aliases them, so the types are defined
 // exactly once per translation unit instead of two or three times. The copies exist by design;
 // the handshake makes them mutually exclusive per translation unit, and the differential tests
 // against native __int128 in each C++ home are what keep every copy honest — drift fails loudly.
@@ -161,25 +161,34 @@
 //
 // Semantics match native __int128 exactly, with documented choices where native has none:
 // shift counts outside [0,127] yield zero (all sign bits for the signed arithmetic right
-// shift; native shifts by 128 or more are undefined behavior), division or modulo by zero
-// yields zero quotient and zero remainder (this block has no assert dependency by design, and
-// deterministic zero is the safest portable behavior), and signed INT128_MIN over -1 wraps to
-// INT128_MIN, the bit pattern native hardware produces.
+// shift; native shifts by 128 or more are undefined behavior), and signed INT128_MIN over -1
+// wraps to INT128_MIN, the bit pattern native hardware produces.
+//
+// DIVISION OR MODULO BY ZERO IS UNDEFINED. Do not do it. It is undefined for native
+// __int128 too — C++ says so, and the hardware disagrees with itself: measured, arm64
+// returns zero for x / 0 but returns the DIVIDEND for x % 0, while x86-64 IDIV/DIV raises a
+// hardware exception and terminates. There is therefore no portable behavior available to
+// match, and any value this block returned would be a divergence from somewhere.
+// What the block guarantees is only that it is TOTAL — it returns zero quotient and zero
+// remainder rather than trapping, so a caller's mistake cannot crash a process and the block
+// keeps its no-assert-dependency design. That is an implementation detail, not a contract:
+// callers may not rely on it, and the differential test against native deliberately excludes
+// zero divisors, because agreement there is not a property either side can promise.
 //
 // When tests are enabled the pair is defined even where native __int128 exists, so the test
 // suite can prove the emulation agrees with native operator by operator and produces byte
 // identical wire.
 
-#if !defined( MAS_UINT128_DEFINED ) && ( !defined( __SIZEOF_INT128__ ) || SERIALIZE_ENABLE_TESTS )
+#if !defined( SERIALIZE_UINT128_DEFINED ) && ( !defined( __SIZEOF_INT128__ ) || SERIALIZE_ENABLE_TESTS )
 
-typedef struct mas_uint128_t
+typedef struct serialize_uint128_t
 {
     uint64_t lo;            ///< the low 64 bits. first, matching the little endian layout and the wire order
     uint64_t hi;            ///< the high 64 bits
 
 #ifdef __cplusplus
 
-    mas_uint128_t() = default;
+    serialize_uint128_t() = default;
 
     // construction mirrors native conversion to unsigned __int128 exactly: unsigned sources zero
     // extend, signed sources sign extend (a negative value wraps modulo 2^128, so the high lane
@@ -187,85 +196,85 @@ typedef struct mas_uint128_t
     // after integer promotion — a lone uint64_t constructor would zero extend negative int64
     // values where native sign extends, silently diverging the wire between representations.
 
-    mas_uint128_t( int value )                : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
-    mas_uint128_t( long value )               : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
-    mas_uint128_t( long long value )          : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
-    mas_uint128_t( unsigned int value )       : lo( value ), hi( 0 ) {}
-    mas_uint128_t( unsigned long value )      : lo( value ), hi( 0 ) {}
-    mas_uint128_t( unsigned long long value ) : lo( value ), hi( 0 ) {}
+    serialize_uint128_t( int value )                : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_uint128_t( long value )               : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_uint128_t( long long value )          : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_uint128_t( unsigned int value )       : lo( value ), hi( 0 ) {}
+    serialize_uint128_t( unsigned long value )      : lo( value ), hi( 0 ) {}
+    serialize_uint128_t( unsigned long long value ) : lo( value ), hi( 0 ) {}
 
     explicit operator uint64_t () const
     {
         return lo;
     }
 
-    bool operator == ( mas_uint128_t other ) const
+    bool operator == ( serialize_uint128_t other ) const
     {
         return lo == other.lo && hi == other.hi;
     }
 
-    bool operator != ( mas_uint128_t other ) const
+    bool operator != ( serialize_uint128_t other ) const
     {
         return ! ( *this == other );
     }
 
-    bool operator < ( mas_uint128_t other ) const
+    bool operator < ( serialize_uint128_t other ) const
     {
         return ( hi != other.hi ) ? ( hi < other.hi ) : ( lo < other.lo );
     }
 
-    bool operator > ( mas_uint128_t other ) const
+    bool operator > ( serialize_uint128_t other ) const
     {
         return other < *this;
     }
 
-    bool operator <= ( mas_uint128_t other ) const
+    bool operator <= ( serialize_uint128_t other ) const
     {
         return ! ( other < *this );
     }
 
-    bool operator >= ( mas_uint128_t other ) const
+    bool operator >= ( serialize_uint128_t other ) const
     {
         return ! ( *this < other );
     }
 
-    mas_uint128_t operator ~ () const
+    serialize_uint128_t operator ~ () const
     {
-        mas_uint128_t result( 0 );
+        serialize_uint128_t result( 0 );
         result.lo = ~lo;
         result.hi = ~hi;
         return result;
     }
 
-    mas_uint128_t operator & ( mas_uint128_t other ) const
+    serialize_uint128_t operator & ( serialize_uint128_t other ) const
     {
-        mas_uint128_t result( 0 );
+        serialize_uint128_t result( 0 );
         result.lo = lo & other.lo;
         result.hi = hi & other.hi;
         return result;
     }
 
-    mas_uint128_t operator | ( mas_uint128_t other ) const
+    serialize_uint128_t operator | ( serialize_uint128_t other ) const
     {
-        mas_uint128_t result( 0 );
+        serialize_uint128_t result( 0 );
         result.lo = lo | other.lo;
         result.hi = hi | other.hi;
         return result;
     }
 
-    mas_uint128_t operator ^ ( mas_uint128_t other ) const
+    serialize_uint128_t operator ^ ( serialize_uint128_t other ) const
     {
-        mas_uint128_t result( 0 );
+        serialize_uint128_t result( 0 );
         result.lo = lo ^ other.lo;
         result.hi = hi ^ other.hi;
         return result;
     }
 
-    mas_uint128_t operator << ( int shift ) const
+    serialize_uint128_t operator << ( int shift ) const
     {
         // shifting a uint64 lane by 64 is undefined behavior, so the half boundary is an explicit
         // branch. shift counts outside [0,127] yield zero, documented above.
-        mas_uint128_t result( 0 );
+        serialize_uint128_t result( 0 );
         if ( shift == 0 )
         {
             result = *this;
@@ -283,11 +292,11 @@ typedef struct mas_uint128_t
         return result;
     }
 
-    mas_uint128_t operator >> ( int shift ) const
+    serialize_uint128_t operator >> ( int shift ) const
     {
         // shifting a uint64 lane by 64 is undefined behavior, so the half boundary is an explicit
         // branch. shift counts outside [0,127] yield zero, documented above.
-        mas_uint128_t result( 0 );
+        serialize_uint128_t result( 0 );
         if ( shift == 0 )
         {
             result = *this;
@@ -305,23 +314,23 @@ typedef struct mas_uint128_t
         return result;
     }
 
-    mas_uint128_t operator + ( mas_uint128_t other ) const
+    serialize_uint128_t operator + ( serialize_uint128_t other ) const
     {
-        mas_uint128_t result( 0 );
+        serialize_uint128_t result( 0 );
         result.lo = lo + other.lo;
         result.hi = hi + other.hi + ( ( result.lo < lo ) ? 1 : 0 );         // carry out of the low lane
         return result;
     }
 
-    mas_uint128_t operator - ( mas_uint128_t other ) const
+    serialize_uint128_t operator - ( serialize_uint128_t other ) const
     {
-        mas_uint128_t result( 0 );
+        serialize_uint128_t result( 0 );
         result.lo = lo - other.lo;
         result.hi = hi - other.hi - ( ( lo < other.lo ) ? 1 : 0 );          // borrow out of the low lane
         return result;
     }
 
-    mas_uint128_t operator * ( mas_uint128_t other ) const
+    serialize_uint128_t operator * ( serialize_uint128_t other ) const
     {
         // schoolbook multiplication in 32 bit limbs over the uint64 lanes: the low 64 x 64 product
         // is computed exactly, then the cross products fold into the high lane modulo 2^64
@@ -337,27 +346,28 @@ typedef struct mas_uint128_t
 
         const uint64_t carry = ( ( product_ll >> 32 ) + ( product_lh & 0xFFFFFFFFULL ) + ( product_hl & 0xFFFFFFFFULL ) ) >> 32;
 
-        mas_uint128_t result( 0 );
+        serialize_uint128_t result( 0 );
         result.lo = product_ll + ( product_lh << 32 ) + ( product_hl << 32 );
         result.hi = product_hh + ( product_lh >> 32 ) + ( product_hl >> 32 ) + carry;
         result.hi += lo * other.hi + hi * other.lo;
         return result;
     }
 
-    static void DivMod( mas_uint128_t dividend, mas_uint128_t divisor, mas_uint128_t & quotient, mas_uint128_t & remainder )
+    static void DivMod( serialize_uint128_t dividend, serialize_uint128_t divisor, serialize_uint128_t & quotient, serialize_uint128_t & remainder )
     {
-        // shift subtract long division. division by zero yields zero quotient and zero remainder,
-        // documented above: this block has no assert dependency by design.
-        quotient = mas_uint128_t( 0 );
-        remainder = mas_uint128_t( 0 );
-        if ( divisor == mas_uint128_t( 0 ) )
+        // shift subtract long division. division by zero is UNDEFINED (documented above) — this
+        // returns zero quotient and zero remainder only to stay TOTAL, since the block has no
+        // assert dependency by design. Not a contract; callers may not rely on the value.
+        quotient = serialize_uint128_t( 0 );
+        remainder = serialize_uint128_t( 0 );
+        if ( divisor == serialize_uint128_t( 0 ) )
         {
             return;
         }
         if ( dividend.hi == 0 && divisor.hi == 0 )
         {
-            quotient = mas_uint128_t( dividend.lo / divisor.lo );
-            remainder = mas_uint128_t( dividend.lo % divisor.lo );
+            quotient = serialize_uint128_t( dividend.lo / divisor.lo );
+            remainder = serialize_uint128_t( dividend.lo % divisor.lo );
             return;
         }
         for ( int i = 127; i >= 0; i-- )
@@ -367,77 +377,77 @@ typedef struct mas_uint128_t
             if ( remainder >= divisor )
             {
                 remainder = remainder - divisor;
-                quotient = quotient | ( mas_uint128_t( 1 ) << i );
+                quotient = quotient | ( serialize_uint128_t( 1 ) << i );
             }
         }
     }
 
-    mas_uint128_t operator / ( mas_uint128_t other ) const
+    serialize_uint128_t operator / ( serialize_uint128_t other ) const
     {
-        mas_uint128_t quotient( 0 );
-        mas_uint128_t remainder( 0 );
+        serialize_uint128_t quotient( 0 );
+        serialize_uint128_t remainder( 0 );
         DivMod( *this, other, quotient, remainder );
         return quotient;
     }
 
-    mas_uint128_t operator % ( mas_uint128_t other ) const
+    serialize_uint128_t operator % ( serialize_uint128_t other ) const
     {
-        mas_uint128_t quotient( 0 );
-        mas_uint128_t remainder( 0 );
+        serialize_uint128_t quotient( 0 );
+        serialize_uint128_t remainder( 0 );
         DivMod( *this, other, quotient, remainder );
         return remainder;
     }
 
-    mas_uint128_t operator + () const
+    serialize_uint128_t operator + () const
     {
         return *this;
     }
 
-    mas_uint128_t operator - () const
+    serialize_uint128_t operator - () const
     {
-        return mas_uint128_t( 0 ) - *this;
+        return serialize_uint128_t( 0 ) - *this;
     }
 
-    mas_uint128_t & operator += ( mas_uint128_t other ) { *this = *this + other; return *this; }
-    mas_uint128_t & operator -= ( mas_uint128_t other ) { *this = *this - other; return *this; }
-    mas_uint128_t & operator *= ( mas_uint128_t other ) { *this = *this * other; return *this; }
-    mas_uint128_t & operator /= ( mas_uint128_t other ) { *this = *this / other; return *this; }
-    mas_uint128_t & operator %= ( mas_uint128_t other ) { *this = *this % other; return *this; }
-    mas_uint128_t & operator &= ( mas_uint128_t other ) { *this = *this & other; return *this; }
-    mas_uint128_t & operator |= ( mas_uint128_t other ) { *this = *this | other; return *this; }
-    mas_uint128_t & operator ^= ( mas_uint128_t other ) { *this = *this ^ other; return *this; }
-    mas_uint128_t & operator <<= ( int shift )          { *this = *this << shift; return *this; }
-    mas_uint128_t & operator >>= ( int shift )          { *this = *this >> shift; return *this; }
+    serialize_uint128_t & operator += ( serialize_uint128_t other ) { *this = *this + other; return *this; }
+    serialize_uint128_t & operator -= ( serialize_uint128_t other ) { *this = *this - other; return *this; }
+    serialize_uint128_t & operator *= ( serialize_uint128_t other ) { *this = *this * other; return *this; }
+    serialize_uint128_t & operator /= ( serialize_uint128_t other ) { *this = *this / other; return *this; }
+    serialize_uint128_t & operator %= ( serialize_uint128_t other ) { *this = *this % other; return *this; }
+    serialize_uint128_t & operator &= ( serialize_uint128_t other ) { *this = *this & other; return *this; }
+    serialize_uint128_t & operator |= ( serialize_uint128_t other ) { *this = *this | other; return *this; }
+    serialize_uint128_t & operator ^= ( serialize_uint128_t other ) { *this = *this ^ other; return *this; }
+    serialize_uint128_t & operator <<= ( int shift )          { *this = *this << shift; return *this; }
+    serialize_uint128_t & operator >>= ( int shift )          { *this = *this >> shift; return *this; }
 
-    mas_uint128_t & operator ++ ()
+    serialize_uint128_t & operator ++ ()
     {
-        *this = *this + mas_uint128_t( 1 );
+        *this = *this + serialize_uint128_t( 1 );
         return *this;
     }
 
-    mas_uint128_t operator ++ ( int )
+    serialize_uint128_t operator ++ ( int )
     {
-        mas_uint128_t before = *this;
+        serialize_uint128_t before = *this;
         ++( *this );
         return before;
     }
 
-    mas_uint128_t & operator -- ()
+    serialize_uint128_t & operator -- ()
     {
-        *this = *this - mas_uint128_t( 1 );
+        *this = *this - serialize_uint128_t( 1 );
         return *this;
     }
 
-    mas_uint128_t operator -- ( int )
+    serialize_uint128_t operator -- ( int )
     {
-        mas_uint128_t before = *this;
+        serialize_uint128_t before = *this;
         --( *this );
         return before;
     }
 
 #endif // #ifdef __cplusplus
 
-} mas_uint128_t;
+} serialize_uint128_t;
 
 /**
     The emulated signed 128 bit integer: a thin two's complement layer over the unsigned lanes.
@@ -449,24 +459,26 @@ typedef struct mas_uint128_t
     with the remainder sign following the dividend), unary minus, the sign extending int64_t
     constructor, and the bit preserving conversions to and from the unsigned type.
     Documented choices where native has none: shift counts outside [0,127] yield zero for <<
-    and all sign bits for >> (the limit of shifting further); division or modulo by zero yields
-    zero quotient and zero remainder, matching the unsigned type; and the one overflowing
-    division, INT128_MIN over -1, wraps to INT128_MIN quotient and zero remainder — the same bit
-    pattern native two's complement hardware produces.
-    This struct is part of the mas_uint128_t definition block above and is carried with it: the
-    two types are one facility, announced together by the single MAS_UINT128_DEFINED handshake
+    and all sign bits for >> (the limit of shifting further); and the one overflowing division,
+    INT128_MIN over -1, wraps to INT128_MIN quotient and zero remainder — the same bit pattern
+    native two's complement hardware produces.
+    Division or modulo by zero is UNDEFINED, as it is for native __int128 — see the block comment
+    on serialize_uint128_t. This type stays total and returns zero rather than trapping, which is
+    an implementation detail and not a contract.
+    This struct is part of the serialize_uint128_t definition block above and is carried with it: the
+    two types are one facility, announced together by the single SERIALIZE_UINT128_DEFINED handshake
     macro and defined exactly once per translation unit. Copies in sibling projects carry the
     whole pair, never just one half.
  */
 
-typedef struct mas_int128_t
+typedef struct serialize_int128_t
 {
     uint64_t lo;            ///< the low 64 bits. first, matching the little endian layout and the wire order
     uint64_t hi;            ///< the high 64 bits. the top bit is the sign
 
 #ifdef __cplusplus
 
-    mas_int128_t() = default;
+    serialize_int128_t() = default;
 
     // construction mirrors native conversion to __int128 exactly: signed sources sign extend,
     // unsigned sources zero extend (any uint64 is below 2^127, so the conversion is value
@@ -475,18 +487,18 @@ typedef struct mas_int128_t
     // uint64 values negative where native keeps them positive, silently diverging the wire
     // between representations.
 
-    mas_int128_t( int value )                : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
-    mas_int128_t( long value )               : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
-    mas_int128_t( long long value )          : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
-    mas_int128_t( unsigned int value )       : lo( value ), hi( 0 ) {}
-    mas_int128_t( unsigned long value )      : lo( value ), hi( 0 ) {}
-    mas_int128_t( unsigned long long value ) : lo( value ), hi( 0 ) {}
+    serialize_int128_t( int value )                : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_int128_t( long value )               : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_int128_t( long long value )          : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    serialize_int128_t( unsigned int value )       : lo( value ), hi( 0 ) {}
+    serialize_int128_t( unsigned long value )      : lo( value ), hi( 0 ) {}
+    serialize_int128_t( unsigned long long value ) : lo( value ), hi( 0 ) {}
 
-    explicit mas_int128_t( mas_uint128_t value ) : lo( value.lo ), hi( value.hi ) {}        // bit preserving
+    explicit serialize_int128_t( serialize_uint128_t value ) : lo( value.lo ), hi( value.hi ) {}        // bit preserving
 
-    explicit operator mas_uint128_t () const                                                // bit preserving
+    explicit operator serialize_uint128_t () const                                                // bit preserving
     {
-        mas_uint128_t result( 0 );
+        serialize_uint128_t result( 0 );
         result.lo = lo;
         result.hi = hi;
         return result;
@@ -502,17 +514,17 @@ typedef struct mas_int128_t
         return ( hi >> 63 ) != 0;
     }
 
-    bool operator == ( mas_int128_t other ) const
+    bool operator == ( serialize_int128_t other ) const
     {
         return lo == other.lo && hi == other.hi;
     }
 
-    bool operator != ( mas_int128_t other ) const
+    bool operator != ( serialize_int128_t other ) const
     {
         return ! ( *this == other );
     }
 
-    bool operator < ( mas_int128_t other ) const
+    bool operator < ( serialize_int128_t other ) const
     {
         // signed ordering: the high lanes compare signed, the low lanes break ties unsigned
         if ( hi != other.hi )
@@ -522,17 +534,17 @@ typedef struct mas_int128_t
         return lo < other.lo;
     }
 
-    bool operator > ( mas_int128_t other ) const
+    bool operator > ( serialize_int128_t other ) const
     {
         return other < *this;
     }
 
-    bool operator <= ( mas_int128_t other ) const
+    bool operator <= ( serialize_int128_t other ) const
     {
         return ! ( other < *this );
     }
 
-    bool operator >= ( mas_int128_t other ) const
+    bool operator >= ( serialize_int128_t other ) const
     {
         return ! ( *this < other );
     }
@@ -541,125 +553,125 @@ typedef struct mas_int128_t
     // same bit patterns as unsigned, so they delegate to the unsigned type. signed overflow wraps
     // by construction, exactly like the underlying hardware.
 
-    mas_int128_t operator + ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) + mas_uint128_t( other ) ); }
-    mas_int128_t operator - ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) - mas_uint128_t( other ) ); }
-    mas_int128_t operator * ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) * mas_uint128_t( other ) ); }
+    serialize_int128_t operator + ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) + serialize_uint128_t( other ) ); }
+    serialize_int128_t operator - ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) - serialize_uint128_t( other ) ); }
+    serialize_int128_t operator * ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) * serialize_uint128_t( other ) ); }
 
-    mas_int128_t operator ~ () const                     { return mas_int128_t( ~mas_uint128_t( *this ) ); }
-    mas_int128_t operator & ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) & mas_uint128_t( other ) ); }
-    mas_int128_t operator | ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) | mas_uint128_t( other ) ); }
-    mas_int128_t operator ^ ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) ^ mas_uint128_t( other ) ); }
+    serialize_int128_t operator ~ () const                     { return serialize_int128_t( ~serialize_uint128_t( *this ) ); }
+    serialize_int128_t operator & ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) & serialize_uint128_t( other ) ); }
+    serialize_int128_t operator | ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) | serialize_uint128_t( other ) ); }
+    serialize_int128_t operator ^ ( serialize_int128_t other ) const { return serialize_int128_t( serialize_uint128_t( *this ) ^ serialize_uint128_t( other ) ); }
 
-    mas_int128_t operator << ( int shift ) const
+    serialize_int128_t operator << ( int shift ) const
     {
         // a logical shift of the bit pattern, matching what native two's complement hardware does.
         // shift counts outside [0,127] yield zero, matching the unsigned type
-        return mas_int128_t( mas_uint128_t( *this ) << shift );
+        return serialize_int128_t( serialize_uint128_t( *this ) << shift );
     }
 
-    mas_int128_t operator >> ( int shift ) const
+    serialize_int128_t operator >> ( int shift ) const
     {
         // ARITHMETIC shift right: the vacated high bits fill with the sign. shift counts outside
         // [0,127] yield all sign bits — 0 for non negative values, -1 for negative ones — which is
         // the limit of shifting further, documented above
         if ( shift < 0 || shift >= 128 )
         {
-            return IsNegative() ? mas_int128_t( -1 ) : mas_int128_t( 0 );
+            return IsNegative() ? serialize_int128_t( -1 ) : serialize_int128_t( 0 );
         }
-        mas_uint128_t result = mas_uint128_t( *this ) >> shift;
+        serialize_uint128_t result = serialize_uint128_t( *this ) >> shift;
         if ( IsNegative() && shift > 0 )
         {
-            result = result | ( ~mas_uint128_t( 0 ) << ( 128 - shift ) );
+            result = result | ( ~serialize_uint128_t( 0 ) << ( 128 - shift ) );
         }
-        return mas_int128_t( result );
+        return serialize_int128_t( result );
     }
 
-    mas_int128_t operator + () const
+    serialize_int128_t operator + () const
     {
         return *this;
     }
 
-    mas_int128_t operator - () const
+    serialize_int128_t operator - () const
     {
-        return mas_int128_t( -mas_uint128_t( *this ) );                 // two's complement negation. -INT128_MIN wraps to itself, like native
+        return serialize_int128_t( -serialize_uint128_t( *this ) );                 // two's complement negation. -INT128_MIN wraps to itself, like native
     }
 
-    static void DivMod( mas_int128_t dividend, mas_int128_t divisor, mas_int128_t & quotient, mas_int128_t & remainder )
+    static void DivMod( serialize_int128_t dividend, serialize_int128_t divisor, serialize_int128_t & quotient, serialize_int128_t & remainder )
     {
         // sign extraction, unsigned shift subtract division on the magnitudes, then sign
         // application: C++ semantics, truncation toward zero with the remainder sign following
         // the dividend. the documented edge choices live in the comment block above.
         const bool dividend_negative = dividend.IsNegative();
         const bool divisor_negative = divisor.IsNegative();
-        const mas_uint128_t dividend_magnitude = dividend_negative ? -mas_uint128_t( dividend ) : mas_uint128_t( dividend );
-        const mas_uint128_t divisor_magnitude = divisor_negative ? -mas_uint128_t( divisor ) : mas_uint128_t( divisor );
-        mas_uint128_t unsigned_quotient( 0 );
-        mas_uint128_t unsigned_remainder( 0 );
-        mas_uint128_t::DivMod( dividend_magnitude, divisor_magnitude, unsigned_quotient, unsigned_remainder );
-        quotient = mas_int128_t( ( dividend_negative != divisor_negative ) ? -unsigned_quotient : unsigned_quotient );
-        remainder = mas_int128_t( dividend_negative ? -unsigned_remainder : unsigned_remainder );
+        const serialize_uint128_t dividend_magnitude = dividend_negative ? -serialize_uint128_t( dividend ) : serialize_uint128_t( dividend );
+        const serialize_uint128_t divisor_magnitude = divisor_negative ? -serialize_uint128_t( divisor ) : serialize_uint128_t( divisor );
+        serialize_uint128_t unsigned_quotient( 0 );
+        serialize_uint128_t unsigned_remainder( 0 );
+        serialize_uint128_t::DivMod( dividend_magnitude, divisor_magnitude, unsigned_quotient, unsigned_remainder );
+        quotient = serialize_int128_t( ( dividend_negative != divisor_negative ) ? -unsigned_quotient : unsigned_quotient );
+        remainder = serialize_int128_t( dividend_negative ? -unsigned_remainder : unsigned_remainder );
     }
 
-    mas_int128_t operator / ( mas_int128_t other ) const
+    serialize_int128_t operator / ( serialize_int128_t other ) const
     {
-        mas_int128_t quotient( 0 );
-        mas_int128_t remainder( 0 );
+        serialize_int128_t quotient( 0 );
+        serialize_int128_t remainder( 0 );
         DivMod( *this, other, quotient, remainder );
         return quotient;
     }
 
-    mas_int128_t operator % ( mas_int128_t other ) const
+    serialize_int128_t operator % ( serialize_int128_t other ) const
     {
-        mas_int128_t quotient( 0 );
-        mas_int128_t remainder( 0 );
+        serialize_int128_t quotient( 0 );
+        serialize_int128_t remainder( 0 );
         DivMod( *this, other, quotient, remainder );
         return remainder;
     }
 
-    mas_int128_t & operator += ( mas_int128_t other ) { *this = *this + other; return *this; }
-    mas_int128_t & operator -= ( mas_int128_t other ) { *this = *this - other; return *this; }
-    mas_int128_t & operator *= ( mas_int128_t other ) { *this = *this * other; return *this; }
-    mas_int128_t & operator /= ( mas_int128_t other ) { *this = *this / other; return *this; }
-    mas_int128_t & operator %= ( mas_int128_t other ) { *this = *this % other; return *this; }
-    mas_int128_t & operator &= ( mas_int128_t other ) { *this = *this & other; return *this; }
-    mas_int128_t & operator |= ( mas_int128_t other ) { *this = *this | other; return *this; }
-    mas_int128_t & operator ^= ( mas_int128_t other ) { *this = *this ^ other; return *this; }
-    mas_int128_t & operator <<= ( int shift )         { *this = *this << shift; return *this; }
-    mas_int128_t & operator >>= ( int shift )         { *this = *this >> shift; return *this; }
+    serialize_int128_t & operator += ( serialize_int128_t other ) { *this = *this + other; return *this; }
+    serialize_int128_t & operator -= ( serialize_int128_t other ) { *this = *this - other; return *this; }
+    serialize_int128_t & operator *= ( serialize_int128_t other ) { *this = *this * other; return *this; }
+    serialize_int128_t & operator /= ( serialize_int128_t other ) { *this = *this / other; return *this; }
+    serialize_int128_t & operator %= ( serialize_int128_t other ) { *this = *this % other; return *this; }
+    serialize_int128_t & operator &= ( serialize_int128_t other ) { *this = *this & other; return *this; }
+    serialize_int128_t & operator |= ( serialize_int128_t other ) { *this = *this | other; return *this; }
+    serialize_int128_t & operator ^= ( serialize_int128_t other ) { *this = *this ^ other; return *this; }
+    serialize_int128_t & operator <<= ( int shift )         { *this = *this << shift; return *this; }
+    serialize_int128_t & operator >>= ( int shift )         { *this = *this >> shift; return *this; }
 
-    mas_int128_t & operator ++ ()
+    serialize_int128_t & operator ++ ()
     {
-        *this = *this + mas_int128_t( 1 );
+        *this = *this + serialize_int128_t( 1 );
         return *this;
     }
 
-    mas_int128_t operator ++ ( int )
+    serialize_int128_t operator ++ ( int )
     {
-        mas_int128_t before = *this;
+        serialize_int128_t before = *this;
         ++( *this );
         return before;
     }
 
-    mas_int128_t & operator -- ()
+    serialize_int128_t & operator -- ()
     {
-        *this = *this - mas_int128_t( 1 );
+        *this = *this - serialize_int128_t( 1 );
         return *this;
     }
 
-    mas_int128_t operator -- ( int )
+    serialize_int128_t operator -- ( int )
     {
-        mas_int128_t before = *this;
+        serialize_int128_t before = *this;
         --( *this );
         return before;
     }
 
 #endif // #ifdef __cplusplus
 
-} mas_int128_t;
+} serialize_int128_t;
 
-#define MAS_UINT128_DEFINED 1
+#define SERIALIZE_UINT128_DEFINED 1
 
-#endif // #if !defined( MAS_UINT128_DEFINED ) && ( !defined( __SIZEOF_INT128__ ) || SERIALIZE_ENABLE_TESTS )
+#endif // #if !defined( SERIALIZE_UINT128_DEFINED ) && ( !defined( __SIZEOF_INT128__ ) || SERIALIZE_ENABLE_TESTS )
 
 namespace serialize
 {
@@ -677,12 +689,12 @@ namespace serialize
 #else // #if defined(__SIZEOF_INT128__)
 
     /**
-        The 128 bit integer types on compilers without native __int128: the emulated ::mas_uint128_t and ::mas_int128_t pair.
-        See the comment block on mas_uint128_t above for the sharing convention between projects.
+        The 128 bit integer types on compilers without native __int128: the emulated ::serialize_uint128_t and ::serialize_int128_t pair.
+        See the comment block on serialize_uint128_t above for the sharing convention between projects.
      */
 
-    typedef ::mas_int128_t   int128_t;
-    typedef ::mas_uint128_t uint128_t;
+    typedef ::serialize_int128_t   int128_t;
+    typedef ::serialize_uint128_t uint128_t;
 
 #endif // #if defined(__SIZEOF_INT128__)
 
@@ -871,6 +883,29 @@ namespace serialize
         const uint32_t high = uint32_t( diff >> 32 );
         return high ? ( 32 + bits_required( 0, high ) ) : bits_required( 0, uint32_t( diff ) );
 #endif // #ifdef __GNUC__
+    }
+
+    /**
+        Calculates the number of bits required to serialize a 128 bit integer in range [min,max].
+        The subtraction is performed in the unsigned domain, so ranges wider than 2^127 work.
+        Unlike the compile time serialize::BitsRequired128, which needs native __int128 as a non type
+        template parameter, this runs on every platform: the emulated pair supports every operation
+        it uses, so the 128 bit ranged codec works on pure MSVC too.
+        @param min The minimum value.
+        @param max The maximum value.
+        @returns The number of bits required to serialize the integer in [0,128].
+     */
+
+    inline int bits_required128( uint128_t min, uint128_t max )
+    {
+        if ( min == max )
+        {
+            return 0;
+        }
+        // subtract in the unsigned domain: max - min overflows signed arithmetic when the range is wider than 2^127
+        const uint128_t diff = max - min;
+        const uint64_t high = uint64_t( diff >> 64 );
+        return high ? ( 64 + bits_required64( 0, high ) ) : bits_required64( 0, uint64_t( diff ) );
     }
 
     /**
@@ -1519,6 +1554,52 @@ namespace serialize
         }
 
         /**
+            Serialize a 128 bit integer (write).
+            @param value The integer value in [min,max].
+            @param min The minimum value.
+            @param max The maximum value.
+            @returns Always returns true. All checking is performed by debug asserts only on write.
+         */
+
+        bool SerializeInteger128( int128_t value, int128_t min, int128_t max )
+        {
+            serialize_assert( min < max );
+            serialize_assert( value >= min );
+            serialize_assert( value <= max );
+            const int bits = bits_required128( uint128_t(min), uint128_t(max) );
+            // subtract in the unsigned domain: value - min overflows signed arithmetic when the range is wider than 2^127
+            const uint128_t unsigned_value = uint128_t(value) - uint128_t(min);
+            // 32 bit groups, least significant first: the same convention as serialize_bits, serialize_uint64 and the wide fixed point path
+            const uint32_t group0 = uint32_t( uint64_t( unsigned_value       ) & 0xFFFFFFFF );
+            const uint32_t group1 = uint32_t( uint64_t( unsigned_value >> 32 ) & 0xFFFFFFFF );
+            const uint32_t group2 = uint32_t( uint64_t( unsigned_value >> 64 ) & 0xFFFFFFFF );
+            const uint32_t group3 = uint32_t( uint64_t( unsigned_value >> 96 ) & 0xFFFFFFFF );
+            if ( bits <= 32 )
+            {
+                m_writer.WriteBits( group0, bits );
+            }
+            else if ( bits <= 64 )
+            {
+                m_writer.WriteBits( group0, 32 );
+                m_writer.WriteBits( group1, bits - 32 );
+            }
+            else if ( bits <= 96 )
+            {
+                m_writer.WriteBits( group0, 32 );
+                m_writer.WriteBits( group1, 32 );
+                m_writer.WriteBits( group2, bits - 64 );
+            }
+            else
+            {
+                m_writer.WriteBits( group0, 32 );
+                m_writer.WriteBits( group1, 32 );
+                m_writer.WriteBits( group2, 32 );
+                m_writer.WriteBits( group3, bits - 96 );
+            }
+            return true;
+        }
+
+        /**
             Serialize a number of bits (write).
             @param value The unsigned integer value to serialize. Must be in range [0,(1<<bits)-1].
             @param bits The number of bits to write in [1,32].
@@ -1707,6 +1788,55 @@ namespace serialize
         }
 
         /**
+            Serialize a 128 bit integer (read).
+            @param value The integer value read is stored here. It is guaranteed to be in [min,max] if this function succeeds.
+            @param min The minimum allowed value.
+            @param max The maximum allowed value.
+            @returns Returns true if the serialize succeeded and the value is in the correct range. False otherwise.
+         */
+
+        bool SerializeInteger128( int128_t & value, int128_t min, int128_t max )
+        {
+            serialize_assert( min < max );
+            const int bits = bits_required128( uint128_t(min), uint128_t(max) );
+            if ( m_reader.WouldReadPastEnd( bits ) )
+                return false;
+            // 32 bit groups, least significant first: the same convention as the write path
+            uint32_t group0 = 0;
+            uint32_t group1 = 0;
+            uint32_t group2 = 0;
+            uint32_t group3 = 0;
+            if ( bits <= 32 )
+            {
+                group0 = m_reader.ReadBits( bits );
+            }
+            else if ( bits <= 64 )
+            {
+                group0 = m_reader.ReadBits( 32 );
+                group1 = m_reader.ReadBits( bits - 32 );
+            }
+            else if ( bits <= 96 )
+            {
+                group0 = m_reader.ReadBits( 32 );
+                group1 = m_reader.ReadBits( 32 );
+                group2 = m_reader.ReadBits( bits - 64 );
+            }
+            else
+            {
+                group0 = m_reader.ReadBits( 32 );
+                group1 = m_reader.ReadBits( 32 );
+                group2 = m_reader.ReadBits( 32 );
+                group3 = m_reader.ReadBits( bits - 96 );
+            }
+            const uint128_t unsigned_value = ( uint128_t( group3 ) << 96 ) | ( uint128_t( group2 ) << 64 ) | ( uint128_t( group1 ) << 32 ) | uint128_t( group0 );
+            if ( unsigned_value > uint128_t(max) - uint128_t(min) )
+                return false;
+            // add in the unsigned domain: unsigned_value + min overflows signed arithmetic when the range is wider than 2^127
+            value = int128_t( unsigned_value + uint128_t(min) );
+            return true;
+        }
+
+        /**
             Serialize a number of bits (read).
             @param value The integer value read is stored here. Will be in range [0,(1<<bits)-1].
             @param bits The number of bits to read in [1,32].
@@ -1849,6 +1979,25 @@ namespace serialize
             serialize_assert( value >= min );
             serialize_assert( value <= max );
             const int bits = bits_required64( uint64_t(min), uint64_t(max) );
+            m_bitsWritten += bits;
+            return true;
+        }
+
+        /**
+            Serialize a 128 bit integer (measure).
+            @param value The integer value to measure. Not actually used or checked beyond the debug asserts.
+            @param min The minimum value.
+            @param max The maximum value.
+            @returns Always returns true. All checking is performed by debug asserts on write.
+         */
+
+        bool SerializeInteger128( int128_t value, int128_t min, int128_t max )
+        {
+            (void) value;
+            serialize_assert( min < max );
+            serialize_assert( value >= min );
+            serialize_assert( value <= max );
+            const int bits = bits_required128( uint128_t(min), uint128_t(max) );
             m_bitsWritten += bits;
             return true;
         }
@@ -2006,6 +2155,46 @@ namespace serialize
                     return false;                                       \
                 }                                                       \
             }                                                           \
+        } while (0)
+
+    /**
+        Serialize a ranged 128 bit integer to the stream (read/write/measure).
+        This is a helper macro to make writing unified serialize functions easier.
+        The value is serialized as an offset from min in the minimal number of bits for the range, exactly as serialize_int and serialize_int64 do at their widths, and the bounds are runtime values. Where the range fits 64 bits or fewer the bytes are identical to serialize_int64 over the same bounds.
+        The bounds and value are serialize::int128_t, which exists on every platform: native __int128 where the compiler provides it, the emulated pair where it doesn't. The bit count comes from the runtime serialize::bits_required128, so this works on pure MSVC — unlike the compile time serialize::BitsRequired128, which needs native __int128.
+        **Do not confuse this with serialize_uint128**, which is not ranged — it is a raw 128 bit field and always costs 128 bits.
+        Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The 128 bit integer value to serialize, in [min,max].
+        @param min The minimum value.
+        @param max The maximum value.
+     */
+
+    #define serialize_int128( stream, value, min, max )                                             \
+        do                                                                                          \
+        {                                                                                           \
+            serialize_assert( serialize::int128_t(min) < serialize::int128_t(max) );                \
+            serialize::int128_t int128_value = 0;                                                   \
+            if ( Stream::IsWriting )                                                                \
+            {                                                                                       \
+                serialize_assert( serialize::int128_t(value) >= serialize::int128_t(min) );         \
+                serialize_assert( serialize::int128_t(value) <= serialize::int128_t(max) );         \
+                int128_value = serialize::int128_t( value );                                        \
+            }                                                                                       \
+            if ( !stream.SerializeInteger128( int128_value, min, max ) )                            \
+            {                                                                                       \
+                return false;                                                                       \
+            }                                                                                       \
+            if ( Stream::IsReading )                                                                \
+            {                                                                                       \
+                value = int128_value;                                                               \
+                if ( serialize::int128_t(value) < serialize::int128_t(min) ||                       \
+                     serialize::int128_t(value) > serialize::int128_t(max) )                        \
+                {                                                                                   \
+                    return false;                                                                   \
+                }                                                                                   \
+            }                                                                                       \
         } while (0)
 
     /**
@@ -2310,7 +2499,7 @@ namespace serialize
     /**
         Serialize unsigned 128 bit integer (read/write/measure).
         The wire format is 128 bits raw: the low 64 bit half first, then the high half, following the lo-then-hi convention of serialize_bits.
-        The value may be serialize::uint128_t — which exists on every platform: native unsigned __int128 where the compiler provides it, the emulated mas_uint128_t elsewhere — or any 128 bit unsigned integer type meeting the requirements documented on serialize_uint128_internal. All representations produce identical bytes.
+        The value may be serialize::uint128_t — which exists on every platform: native unsigned __int128 where the compiler provides it, the emulated serialize_uint128_t elsewhere — or any 128 bit unsigned integer type meeting the requirements documented on serialize_uint128_internal. All representations produce identical bytes.
         IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
         @param stream The stream object. May be a read, write or measure stream.
         @param value The 128 bit unsigned integer value.
@@ -2640,13 +2829,13 @@ namespace serialize
     template <> struct FixedPointInteger<int128_t>                  { enum { is_integer = 1, is_signed = 1 }; };
     template <> struct FixedPointInteger<uint128_t>                 { enum { is_integer = 1, is_signed = 0 }; };
 #endif // #if defined(__SIZEOF_INT128__)
-#if defined(MAS_UINT128_DEFINED)
+#if defined(SERIALIZE_UINT128_DEFINED)
     // the emulated pair works as storage too. without native __int128 these ARE the serialize
     // typedefs; with it they are a distinct set of types (present when tests are enabled, or
     // when a sibling header defined the block first), so the specializations never collide
-    template <> struct FixedPointInteger<::mas_int128_t>            { enum { is_integer = 1, is_signed = 1 }; };
-    template <> struct FixedPointInteger<::mas_uint128_t>           { enum { is_integer = 1, is_signed = 0 }; };
-#endif // #if defined(MAS_UINT128_DEFINED)
+    template <> struct FixedPointInteger<::serialize_int128_t>            { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<::serialize_uint128_t>           { enum { is_integer = 1, is_signed = 0 }; };
+#endif // #if defined(SERIALIZE_UINT128_DEFINED)
 
     /**
         Compile time map from a 128 bit fixed point storage type to its unsigned counterpart,
@@ -2662,10 +2851,10 @@ namespace serialize
     template <> struct FixedPointUnsigned<int128_t>                 { typedef uint128_t type; };
     template <> struct FixedPointUnsigned<uint128_t>                { typedef uint128_t type; };
 #endif // #if defined(__SIZEOF_INT128__)
-#if defined(MAS_UINT128_DEFINED)
-    template <> struct FixedPointUnsigned<::mas_int128_t>           { typedef ::mas_uint128_t type; };
-    template <> struct FixedPointUnsigned<::mas_uint128_t>          { typedef ::mas_uint128_t type; };
-#endif // #if defined(MAS_UINT128_DEFINED)
+#if defined(SERIALIZE_UINT128_DEFINED)
+    template <> struct FixedPointUnsigned<::serialize_int128_t>           { typedef ::serialize_uint128_t type; };
+    template <> struct FixedPointUnsigned<::serialize_uint128_t>          { typedef ::serialize_uint128_t type; };
+#endif // #if defined(SERIALIZE_UINT128_DEFINED)
 
     /**
         Fixed point codec, specialized on storage width.
@@ -2755,7 +2944,7 @@ namespace serialize
         static bool Serialize( Stream & stream, Storage & value )
         {
             // the unsigned counterpart of the storage type: native unsigned __int128 for native
-            // storage, the emulated mas_uint128_t for emulated storage. all raw offset math runs
+            // storage, the emulated serialize_uint128_t for emulated storage. all raw offset math runs
             // in this type, where wrap around is exact two's complement in both representations,
             // so this codec is representation generic and needs no compiler guard at all.
             typedef typename FixedPointUnsigned<Storage>::type Unsigned;
@@ -2979,6 +3168,23 @@ namespace serialize
             }                                                                               \
         } while (0)
 
+    #define read_int128( stream, value, min, max )                                          \
+        do                                                                                  \
+        {                                                                                   \
+            serialize_assert( serialize::int128_t(min) < serialize::int128_t(max) );        \
+            serialize::int128_t int128_value = 0;                                           \
+            if ( !stream.SerializeInteger128( int128_value, min, max ) )                    \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+            value = int128_value;                                                           \
+            if ( serialize::int128_t(value) < serialize::int128_t(min) ||                   \
+                 serialize::int128_t(value) > serialize::int128_t(max) )                    \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+        } while (0)
+
     #define read_fixed( stream, value, integer_bits, fraction_bits, min, max )                                  \
         do                                                                                                      \
         {                                                                                                       \
@@ -3079,6 +3285,16 @@ namespace serialize
             serialize_assert( int64_t( value ) <= int64_t( max ) );                         \
             int64_t int64_value = (int64_t) ( value );                                      \
             stream.SerializeInteger64( int64_value, min, max );                             \
+        } while (0)
+
+    #define write_int128( stream, value, min, max )                                         \
+        do                                                                                  \
+        {                                                                                   \
+            serialize_assert( serialize::int128_t( min ) < serialize::int128_t( max ) );    \
+            serialize_assert( serialize::int128_t( value ) >= serialize::int128_t( min ) ); \
+            serialize_assert( serialize::int128_t( value ) <= serialize::int128_t( max ) ); \
+            serialize::int128_t int128_value = serialize::int128_t( value );                \
+            stream.SerializeInteger128( int128_value, min, max );                           \
         } while (0)
 
     #define write_fixed( stream, value, integer_bits, fraction_bits, min, max )                                 \
@@ -3337,6 +3553,42 @@ inline void test_bits_required64()
     serialize_check( serialize::bits_required64( 0, 0xFFFFFFFFFFFFFFFFULL ) == 64 );
     serialize_check( serialize::bits_required64( uint64_t(INT64_MIN), uint64_t(INT64_MAX) ) == 64 );
     serialize_check( serialize::bits_required64( uint64_t(-5000000000LL), uint64_t(+5000000000LL) ) == 34 );
+}
+
+inline void test_bits_required128()
+{
+    typedef serialize::uint128_t u128;
+
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 0 ) ) == 0 );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 1 ) ) == 1 );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 255 ) ) == 8 );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 4294967295ULL ) ) == 32 );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 4294967296ULL ) ) == 33 );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 0xFFFFFFFFFFFFFFFFULL ) ) == 64 );
+
+    // the boundary the 64 bit helper cannot reach: one past a full low lane needs the high lane
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 1 ) << 64 ) == 65 );
+    serialize_check( serialize::bits_required128( u128( 0 ), ( u128( 1 ) << 127 ) ) == 128 );
+    serialize_check( serialize::bits_required128( u128( 0 ), ~u128( 0 ) ) == 128 );
+
+    // the two helpers must agree wherever the range fits 64 bits, or the wire identity claim in
+    // STANDARD.md is false and serialize_int128 would silently disagree with serialize_int64
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( 4294967296ULL ) ) == serialize::bits_required64( 0, 4294967296ULL ) );
+    serialize_check( serialize::bits_required128( u128( 0 ), u128( ( 1ULL << 40 ) ) ) == serialize::bits_required64( 0, ( 1ULL << 40 ) ) );
+
+    // NEGATIVE BOUNDS MUST ARRIVE SIGN EXTENDED, which is what the codec does — it converts
+    // serialize::int128_t bounds straight to the unsigned domain. This is the same 34 bits the 64
+    // bit helper reports for the same signed range.
+    serialize_check( serialize::bits_required128( u128( serialize::int128_t( -5000000000LL ) ), u128( serialize::int128_t( +5000000000LL ) ) ) == 34 );
+
+    // AND THE TRAP IT WOULD BE EASY TO WALK INTO, pinned so nobody "fixes" the conversion:
+    // widening an ALREADY WRAPPED uint64_t bound zero extends instead of sign extending, so the
+    // range comes out just under 2^128 and the field would cost 128 bits instead of 34. Correct
+    // arithmetic on the wrong input — no assert would ever fire.
+    serialize_check( serialize::bits_required128( u128( uint64_t(-5000000000LL) ), u128( uint64_t(+5000000000LL) ) ) == 128 );
+
+    // a range wider than 2^127: the subtraction must run in the unsigned domain or this wraps wrong
+    serialize_check( serialize::bits_required128( u128( 1 ), ~u128( 0 ) ) == 128 );
 }
 
 inline void test_zigzag()
@@ -4509,24 +4761,24 @@ inline void test_serialize_fixed_wide_emulated()
     // is what makes wide fixed point available on compilers without native __int128. run the wide
     // case list through the emulated types explicitly, on every platform — where native exists
     // this doubles as proof that both representations drive the same codec.
-    check_fixed_cases<112, 16, -1152921504606846976LL, +1152921504606846976LL>( ::mas_int128_t( 65536 ) );
-    check_fixed_cases<112, 16, -2, +2>( ::mas_int128_t( 65536 ) );
-    check_fixed_cases<64, 64, -1000, +1000>( ::mas_int128_t( 1 ) << 64 );
-    check_fixed_cases<64, 64, INT64_MIN, INT64_MAX>( ::mas_int128_t( 1 ) << 64 );
-    check_fixed_cases<112, 16, 0, 2305843009213693952LL>( ::mas_uint128_t( 65536 ) );
+    check_fixed_cases<112, 16, -1152921504606846976LL, +1152921504606846976LL>( ::serialize_int128_t( 65536 ) );
+    check_fixed_cases<112, 16, -2, +2>( ::serialize_int128_t( 65536 ) );
+    check_fixed_cases<64, 64, -1000, +1000>( ::serialize_int128_t( 1 ) << 64 );
+    check_fixed_cases<64, 64, INT64_MIN, INT64_MAX>( ::serialize_int128_t( 1 ) << 64 );
+    check_fixed_cases<112, 16, 0, 2305843009213693952LL>( ::serialize_uint128_t( 65536 ) );
 
     // the 33..64 bit two group band on emulated wide storage: both boundaries and the example's shape
-    check_fixed_cases<112, 16, -32768, +32768>( ::mas_int128_t( 65536 ) );
-    check_fixed_cases<112, 16, -100000000000LL, +100000000000LL>( ::mas_int128_t( 65536 ) );
-    check_fixed_cases<112, 16, -140737488355328LL, +140737488355327LL>( ::mas_int128_t( 65536 ) );
+    check_fixed_cases<112, 16, -32768, +32768>( ::serialize_int128_t( 65536 ) );
+    check_fixed_cases<112, 16, -100000000000LL, +100000000000LL>( ::serialize_int128_t( 65536 ) );
+    check_fixed_cases<112, 16, -140737488355328LL, +140737488355327LL>( ::serialize_int128_t( 65536 ) );
 
     // one raw step past raw_max must be rejected through the emulated read path too
-    check_fixed_wide_rejects_out_of_range<112, 16, -1152921504606846976LL, +1152921504606846976LL>( ::mas_int128_t( 0 ) );
-    check_fixed_wide_rejects_out_of_range<64, 64, -1000, +1000>( ::mas_int128_t( 0 ) );
-    check_fixed_wide_rejects_out_of_range<112, 16, 0, 2305843009213693952LL>( ::mas_uint128_t( 0 ) );
-    check_fixed_wide_rejects_out_of_range<112, 16, -32768, +32768>( ::mas_int128_t( 0 ) );
-    check_fixed_wide_rejects_out_of_range<112, 16, -100000000000LL, +100000000000LL>( ::mas_int128_t( 0 ) );
-    check_fixed_wide_rejects_out_of_range<112, 16, -140737488355328LL, +140737488355327LL>( ::mas_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -1152921504606846976LL, +1152921504606846976LL>( ::serialize_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<64, 64, -1000, +1000>( ::serialize_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, 0, 2305843009213693952LL>( ::serialize_uint128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -32768, +32768>( ::serialize_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -100000000000LL, +100000000000LL>( ::serialize_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -140737488355328LL, +140737488355327LL>( ::serialize_int128_t( 0 ) );
 
 #if defined(__SIZEOF_INT128__)
     // cross representation wire identity: native and emulated storage must produce byte identical
@@ -4542,7 +4794,7 @@ inline void test_serialize_fixed_wide_emulated()
 
         uint8_t emulated_buffer[16 + 8] = { 0 };
         serialize::WriteStream emulatedStream( emulated_buffer, 16 );
-        ::mas_int128_t emulated_value( raw );
+        ::serialize_int128_t emulated_value( raw );
         serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( emulatedStream, emulated_value ) ) == true );
         emulatedStream.Flush();
 
@@ -4551,9 +4803,9 @@ inline void test_serialize_fixed_wide_emulated()
 
         // read the native bytes back through emulated storage
         serialize::ReadStream readStream( native_buffer, nativeStream.GetBytesProcessed() );
-        ::mas_int128_t read_back( 0 );
+        ::serialize_int128_t read_back( 0 );
         serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( readStream, read_back ) ) == true );
-        serialize_check( read_back == ::mas_int128_t( raw ) );
+        serialize_check( read_back == ::serialize_int128_t( raw ) );
     }
 #endif // #if defined(__SIZEOF_INT128__)
 }
@@ -4646,13 +4898,175 @@ inline void test_serialize_uint128()
     }
 }
 
+inline void test_serialize_int128()
+{
+    typedef serialize::int128_t i128;
+
+    // 1. WIRE IDENTITY WITH serialize_int64 wherever the range fits 64 bits. this is what lets a
+    //    schema widen a field without a wire change, so it is pinned by memcmp rather than assumed.
+    {
+        const int64_t min64 = -5000000000LL;
+        const int64_t max64 = +5000000000LL;
+        const int64_t values[] = { min64, min64 + 1, -1, 0, +1, 4123456789LL, max64 - 1, max64 };
+
+        for ( int i = 0; i < (int) ( sizeof(values) / sizeof(values[0]) ); i++ )
+        {
+            uint8_t buffer128[32 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+            uint8_t buffer64[32 + 8] = { 0 };
+
+            serialize::WriteStream w128( buffer128, 32 );
+            serialize_check( w128.SerializeInteger128( i128( values[i] ), i128( min64 ), i128( max64 ) ) == true );
+            w128.Flush();
+
+            serialize::WriteStream w64( buffer64, 32 );
+            serialize_check( w64.SerializeInteger64( values[i], min64, max64 ) == true );
+            w64.Flush();
+
+            serialize_check( w128.GetBitsProcessed() == w64.GetBitsProcessed() );
+            serialize_check( w128.GetBytesProcessed() == w64.GetBytesProcessed() );
+            serialize_check( memcmp( buffer128, buffer64, (size_t) w64.GetBytesProcessed() ) == 0 );
+
+            serialize::ReadStream readStream( buffer128, 32 );
+            i128 read_back = 0;
+            serialize_check( readStream.SerializeInteger128( read_back, i128( min64 ), i128( max64 ) ) == true );
+            serialize_check( read_back == i128( values[i] ) );
+        }
+    }
+
+    // 2. the wide bands the 64 bit path cannot express at all: three group and four group ranges,
+    //    including the widest possible range, which exercises the fourth group and the unsigned
+    //    domain subtraction that a signed one would overflow
+    {
+        const i128 wide_min = -( i128( 1 ) << 100 );
+        const i128 wide_max =  ( i128( 1 ) << 100 );
+        const i128 values[] = { wide_min, wide_min + 1, i128( -1 ), i128( 0 ), i128( 1 ), ( i128( 1 ) << 99 ), wide_max - 1, wide_max };
+
+        for ( int i = 0; i < (int) ( sizeof(values) / sizeof(values[0]) ); i++ )
+        {
+            uint8_t buffer[32 + 8] = { 0 };
+
+            serialize::WriteStream writeStream( buffer, 32 );
+            serialize_check( writeStream.SerializeInteger128( values[i], wide_min, wide_max ) == true );
+            writeStream.Flush();
+            serialize_check( writeStream.GetBitsProcessed() == 102 );        // bits_required128( -2^100, 2^100 ) == 102
+
+            serialize::ReadStream readStream( buffer, 32 );
+            i128 read_back = 0;
+            serialize_check( readStream.SerializeInteger128( read_back, wide_min, wide_max ) == true );
+            serialize_check( read_back == values[i] );
+        }
+    }
+
+    // 3. the full 128 bit range: every group full, and the range is wider than 2^127
+    {
+        const i128 full_min = i128( ( serialize::uint128_t( 1 ) << 127 ) );                  // INT128_MIN
+        const i128 full_max = i128( ~( serialize::uint128_t( 1 ) << 127 ) );                 // INT128_MAX
+        const i128 values[] = { full_min, full_min + 1, i128( -1 ), i128( 0 ), i128( 1 ), full_max - 1, full_max };
+
+        for ( int i = 0; i < (int) ( sizeof(values) / sizeof(values[0]) ); i++ )
+        {
+            uint8_t buffer[32 + 8] = { 0 };
+
+            serialize::WriteStream writeStream( buffer, 32 );
+            serialize_check( writeStream.SerializeInteger128( values[i], full_min, full_max ) == true );
+            writeStream.Flush();
+            serialize_check( writeStream.GetBitsProcessed() == 128 );
+
+            serialize::ReadStream readStream( buffer, 32 );
+            i128 read_back = 0;
+            serialize_check( readStream.SerializeInteger128( read_back, full_min, full_max ) == true );
+            serialize_check( read_back == values[i] );
+        }
+    }
+
+    // 4. the measure stream must agree with the write stream exactly, at every group width
+    {
+        const i128 cases[][3] =
+        {
+            { i128( 0 ), i128( 0 ), i128( 255 ) },
+            { i128( 7 ), i128( -5000000000LL ), i128( +5000000000LL ) },
+            { i128( 1 ), -( i128( 1 ) << 100 ), ( i128( 1 ) << 100 ) },
+            { i128( 0 ), i128( ( serialize::uint128_t( 1 ) << 127 ) ), i128( ~( serialize::uint128_t( 1 ) << 127 ) ) },
+        };
+
+        for ( int i = 0; i < (int) ( sizeof(cases) / sizeof(cases[0]) ); i++ )
+        {
+            uint8_t buffer[32 + 8] = { 0 };
+
+            serialize::WriteStream writeStream( buffer, 32 );
+            serialize_check( writeStream.SerializeInteger128( cases[i][0], cases[i][1], cases[i][2] ) == true );
+            writeStream.Flush();
+
+            serialize::MeasureStream measureStream;
+            serialize_check( measureStream.SerializeInteger128( cases[i][0], cases[i][1], cases[i][2] ) == true );
+            serialize_check( measureStream.GetBitsProcessed() == writeStream.GetBitsProcessed() );
+        }
+    }
+
+    // 5. a value outside the bounds must be REFUSED on read. the bit count is identical for both
+    //    bound pairs here, so the reader consumes the same bits and the range check is what
+    //    convicts it — proving the refusal, not just the absence of a crash
+    {
+        uint8_t buffer[32 + 8] = { 0 };
+
+        serialize::WriteStream writeStream( buffer, 32 );
+        serialize_check( writeStream.SerializeInteger128( i128( 255 ), i128( 0 ), i128( 255 ) ) == true );
+        writeStream.Flush();
+
+        serialize_check( serialize::bits_required128( serialize::uint128_t( 0 ), serialize::uint128_t( 200 ) ) == 8 );
+
+        serialize::ReadStream readStream( buffer, 32 );
+        i128 read_back = 0;
+        serialize_check( readStream.SerializeInteger128( read_back, i128( 0 ), i128( 200 ) ) == false );
+    }
+
+    // 6. a truncated buffer must be refused rather than read past the end
+    {
+        uint8_t buffer[32 + 8] = { 0 };
+
+        serialize::ReadStream readStream( buffer, 4 );          // 32 bits available, 128 required
+        i128 read_back = 0;
+        serialize_check( readStream.SerializeInteger128( read_back, i128( ( serialize::uint128_t( 1 ) << 127 ) ), i128( ~( serialize::uint128_t( 1 ) << 127 ) ) ) == false );
+    }
+
+    // 7. THE GOLDEN PIN, and its bytes were derived from STANDARD.md's stated rule in the
+    //    conformance checker's language, not read back out of this implementation — so this
+    //    memcmp is the document and the code agreeing, rather than the code agreeing with itself.
+    //    Bounds of +/- 2^70 need 72 bits, which is the THREE GROUP structure: 32, 32, then 8.
+    {
+        static const uint8_t golden_int128_bytes[] =
+        {
+            0x11, 0x32, 0x54, 0x76, 0x98, 0xBA, 0xDC, 0xFE,
+            0x3F, 0x00, 0x00, 0x00
+        };
+
+        const i128 golden_min = -( i128( 1 ) << 70 );
+        const i128 golden_max =  ( i128( 1 ) << 70 );
+        const i128 golden_value = -( i128( 0x0123456789ABCDEFLL ) );
+
+        uint8_t buffer[16 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::WriteStream writeStream( buffer, 16 );
+        serialize_check( writeStream.SerializeInteger128( golden_value, golden_min, golden_max ) == true );
+        writeStream.Flush();
+        serialize_check( writeStream.GetBitsProcessed() == 72 );
+        serialize_check( memcmp( buffer, golden_int128_bytes, sizeof( golden_int128_bytes ) ) == 0 );
+
+        memcpy( buffer, golden_int128_bytes, sizeof( golden_int128_bytes ) );
+        serialize::ReadStream readStream( buffer, 16 );
+        i128 read_back = 0;
+        serialize_check( readStream.SerializeInteger128( read_back, golden_min, golden_max ) == true );
+        serialize_check( read_back == golden_value );
+    }
+}
+
 // builds an emulated 128 bit value from its two lanes. the emulated type is defined on every
 // platform when tests are enabled — where native __int128 exists it coexists with it, so the
 // tests below run everywhere and the differential test can compare the two representations.
 
-inline ::mas_uint128_t uint128_emulated( uint64_t hi, uint64_t lo )
+inline ::serialize_uint128_t uint128_emulated( uint64_t hi, uint64_t lo )
 {
-    ::mas_uint128_t result( lo );
+    ::serialize_uint128_t result( lo );
     result.hi = hi;
     return result;
 }
@@ -4668,7 +5082,7 @@ inline void test_uint128_emulation()
 
     // construction from uint64_t fills the low lane. explicit conversion truncates back to it
     {
-        ::mas_uint128_t value( lo );
+        ::serialize_uint128_t value( lo );
         serialize_check( value.lo == lo && value.hi == 0 );
         serialize_check( uint64_t( value ) == lo );
         serialize_check( uint64_t( uint128_emulated( hi, lo ) ) == lo );
@@ -4678,20 +5092,20 @@ inline void test_uint128_emulation()
     // sign extend (negatives wrap modulo 2^128), unsigned sources zero extend. these are the
     // exact cross signed cases that diverged before the per-type constructors existed.
     {
-        serialize_check( ::mas_uint128_t( int64_t( -1 ) ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
-        serialize_check( ::mas_uint128_t( INT64_MIN ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0x8000000000000000ULL ) );
-        serialize_check( ::mas_uint128_t( uint64_t( 1 ) << 63 ) == uint128_emulated( 0, 0x8000000000000000ULL ) );
-        serialize_check( ::mas_uint128_t( UINT64_MAX ) == uint128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL ) );
-        serialize_check( ::mas_uint128_t( -5 ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFBULL ) );       // int: sign extends
-        serialize_check( ::mas_uint128_t( 3000000000U ) == uint128_emulated( 0, 3000000000ULL ) );                          // unsigned: zero extends
-        serialize_check( ::mas_uint128_t( int64_t( 7 ) ) == uint128_emulated( 0, 7 ) );                                     // non negative signed: zero high lane
+        serialize_check( ::serialize_uint128_t( int64_t( -1 ) ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::serialize_uint128_t( INT64_MIN ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0x8000000000000000ULL ) );
+        serialize_check( ::serialize_uint128_t( uint64_t( 1 ) << 63 ) == uint128_emulated( 0, 0x8000000000000000ULL ) );
+        serialize_check( ::serialize_uint128_t( UINT64_MAX ) == uint128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::serialize_uint128_t( -5 ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFBULL ) );       // int: sign extends
+        serialize_check( ::serialize_uint128_t( 3000000000U ) == uint128_emulated( 0, 3000000000ULL ) );                          // unsigned: zero extends
+        serialize_check( ::serialize_uint128_t( int64_t( 7 ) ) == uint128_emulated( 0, 7 ) );                                     // non negative signed: zero high lane
     }
 
     // all six comparisons, driven by the high lane, the low lane, and equality
     {
-        const ::mas_uint128_t a = uint128_emulated( 1, 0 );
-        const ::mas_uint128_t b = uint128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL );
-        const ::mas_uint128_t c = uint128_emulated( 1, 1 );
+        const ::serialize_uint128_t a = uint128_emulated( 1, 0 );
+        const ::serialize_uint128_t b = uint128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL );
+        const ::serialize_uint128_t c = uint128_emulated( 1, 1 );
         serialize_check( a > b );                                       // the high lane dominates
         serialize_check( b < a );
         serialize_check( c > a );                                       // the low lane breaks ties
@@ -4702,106 +5116,107 @@ inline void test_uint128_emulation()
 
     // left shift edges: 0, 1, 63, 64, 65, 127, and out of range counts
     {
-        const ::mas_uint128_t value = uint128_emulated( hi, lo );
+        const ::serialize_uint128_t value = uint128_emulated( hi, lo );
         serialize_check( ( value << 0 ) == value );
         serialize_check( ( value << 1 ) == uint128_emulated( ( hi << 1 ) | ( lo >> 63 ), lo << 1 ) );
         serialize_check( ( value << 63 ) == uint128_emulated( ( hi << 63 ) | ( lo >> 1 ), lo << 63 ) );
         serialize_check( ( value << 64 ) == uint128_emulated( lo, 0 ) );                    // the low lane becomes the high lane
         serialize_check( ( value << 65 ) == uint128_emulated( lo << 1, 0 ) );
         serialize_check( ( value << 127 ) == uint128_emulated( lo << 63, 0 ) );
-        serialize_check( ( value << 128 ) == ::mas_uint128_t( 0 ) );                        // >= 128 yields zero, documented
-        serialize_check( ( value << 200 ) == ::mas_uint128_t( 0 ) );
+        serialize_check( ( value << 128 ) == ::serialize_uint128_t( 0 ) );                        // >= 128 yields zero, documented
+        serialize_check( ( value << 200 ) == ::serialize_uint128_t( 0 ) );
     }
 
     // right shift edges: the mirror image
     {
-        const ::mas_uint128_t value = uint128_emulated( hi, lo );
+        const ::serialize_uint128_t value = uint128_emulated( hi, lo );
         serialize_check( ( value >> 0 ) == value );
         serialize_check( ( value >> 1 ) == uint128_emulated( hi >> 1, ( lo >> 1 ) | ( hi << 63 ) ) );
         serialize_check( ( value >> 63 ) == uint128_emulated( hi >> 63, ( lo >> 63 ) | ( hi << 1 ) ) );
         serialize_check( ( value >> 64 ) == uint128_emulated( 0, hi ) );                    // the high lane becomes the low lane
         serialize_check( ( value >> 65 ) == uint128_emulated( 0, hi >> 1 ) );
         serialize_check( ( value >> 127 ) == uint128_emulated( 0, hi >> 63 ) );
-        serialize_check( ( value >> 128 ) == ::mas_uint128_t( 0 ) );                        // >= 128 yields zero, documented
-        serialize_check( ( value >> 200 ) == ::mas_uint128_t( 0 ) );
+        serialize_check( ( value >> 128 ) == ::serialize_uint128_t( 0 ) );                        // >= 128 yields zero, documented
+        serialize_check( ( value >> 200 ) == ::serialize_uint128_t( 0 ) );
     }
 
     // addition carries out of the low lane, subtraction borrows back into it
     {
-        const ::mas_uint128_t max64( 0xFFFFFFFFFFFFFFFFULL );
-        const ::mas_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
-        serialize_check( max64 + ::mas_uint128_t( 1 ) == uint128_emulated( 1, 0 ) );        // carry
-        serialize_check( all_ones + ::mas_uint128_t( 1 ) == ::mas_uint128_t( 0 ) );         // wraps modulo 2^128
-        serialize_check( ::mas_uint128_t( 0 ) - ::mas_uint128_t( 1 ) == all_ones );         // borrow wraps back
-        serialize_check( uint128_emulated( 1, 0 ) - ::mas_uint128_t( 1 ) == max64 );        // borrow out of the high lane
+        const ::serialize_uint128_t max64( 0xFFFFFFFFFFFFFFFFULL );
+        const ::serialize_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( max64 + ::serialize_uint128_t( 1 ) == uint128_emulated( 1, 0 ) );        // carry
+        serialize_check( all_ones + ::serialize_uint128_t( 1 ) == ::serialize_uint128_t( 0 ) );         // wraps modulo 2^128
+        serialize_check( ::serialize_uint128_t( 0 ) - ::serialize_uint128_t( 1 ) == all_ones );         // borrow wraps back
+        serialize_check( uint128_emulated( 1, 0 ) - ::serialize_uint128_t( 1 ) == max64 );        // borrow out of the high lane
 
-        ::mas_uint128_t accumulator( 0xFFFFFFFFFFFFFFFFULL );
-        accumulator += ::mas_uint128_t( 1 );
+        ::serialize_uint128_t accumulator( 0xFFFFFFFFFFFFFFFFULL );
+        accumulator += ::serialize_uint128_t( 1 );
         serialize_check( accumulator == uint128_emulated( 1, 0 ) );
-        accumulator -= ::mas_uint128_t( 1 );
+        accumulator -= ::serialize_uint128_t( 1 );
         serialize_check( accumulator == max64 );
     }
 
     // increment and decrement, both forms, across the lane boundary
     {
-        ::mas_uint128_t value( 0xFFFFFFFFFFFFFFFFULL );
-        serialize_check( value++ == ::mas_uint128_t( 0xFFFFFFFFFFFFFFFFULL ) );             // post returns the value before
+        ::serialize_uint128_t value( 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( value++ == ::serialize_uint128_t( 0xFFFFFFFFFFFFFFFFULL ) );             // post returns the value before
         serialize_check( value == uint128_emulated( 1, 0 ) );
         serialize_check( ++value == uint128_emulated( 1, 1 ) );                             // pre returns the value after
         serialize_check( value-- == uint128_emulated( 1, 1 ) );
-        serialize_check( --value == ::mas_uint128_t( 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( --value == ::serialize_uint128_t( 0xFFFFFFFFFFFFFFFFULL ) );
     }
 
     // multiplication: lane crossing products with known answers
     {
-        const ::mas_uint128_t two_to_32( uint64_t( 1 ) << 32 );
-        const ::mas_uint128_t max64( 0xFFFFFFFFFFFFFFFFULL );
-        const ::mas_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
-        serialize_check( ::mas_uint128_t( 3 ) * ::mas_uint128_t( 5 ) == ::mas_uint128_t( 15 ) );
+        const ::serialize_uint128_t two_to_32( uint64_t( 1 ) << 32 );
+        const ::serialize_uint128_t max64( 0xFFFFFFFFFFFFFFFFULL );
+        const ::serialize_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( ::serialize_uint128_t( 3 ) * ::serialize_uint128_t( 5 ) == ::serialize_uint128_t( 15 ) );
         serialize_check( two_to_32 * two_to_32 == uint128_emulated( 1, 0 ) );                                       // 2^64 crosses into the high lane
         serialize_check( max64 * max64 == uint128_emulated( 0xFFFFFFFFFFFFFFFEULL, 1 ) );                           // 2^128 - 2^65 + 1
-        serialize_check( uint128_emulated( 1, 0 ) * ::mas_uint128_t( 5 ) == uint128_emulated( 5, 0 ) );             // the high lane path
-        serialize_check( all_ones * all_ones == ::mas_uint128_t( 1 ) );                                             // ( 2^128 - 1 )^2 mod 2^128
+        serialize_check( uint128_emulated( 1, 0 ) * ::serialize_uint128_t( 5 ) == uint128_emulated( 5, 0 ) );             // the high lane path
+        serialize_check( all_ones * all_ones == ::serialize_uint128_t( 1 ) );                                             // ( 2^128 - 1 )^2 mod 2^128
 
-        ::mas_uint128_t accumulator( 3 );
-        accumulator *= ::mas_uint128_t( 5 );
-        serialize_check( accumulator == ::mas_uint128_t( 15 ) );
+        ::serialize_uint128_t accumulator( 3 );
+        accumulator *= ::serialize_uint128_t( 5 );
+        serialize_check( accumulator == ::serialize_uint128_t( 15 ) );
     }
 
     // division and modulo: the small fast path, wide dividends, wide divisors, and the
-    // documented division by zero choice — zero quotient, zero remainder
+    // TOTALITY of division by zero — the operation is undefined and these pin only that it
+    // returns rather than traps, never that the value is a contract
     {
-        const ::mas_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
-        serialize_check( ::mas_uint128_t( 100 ) / ::mas_uint128_t( 7 ) == ::mas_uint128_t( 14 ) );
-        serialize_check( ::mas_uint128_t( 100 ) % ::mas_uint128_t( 7 ) == ::mas_uint128_t( 2 ) );
-        serialize_check( uint128_emulated( 1, 7 ) / ::mas_uint128_t( 16 ) == ::mas_uint128_t( uint64_t( 1 ) << 60 ) );      // 2^64 + 7 over 16
-        serialize_check( uint128_emulated( 1, 7 ) % ::mas_uint128_t( 16 ) == ::mas_uint128_t( 7 ) );
-        serialize_check( uint128_emulated( uint64_t( 1 ) << 63, 0 ) / uint128_emulated( 1, 0 ) == ::mas_uint128_t( uint64_t( 1 ) << 63 ) );     // 2^127 over 2^64
-        serialize_check( all_ones / ::mas_uint128_t( 3 ) == uint128_emulated( 0x5555555555555555ULL, 0x5555555555555555ULL ) );
-        serialize_check( all_ones % ::mas_uint128_t( 3 ) == ::mas_uint128_t( 0 ) );
-        serialize_check( ::mas_uint128_t( 7 ) / uint128_emulated( 1, 0 ) == ::mas_uint128_t( 0 ) );                 // dividend below divisor
-        serialize_check( ::mas_uint128_t( 7 ) % uint128_emulated( 1, 0 ) == ::mas_uint128_t( 7 ) );
-        serialize_check( all_ones / ::mas_uint128_t( 0 ) == ::mas_uint128_t( 0 ) );                                 // division by zero: zero, documented
-        serialize_check( all_ones % ::mas_uint128_t( 0 ) == ::mas_uint128_t( 0 ) );
+        const ::serialize_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( ::serialize_uint128_t( 100 ) / ::serialize_uint128_t( 7 ) == ::serialize_uint128_t( 14 ) );
+        serialize_check( ::serialize_uint128_t( 100 ) % ::serialize_uint128_t( 7 ) == ::serialize_uint128_t( 2 ) );
+        serialize_check( uint128_emulated( 1, 7 ) / ::serialize_uint128_t( 16 ) == ::serialize_uint128_t( uint64_t( 1 ) << 60 ) );      // 2^64 + 7 over 16
+        serialize_check( uint128_emulated( 1, 7 ) % ::serialize_uint128_t( 16 ) == ::serialize_uint128_t( 7 ) );
+        serialize_check( uint128_emulated( uint64_t( 1 ) << 63, 0 ) / uint128_emulated( 1, 0 ) == ::serialize_uint128_t( uint64_t( 1 ) << 63 ) );     // 2^127 over 2^64
+        serialize_check( all_ones / ::serialize_uint128_t( 3 ) == uint128_emulated( 0x5555555555555555ULL, 0x5555555555555555ULL ) );
+        serialize_check( all_ones % ::serialize_uint128_t( 3 ) == ::serialize_uint128_t( 0 ) );
+        serialize_check( ::serialize_uint128_t( 7 ) / uint128_emulated( 1, 0 ) == ::serialize_uint128_t( 0 ) );                 // dividend below divisor
+        serialize_check( ::serialize_uint128_t( 7 ) % uint128_emulated( 1, 0 ) == ::serialize_uint128_t( 7 ) );
+        serialize_check( all_ones / ::serialize_uint128_t( 0 ) == ::serialize_uint128_t( 0 ) );                                 // by zero is UNDEFINED: this pins totality, not a value contract
+        serialize_check( all_ones % ::serialize_uint128_t( 0 ) == ::serialize_uint128_t( 0 ) );
 
-        ::mas_uint128_t accumulator( 100 );
-        accumulator /= ::mas_uint128_t( 7 );
-        serialize_check( accumulator == ::mas_uint128_t( 14 ) );
-        accumulator = ::mas_uint128_t( 100 );
-        accumulator %= ::mas_uint128_t( 7 );
-        serialize_check( accumulator == ::mas_uint128_t( 2 ) );
+        ::serialize_uint128_t accumulator( 100 );
+        accumulator /= ::serialize_uint128_t( 7 );
+        serialize_check( accumulator == ::serialize_uint128_t( 14 ) );
+        accumulator = ::serialize_uint128_t( 100 );
+        accumulator %= ::serialize_uint128_t( 7 );
+        serialize_check( accumulator == ::serialize_uint128_t( 2 ) );
     }
 
     // bitwise operators work lane by lane
     {
-        const ::mas_uint128_t a = uint128_emulated( 0xF0F0F0F0F0F0F0F0ULL, 0xAAAAAAAAAAAAAAAAULL );
-        const ::mas_uint128_t b = uint128_emulated( 0xFF00FF00FF00FF00ULL, 0xCCCCCCCCCCCCCCCCULL );
+        const ::serialize_uint128_t a = uint128_emulated( 0xF0F0F0F0F0F0F0F0ULL, 0xAAAAAAAAAAAAAAAAULL );
+        const ::serialize_uint128_t b = uint128_emulated( 0xFF00FF00FF00FF00ULL, 0xCCCCCCCCCCCCCCCCULL );
         serialize_check( ( a & b ) == uint128_emulated( 0xF000F000F000F000ULL, 0x8888888888888888ULL ) );
         serialize_check( ( a | b ) == uint128_emulated( 0xFFF0FFF0FFF0FFF0ULL, 0xEEEEEEEEEEEEEEEEULL ) );
         serialize_check( ( a ^ b ) == uint128_emulated( 0x0FF00FF00FF00FF0ULL, 0x6666666666666666ULL ) );
         serialize_check( ~a == uint128_emulated( 0x0F0F0F0F0F0F0F0FULL, 0x5555555555555555ULL ) );
 
-        ::mas_uint128_t accumulator = a;
+        ::serialize_uint128_t accumulator = a;
         accumulator &= b;
         serialize_check( accumulator == ( a & b ) );
         accumulator = a;
@@ -4820,17 +5235,17 @@ inline void test_uint128_emulation()
 
     // unary plus is the identity, unary minus is two's complement negation
     {
-        const ::mas_uint128_t value = uint128_emulated( hi, lo );
+        const ::serialize_uint128_t value = uint128_emulated( hi, lo );
         serialize_check( +value == value );
-        serialize_check( -::mas_uint128_t( 0 ) == ::mas_uint128_t( 0 ) );
-        serialize_check( -::mas_uint128_t( 1 ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
-        serialize_check( -value + value == ::mas_uint128_t( 0 ) );
+        serialize_check( -::serialize_uint128_t( 0 ) == ::serialize_uint128_t( 0 ) );
+        serialize_check( -::serialize_uint128_t( 1 ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( -value + value == ::serialize_uint128_t( 0 ) );
     }
 }
 
-inline ::mas_int128_t int128_emulated( uint64_t hi, uint64_t lo )
+inline ::serialize_int128_t int128_emulated( uint64_t hi, uint64_t lo )
 {
-    ::mas_int128_t result( 0 );
+    ::serialize_int128_t result( 0 );
     result.hi = hi;
     result.lo = lo;
     return result;
@@ -4843,58 +5258,58 @@ inline void test_int128_emulation()
     // concentrate on the signed specific pieces: sign extension, signed ordering, the arithmetic
     // right shift, division sign quadrants, and the documented edge choices.
 
-    const ::mas_int128_t int128_min = int128_emulated( 0x8000000000000000ULL, 0 );
-    const ::mas_int128_t int128_max = int128_emulated( 0x7FFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+    const ::serialize_int128_t int128_min = int128_emulated( 0x8000000000000000ULL, 0 );
+    const ::serialize_int128_t int128_max = int128_emulated( 0x7FFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
 
     // the int64_t constructor sign extends into the high lane; the explicit conversion truncates
     // back to the low lane; the unsigned conversions preserve the bit pattern both ways
     {
-        serialize_check( ::mas_int128_t( -1 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
-        serialize_check( ::mas_int128_t( INT64_MIN ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0x8000000000000000ULL ) );
-        serialize_check( ::mas_int128_t( INT64_MAX ) == int128_emulated( 0, 0x7FFFFFFFFFFFFFFFULL ) );
-        serialize_check( ::mas_int128_t( 1 ) == int128_emulated( 0, 1 ) );
-        serialize_check( int64_t( ::mas_int128_t( -5 ) ) == -5 );
-        serialize_check( int64_t( ::mas_int128_t( INT64_MIN ) ) == INT64_MIN );
+        serialize_check( ::serialize_int128_t( -1 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::serialize_int128_t( INT64_MIN ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0x8000000000000000ULL ) );
+        serialize_check( ::serialize_int128_t( INT64_MAX ) == int128_emulated( 0, 0x7FFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::serialize_int128_t( 1 ) == int128_emulated( 0, 1 ) );
+        serialize_check( int64_t( ::serialize_int128_t( -5 ) ) == -5 );
+        serialize_check( int64_t( ::serialize_int128_t( INT64_MIN ) ) == INT64_MIN );
 
         // unsigned sources are value preserving with a zero high lane, exactly like native: a
         // uint64 with the top bit set stays a large positive value, it does NOT wrap negative.
         // these are the exact cross signed cases that diverged before the per-type constructors.
-        serialize_check( ::mas_int128_t( uint64_t( 1 ) << 63 ) == int128_emulated( 0, 0x8000000000000000ULL ) );
-        serialize_check( ::mas_int128_t( uint64_t( 1 ) << 63 ) > ::mas_int128_t( 0 ) );
-        serialize_check( ::mas_int128_t( UINT64_MAX ) == int128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL ) );
-        serialize_check( ::mas_int128_t( UINT64_MAX ) > ::mas_int128_t( 0 ) );
-        serialize_check( ::mas_int128_t( -5 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFBULL ) );     // int: sign extends
-        serialize_check( ::mas_int128_t( 3000000000U ) == int128_emulated( 0, 3000000000ULL ) );                        // unsigned: zero extends
+        serialize_check( ::serialize_int128_t( uint64_t( 1 ) << 63 ) == int128_emulated( 0, 0x8000000000000000ULL ) );
+        serialize_check( ::serialize_int128_t( uint64_t( 1 ) << 63 ) > ::serialize_int128_t( 0 ) );
+        serialize_check( ::serialize_int128_t( UINT64_MAX ) == int128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::serialize_int128_t( UINT64_MAX ) > ::serialize_int128_t( 0 ) );
+        serialize_check( ::serialize_int128_t( -5 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFBULL ) );     // int: sign extends
+        serialize_check( ::serialize_int128_t( 3000000000U ) == int128_emulated( 0, 3000000000ULL ) );                        // unsigned: zero extends
 
-        const ::mas_uint128_t bit_pattern = ::mas_uint128_t( ::mas_int128_t( -1 ) );
+        const ::serialize_uint128_t bit_pattern = ::serialize_uint128_t( ::serialize_int128_t( -1 ) );
         serialize_check( bit_pattern.lo == 0xFFFFFFFFFFFFFFFFULL && bit_pattern.hi == 0xFFFFFFFFFFFFFFFFULL );
-        serialize_check( ::mas_int128_t( bit_pattern ) == ::mas_int128_t( -1 ) );
+        serialize_check( ::serialize_int128_t( bit_pattern ) == ::serialize_int128_t( -1 ) );
     }
 
     // signed ordering: negatives below positives, the high lane compares signed, the low lane
     // breaks ties unsigned
     {
-        serialize_check( ::mas_int128_t( -1 ) < ::mas_int128_t( 0 ) );
-        serialize_check( ::mas_int128_t( 0 ) < ::mas_int128_t( 1 ) );
-        serialize_check( int128_min < ::mas_int128_t( INT64_MIN ) );
-        serialize_check( int128_min < ::mas_int128_t( -1 ) );
-        serialize_check( int128_max > ::mas_int128_t( INT64_MAX ) );
+        serialize_check( ::serialize_int128_t( -1 ) < ::serialize_int128_t( 0 ) );
+        serialize_check( ::serialize_int128_t( 0 ) < ::serialize_int128_t( 1 ) );
+        serialize_check( int128_min < ::serialize_int128_t( INT64_MIN ) );
+        serialize_check( int128_min < ::serialize_int128_t( -1 ) );
+        serialize_check( int128_max > ::serialize_int128_t( INT64_MAX ) );
         serialize_check( int128_min < int128_max );
         serialize_check( int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 5 ) < int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 7 ) );       // low lane tiebreak among negatives
-        serialize_check( ::mas_int128_t( -3 ) <= ::mas_int128_t( -3 ) && ::mas_int128_t( -3 ) >= ::mas_int128_t( -3 ) );
-        serialize_check( ::mas_int128_t( -3 ) != ::mas_int128_t( 3 ) );
-        serialize_check( !( ::mas_int128_t( 1 ) < ::mas_int128_t( -1 ) ) );
+        serialize_check( ::serialize_int128_t( -3 ) <= ::serialize_int128_t( -3 ) && ::serialize_int128_t( -3 ) >= ::serialize_int128_t( -3 ) );
+        serialize_check( ::serialize_int128_t( -3 ) != ::serialize_int128_t( 3 ) );
+        serialize_check( !( ::serialize_int128_t( 1 ) < ::serialize_int128_t( -1 ) ) );
     }
 
     // addition, subtraction and multiplication with mixed signs, and the documented wrap
     {
-        serialize_check( ::mas_int128_t( -3 ) + ::mas_int128_t( 5 ) == ::mas_int128_t( 2 ) );
-        serialize_check( ::mas_int128_t( 3 ) - ::mas_int128_t( 5 ) == ::mas_int128_t( -2 ) );
-        serialize_check( ::mas_int128_t( -3 ) * ::mas_int128_t( 5 ) == ::mas_int128_t( -15 ) );
-        serialize_check( ::mas_int128_t( -3 ) * ::mas_int128_t( -5 ) == ::mas_int128_t( 15 ) );
-        serialize_check( int128_max + ::mas_int128_t( 1 ) == int128_min );                          // wraps two's complement, documented
-        serialize_check( int128_min - ::mas_int128_t( 1 ) == int128_max );
-        serialize_check( ::mas_int128_t( INT64_MAX ) * ::mas_int128_t( 4 ) == int128_emulated( 1, 0xFFFFFFFFFFFFFFFCULL ) );        // crosses the lane boundary
+        serialize_check( ::serialize_int128_t( -3 ) + ::serialize_int128_t( 5 ) == ::serialize_int128_t( 2 ) );
+        serialize_check( ::serialize_int128_t( 3 ) - ::serialize_int128_t( 5 ) == ::serialize_int128_t( -2 ) );
+        serialize_check( ::serialize_int128_t( -3 ) * ::serialize_int128_t( 5 ) == ::serialize_int128_t( -15 ) );
+        serialize_check( ::serialize_int128_t( -3 ) * ::serialize_int128_t( -5 ) == ::serialize_int128_t( 15 ) );
+        serialize_check( int128_max + ::serialize_int128_t( 1 ) == int128_min );                          // wraps two's complement, documented
+        serialize_check( int128_min - ::serialize_int128_t( 1 ) == int128_max );
+        serialize_check( ::serialize_int128_t( INT64_MAX ) * ::serialize_int128_t( 4 ) == int128_emulated( 1, 0xFFFFFFFFFFFFFFFCULL ) );        // crosses the lane boundary
     }
 
     // the arithmetic right shift fills with the sign: edges 0, 1, 63, 64, 65, 127 and out of range
@@ -4902,94 +5317,94 @@ inline void test_int128_emulation()
         serialize_check( ( int128_min >> 0 ) == int128_min );
         serialize_check( ( int128_min >> 1 ) == int128_emulated( 0xC000000000000000ULL, 0 ) );
         serialize_check( ( int128_min >> 63 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0 ) );                             // -2^64
-        serialize_check( ( int128_min >> 64 ) == ::mas_int128_t( INT64_MIN ) );
-        serialize_check( ( int128_min >> 65 ) == ::mas_int128_t( INT64_MIN / 2 ) );
-        serialize_check( ( int128_min >> 127 ) == ::mas_int128_t( -1 ) );
-        serialize_check( ( int128_min >> 128 ) == ::mas_int128_t( -1 ) );                           // all sign bits, documented
-        serialize_check( ( int128_min >> 200 ) == ::mas_int128_t( -1 ) );
-        serialize_check( ( ::mas_int128_t( -7 ) >> 1 ) == ::mas_int128_t( -4 ) );                   // arithmetic shift rounds toward negative infinity
-        serialize_check( ( int128_max >> 127 ) == ::mas_int128_t( 0 ) );
-        serialize_check( ( int128_max >> 128 ) == ::mas_int128_t( 0 ) );                            // non negative: sign fill is zero
-        serialize_check( ( ( ::mas_int128_t( 1 ) << 100 ) >> 100 ) == ::mas_int128_t( 1 ) );
+        serialize_check( ( int128_min >> 64 ) == ::serialize_int128_t( INT64_MIN ) );
+        serialize_check( ( int128_min >> 65 ) == ::serialize_int128_t( INT64_MIN / 2 ) );
+        serialize_check( ( int128_min >> 127 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ( int128_min >> 128 ) == ::serialize_int128_t( -1 ) );                           // all sign bits, documented
+        serialize_check( ( int128_min >> 200 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ( ::serialize_int128_t( -7 ) >> 1 ) == ::serialize_int128_t( -4 ) );                   // arithmetic shift rounds toward negative infinity
+        serialize_check( ( int128_max >> 127 ) == ::serialize_int128_t( 0 ) );
+        serialize_check( ( int128_max >> 128 ) == ::serialize_int128_t( 0 ) );                            // non negative: sign fill is zero
+        serialize_check( ( ( ::serialize_int128_t( 1 ) << 100 ) >> 100 ) == ::serialize_int128_t( 1 ) );
     }
 
     // the left shift moves the bit pattern like hardware: negative values included
     {
-        serialize_check( ( ::mas_int128_t( -1 ) << 1 ) == ::mas_int128_t( -2 ) );
-        serialize_check( ( ::mas_int128_t( -1 ) << 64 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0 ) );
-        serialize_check( ( ::mas_int128_t( 1 ) << 127 ) == int128_min );
-        serialize_check( ( ::mas_int128_t( -1 ) << 128 ) == ::mas_int128_t( 0 ) );                  // out of range yields zero, documented
+        serialize_check( ( ::serialize_int128_t( -1 ) << 1 ) == ::serialize_int128_t( -2 ) );
+        serialize_check( ( ::serialize_int128_t( -1 ) << 64 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0 ) );
+        serialize_check( ( ::serialize_int128_t( 1 ) << 127 ) == int128_min );
+        serialize_check( ( ::serialize_int128_t( -1 ) << 128 ) == ::serialize_int128_t( 0 ) );                  // out of range yields zero, documented
     }
 
     // division and modulo: all four sign quadrants, truncation toward zero, the remainder sign
     // follows the dividend, and the documented edge choices
     {
-        serialize_check( ::mas_int128_t( 7 ) / ::mas_int128_t( 3 ) == ::mas_int128_t( 2 ) );
-        serialize_check( ::mas_int128_t( 7 ) % ::mas_int128_t( 3 ) == ::mas_int128_t( 1 ) );
-        serialize_check( ::mas_int128_t( -7 ) / ::mas_int128_t( 3 ) == ::mas_int128_t( -2 ) );
-        serialize_check( ::mas_int128_t( -7 ) % ::mas_int128_t( 3 ) == ::mas_int128_t( -1 ) );
-        serialize_check( ::mas_int128_t( 7 ) / ::mas_int128_t( -3 ) == ::mas_int128_t( -2 ) );
-        serialize_check( ::mas_int128_t( 7 ) % ::mas_int128_t( -3 ) == ::mas_int128_t( 1 ) );
-        serialize_check( ::mas_int128_t( -7 ) / ::mas_int128_t( -3 ) == ::mas_int128_t( 2 ) );
-        serialize_check( ::mas_int128_t( -7 ) % ::mas_int128_t( -3 ) == ::mas_int128_t( -1 ) );
-        serialize_check( ::mas_int128_t( -1 ) / ::mas_int128_t( 2 ) == ::mas_int128_t( 0 ) );       // truncation toward zero, not the floor
-        serialize_check( ::mas_int128_t( -1 ) % ::mas_int128_t( 2 ) == ::mas_int128_t( -1 ) );
-        serialize_check( int128_min / ::mas_int128_t( 2 ) == int128_emulated( 0xC000000000000000ULL, 0 ) );
-        serialize_check( int128_min / ::mas_int128_t( 1 ) == int128_min );
-        serialize_check( int128_min / ::mas_int128_t( -1 ) == int128_min );                         // the one overflowing case wraps, documented
-        serialize_check( int128_min % ::mas_int128_t( -1 ) == ::mas_int128_t( 0 ) );
-        serialize_check( int128_max / ::mas_int128_t( 0 ) == ::mas_int128_t( 0 ) );                 // division by zero: zero, documented
-        serialize_check( int128_max % ::mas_int128_t( 0 ) == ::mas_int128_t( 0 ) );
+        serialize_check( ::serialize_int128_t( 7 ) / ::serialize_int128_t( 3 ) == ::serialize_int128_t( 2 ) );
+        serialize_check( ::serialize_int128_t( 7 ) % ::serialize_int128_t( 3 ) == ::serialize_int128_t( 1 ) );
+        serialize_check( ::serialize_int128_t( -7 ) / ::serialize_int128_t( 3 ) == ::serialize_int128_t( -2 ) );
+        serialize_check( ::serialize_int128_t( -7 ) % ::serialize_int128_t( 3 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ::serialize_int128_t( 7 ) / ::serialize_int128_t( -3 ) == ::serialize_int128_t( -2 ) );
+        serialize_check( ::serialize_int128_t( 7 ) % ::serialize_int128_t( -3 ) == ::serialize_int128_t( 1 ) );
+        serialize_check( ::serialize_int128_t( -7 ) / ::serialize_int128_t( -3 ) == ::serialize_int128_t( 2 ) );
+        serialize_check( ::serialize_int128_t( -7 ) % ::serialize_int128_t( -3 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ::serialize_int128_t( -1 ) / ::serialize_int128_t( 2 ) == ::serialize_int128_t( 0 ) );       // truncation toward zero, not the floor
+        serialize_check( ::serialize_int128_t( -1 ) % ::serialize_int128_t( 2 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( int128_min / ::serialize_int128_t( 2 ) == int128_emulated( 0xC000000000000000ULL, 0 ) );
+        serialize_check( int128_min / ::serialize_int128_t( 1 ) == int128_min );
+        serialize_check( int128_min / ::serialize_int128_t( -1 ) == int128_min );                         // the one overflowing case wraps, documented
+        serialize_check( int128_min % ::serialize_int128_t( -1 ) == ::serialize_int128_t( 0 ) );
+        serialize_check( int128_max / ::serialize_int128_t( 0 ) == ::serialize_int128_t( 0 ) );                 // by zero is UNDEFINED: this pins totality, not a value contract
+        serialize_check( int128_max % ::serialize_int128_t( 0 ) == ::serialize_int128_t( 0 ) );
     }
 
     // unary minus is two's complement negation; ~ and the bitwise operators work on the pattern
     {
-        serialize_check( -::mas_int128_t( 5 ) == ::mas_int128_t( -5 ) );
-        serialize_check( -::mas_int128_t( -5 ) == ::mas_int128_t( 5 ) );
+        serialize_check( -::serialize_int128_t( 5 ) == ::serialize_int128_t( -5 ) );
+        serialize_check( -::serialize_int128_t( -5 ) == ::serialize_int128_t( 5 ) );
         serialize_check( -int128_min == int128_min );                                               // -INT128_MIN wraps to itself, documented
-        serialize_check( +::mas_int128_t( -5 ) == ::mas_int128_t( -5 ) );
-        serialize_check( ~::mas_int128_t( 0 ) == ::mas_int128_t( -1 ) );
-        serialize_check( ( ::mas_int128_t( -1 ) & ::mas_int128_t( 5 ) ) == ::mas_int128_t( 5 ) );
-        serialize_check( ( ::mas_int128_t( 0 ) | ::mas_int128_t( -1 ) ) == ::mas_int128_t( -1 ) );
-        serialize_check( ( ::mas_int128_t( -1 ) ^ ::mas_int128_t( -1 ) ) == ::mas_int128_t( 0 ) );
+        serialize_check( +::serialize_int128_t( -5 ) == ::serialize_int128_t( -5 ) );
+        serialize_check( ~::serialize_int128_t( 0 ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ( ::serialize_int128_t( -1 ) & ::serialize_int128_t( 5 ) ) == ::serialize_int128_t( 5 ) );
+        serialize_check( ( ::serialize_int128_t( 0 ) | ::serialize_int128_t( -1 ) ) == ::serialize_int128_t( -1 ) );
+        serialize_check( ( ::serialize_int128_t( -1 ) ^ ::serialize_int128_t( -1 ) ) == ::serialize_int128_t( 0 ) );
     }
 
     // increment and decrement, both forms, across zero and across the lane boundary
     {
-        ::mas_int128_t value( -1 );
-        serialize_check( ++value == ::mas_int128_t( 0 ) );
-        serialize_check( value++ == ::mas_int128_t( 0 ) );
-        serialize_check( value == ::mas_int128_t( 1 ) );
-        serialize_check( --value == ::mas_int128_t( 0 ) );
-        serialize_check( value-- == ::mas_int128_t( 0 ) );
-        serialize_check( value == ::mas_int128_t( -1 ) );
+        ::serialize_int128_t value( -1 );
+        serialize_check( ++value == ::serialize_int128_t( 0 ) );
+        serialize_check( value++ == ::serialize_int128_t( 0 ) );
+        serialize_check( value == ::serialize_int128_t( 1 ) );
+        serialize_check( --value == ::serialize_int128_t( 0 ) );
+        serialize_check( value-- == ::serialize_int128_t( 0 ) );
+        serialize_check( value == ::serialize_int128_t( -1 ) );
 
-        ::mas_int128_t boundary = int128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL );                      // 2^64 - 1
+        ::serialize_int128_t boundary = int128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL );                      // 2^64 - 1
         serialize_check( ++boundary == int128_emulated( 1, 0 ) );
 
-        ::mas_int128_t accumulator( -10 );
-        accumulator += ::mas_int128_t( 4 );  serialize_check( accumulator == ::mas_int128_t( -6 ) );
-        accumulator -= ::mas_int128_t( -6 ); serialize_check( accumulator == ::mas_int128_t( 0 ) );
-        accumulator = ::mas_int128_t( -3 );
-        accumulator *= ::mas_int128_t( -3 ); serialize_check( accumulator == ::mas_int128_t( 9 ) );
-        accumulator /= ::mas_int128_t( -2 ); serialize_check( accumulator == ::mas_int128_t( -4 ) );
-        accumulator %= ::mas_int128_t( 3 );  serialize_check( accumulator == ::mas_int128_t( -1 ) );
+        ::serialize_int128_t accumulator( -10 );
+        accumulator += ::serialize_int128_t( 4 );  serialize_check( accumulator == ::serialize_int128_t( -6 ) );
+        accumulator -= ::serialize_int128_t( -6 ); serialize_check( accumulator == ::serialize_int128_t( 0 ) );
+        accumulator = ::serialize_int128_t( -3 );
+        accumulator *= ::serialize_int128_t( -3 ); serialize_check( accumulator == ::serialize_int128_t( 9 ) );
+        accumulator /= ::serialize_int128_t( -2 ); serialize_check( accumulator == ::serialize_int128_t( -4 ) );
+        accumulator %= ::serialize_int128_t( 3 );  serialize_check( accumulator == ::serialize_int128_t( -1 ) );
         accumulator <<= 64;                  serialize_check( accumulator == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0 ) );
-        accumulator >>= 64;                  serialize_check( accumulator == ::mas_int128_t( -1 ) );
-        accumulator &= ::mas_int128_t( 6 );  serialize_check( accumulator == ::mas_int128_t( 6 ) );
-        accumulator |= ::mas_int128_t( 1 );  serialize_check( accumulator == ::mas_int128_t( 7 ) );
-        accumulator ^= ::mas_int128_t( -1 ); serialize_check( accumulator == ::mas_int128_t( -8 ) );
+        accumulator >>= 64;                  serialize_check( accumulator == ::serialize_int128_t( -1 ) );
+        accumulator &= ::serialize_int128_t( 6 );  serialize_check( accumulator == ::serialize_int128_t( 6 ) );
+        accumulator |= ::serialize_int128_t( 1 );  serialize_check( accumulator == ::serialize_int128_t( 7 ) );
+        accumulator ^= ::serialize_int128_t( -1 ); serialize_check( accumulator == ::serialize_int128_t( -8 ) );
     }
 }
 
 #if defined(__SIZEOF_INT128__)
 
-inline serialize::uint128_t uint128_native_from_emulated( ::mas_uint128_t value )
+inline serialize::uint128_t uint128_native_from_emulated( ::serialize_uint128_t value )
 {
     return ( serialize::uint128_t( value.hi ) << 64 ) | value.lo;
 }
 
-inline void check_uint128_agree( ::mas_uint128_t emulated, serialize::uint128_t native )
+inline void check_uint128_agree( ::serialize_uint128_t emulated, serialize::uint128_t native )
 {
     serialize_check( emulated.lo == uint64_t( native ) );
     serialize_check( emulated.hi == uint64_t( native >> 64 ) );
@@ -5025,8 +5440,8 @@ inline void test_uint128_differential()
             default: break;
         }
 
-        const ::mas_uint128_t ea = uint128_emulated( a_hi, a_lo );
-        const ::mas_uint128_t eb = uint128_emulated( b_hi, b_lo );
+        const ::serialize_uint128_t ea = uint128_emulated( a_hi, a_lo );
+        const ::serialize_uint128_t eb = uint128_emulated( b_hi, b_lo );
         const serialize::uint128_t na = ( serialize::uint128_t( a_hi ) << 64 ) | a_lo;
         const serialize::uint128_t nb = ( serialize::uint128_t( b_hi ) << 64 ) | b_lo;
 
@@ -5040,9 +5455,9 @@ inline void test_uint128_differential()
         check_uint128_agree( -ea, serialize::uint128_t( 0 ) - na );
         check_uint128_agree( +ea, na );
 
-        if ( eb != ::mas_uint128_t( 0 ) )
+        if ( eb != ::serialize_uint128_t( 0 ) )
         {
-            check_uint128_agree( ea / eb, na / nb );            // native division by zero is undefined; the emulated choice is pinned in test_uint128_emulation
+            check_uint128_agree( ea / eb, na / nb );            // zero divisors are excluded PERMANENTLY: by zero is undefined on both sides and native hardware disagrees with itself (arm64 x/0 is 0 but x%0 is the dividend; x86-64 traps), so agreement is not a property either side can promise. Totality is pinned in test_uint128_emulation instead
             check_uint128_agree( ea % eb, na % nb );
         }
 
@@ -5058,10 +5473,10 @@ inline void test_uint128_differential()
         serialize_check( ( ea >= eb ) == ( na >= nb ) );
 
         // construction agreement from both signednesses of the drawn lanes
-        check_uint128_agree( ::mas_uint128_t( a_lo ), serialize::uint128_t( a_lo ) );
-        check_uint128_agree( ::mas_uint128_t( int64_t( a_lo ) ), serialize::uint128_t( int64_t( a_lo ) ) );
+        check_uint128_agree( ::serialize_uint128_t( a_lo ), serialize::uint128_t( a_lo ) );
+        check_uint128_agree( ::serialize_uint128_t( int64_t( a_lo ) ), serialize::uint128_t( int64_t( a_lo ) ) );
 
-        ::mas_uint128_t emulated_accumulator = ea;
+        ::serialize_uint128_t emulated_accumulator = ea;
         serialize::uint128_t native_accumulator = na;
         check_uint128_agree( ++emulated_accumulator, ++native_accumulator );
         check_uint128_agree( emulated_accumulator++, native_accumulator++ );
@@ -5080,7 +5495,7 @@ inline void test_uint128_differential()
         emulated_accumulator ^= eb; native_accumulator ^= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
         emulated_accumulator <<= shift; native_accumulator <<= shift; check_uint128_agree( emulated_accumulator, native_accumulator );
         emulated_accumulator >>= shift; native_accumulator >>= shift; check_uint128_agree( emulated_accumulator, native_accumulator );
-        if ( eb != ::mas_uint128_t( 0 ) )
+        if ( eb != ::serialize_uint128_t( 0 ) )
         {
             emulated_accumulator = ea; native_accumulator = na;
             emulated_accumulator /= eb; native_accumulator /= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
@@ -5094,12 +5509,12 @@ inline void test_uint128_differential()
     // construction differential: the exact cross signed cases the audit proved uncovered.
     // identical source expressions must construct identical values in both representations.
     {
-        check_uint128_agree( ::mas_uint128_t( int64_t( -1 ) ),       serialize::uint128_t( int64_t( -1 ) ) );
-        check_uint128_agree( ::mas_uint128_t( INT64_MIN ),           serialize::uint128_t( INT64_MIN ) );
-        check_uint128_agree( ::mas_uint128_t( uint64_t( 1 ) << 63 ), serialize::uint128_t( uint64_t( 1 ) << 63 ) );
-        check_uint128_agree( ::mas_uint128_t( UINT64_MAX ),          serialize::uint128_t( UINT64_MAX ) );
-        check_uint128_agree( ::mas_uint128_t( -5 ),                  serialize::uint128_t( -5 ) );
-        check_uint128_agree( ::mas_uint128_t( 3000000000U ),         serialize::uint128_t( 3000000000U ) );
+        check_uint128_agree( ::serialize_uint128_t( int64_t( -1 ) ),       serialize::uint128_t( int64_t( -1 ) ) );
+        check_uint128_agree( ::serialize_uint128_t( INT64_MIN ),           serialize::uint128_t( INT64_MIN ) );
+        check_uint128_agree( ::serialize_uint128_t( uint64_t( 1 ) << 63 ), serialize::uint128_t( uint64_t( 1 ) << 63 ) );
+        check_uint128_agree( ::serialize_uint128_t( UINT64_MAX ),          serialize::uint128_t( UINT64_MAX ) );
+        check_uint128_agree( ::serialize_uint128_t( -5 ),                  serialize::uint128_t( -5 ) );
+        check_uint128_agree( ::serialize_uint128_t( 3000000000U ),         serialize::uint128_t( 3000000000U ) );
     }
 
     // cross representation wire identity: the emulated type and native __int128 must produce
@@ -5118,7 +5533,7 @@ inline void test_uint128_differential()
 
         for ( int i = 0; i < (int) ( sizeof( lanes ) / sizeof( lanes[0] ) ); i++ )
         {
-            ::mas_uint128_t emulated = uint128_emulated( lanes[i][0], lanes[i][1] );
+            ::serialize_uint128_t emulated = uint128_emulated( lanes[i][0], lanes[i][1] );
             serialize::uint128_t native = uint128_native_from_emulated( emulated );
 
             uint8_t emulated_buffer[16 + 8] = { 0 };            // + 8: read buffer allocations extend 8 bytes past the data
@@ -5136,19 +5551,19 @@ inline void test_uint128_differential()
 
             // read the native bytes back through the emulated type
             serialize::ReadStream readStream( native_buffer, 16 );
-            ::mas_uint128_t read_back( 0 );
+            ::serialize_uint128_t read_back( 0 );
             serialize_check( serialize::serialize_uint128_internal( readStream, read_back ) == true );
             serialize_check( read_back == uint128_emulated( lanes[i][0], lanes[i][1] ) );
         }
     }
 }
 
-inline serialize::int128_t int128_native_from_emulated( ::mas_int128_t value )
+inline serialize::int128_t int128_native_from_emulated( ::serialize_int128_t value )
 {
     return serialize::int128_t( ( serialize::uint128_t( value.hi ) << 64 ) | value.lo );
 }
 
-inline void check_int128_agree( ::mas_int128_t emulated, serialize::int128_t native )
+inline void check_int128_agree( ::serialize_int128_t emulated, serialize::int128_t native )
 {
     serialize_check( emulated.lo == uint64_t( serialize::uint128_t( native ) ) );
     serialize_check( emulated.hi == uint64_t( serialize::uint128_t( native ) >> 64 ) );
@@ -5191,8 +5606,8 @@ inline void test_int128_differential()
             default: break;
         }
 
-        const ::mas_int128_t ea = int128_emulated( a_hi, a_lo );
-        const ::mas_int128_t eb = int128_emulated( b_hi, b_lo );
+        const ::serialize_int128_t ea = int128_emulated( a_hi, a_lo );
+        const ::serialize_int128_t eb = int128_emulated( b_hi, b_lo );
         const serialize::uint128_t ua = ( serialize::uint128_t( a_hi ) << 64 ) | a_lo;
         const serialize::uint128_t ub = ( serialize::uint128_t( b_hi ) << 64 ) | b_lo;
         const serialize::int128_t na = serialize::int128_t( ua );
@@ -5229,24 +5644,24 @@ inline void test_int128_differential()
         serialize_check( ( ea >= eb ) == ( na >= nb ) );
 
         // increments and decrements via the unsigned domain, since native ++ overflows at INT128_MAX
-        ::mas_int128_t incremented = ea;
+        ::serialize_int128_t incremented = ea;
         ++incremented;
         check_int128_agree( incremented, serialize::int128_t( ua + 1 ) );
         incremented--;
         check_int128_agree( incremented, na );
-        ::mas_int128_t decremented = ea;
+        ::serialize_int128_t decremented = ea;
         --decremented;
         check_int128_agree( decremented, serialize::int128_t( ua - 1 ) );
 
         // conversions: the sign extending and value preserving constructors and the truncating
         // conversion match native, from both signednesses of the drawn lane
         const int64_t seed64 = int64_t( a_lo );
-        check_int128_agree( ::mas_int128_t( seed64 ), serialize::int128_t( seed64 ) );
-        check_int128_agree( ::mas_int128_t( a_lo ), serialize::int128_t( a_lo ) );
+        check_int128_agree( ::serialize_int128_t( seed64 ), serialize::int128_t( seed64 ) );
+        check_int128_agree( ::serialize_int128_t( a_lo ), serialize::int128_t( a_lo ) );
         serialize_check( int64_t( ea ) == int64_t( uint64_t( ua ) ) );
 
         // compound forms via the unsigned domain where overflow could occur
-        ::mas_int128_t accumulator = ea;
+        ::serialize_int128_t accumulator = ea;
         accumulator += eb; check_int128_agree( accumulator, serialize::int128_t( ua + ub ) );
         accumulator = ea;
         accumulator -= eb; check_int128_agree( accumulator, serialize::int128_t( ua - ub ) );
@@ -5276,12 +5691,12 @@ inline void test_int128_differential()
     // construction differential: the exact cross signed cases the audit proved uncovered.
     // identical source expressions must construct identical values in both representations.
     {
-        check_int128_agree( ::mas_int128_t( int64_t( -1 ) ),       serialize::int128_t( int64_t( -1 ) ) );
-        check_int128_agree( ::mas_int128_t( INT64_MIN ),           serialize::int128_t( INT64_MIN ) );
-        check_int128_agree( ::mas_int128_t( uint64_t( 1 ) << 63 ), serialize::int128_t( uint64_t( 1 ) << 63 ) );
-        check_int128_agree( ::mas_int128_t( UINT64_MAX ),          serialize::int128_t( UINT64_MAX ) );
-        check_int128_agree( ::mas_int128_t( -5 ),                  serialize::int128_t( -5 ) );
-        check_int128_agree( ::mas_int128_t( 3000000000U ),         serialize::int128_t( 3000000000U ) );
+        check_int128_agree( ::serialize_int128_t( int64_t( -1 ) ),       serialize::int128_t( int64_t( -1 ) ) );
+        check_int128_agree( ::serialize_int128_t( INT64_MIN ),           serialize::int128_t( INT64_MIN ) );
+        check_int128_agree( ::serialize_int128_t( uint64_t( 1 ) << 63 ), serialize::int128_t( uint64_t( 1 ) << 63 ) );
+        check_int128_agree( ::serialize_int128_t( UINT64_MAX ),          serialize::int128_t( UINT64_MAX ) );
+        check_int128_agree( ::serialize_int128_t( -5 ),                  serialize::int128_t( -5 ) );
+        check_int128_agree( ::serialize_int128_t( 3000000000U ),         serialize::int128_t( 3000000000U ) );
     }
 }
 
@@ -5570,6 +5985,7 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_bitpacker );
         SERIALIZE_RUN_TEST( test_bits_required );
         SERIALIZE_RUN_TEST( test_bits_required64 );
+        SERIALIZE_RUN_TEST( test_bits_required128 );
         SERIALIZE_RUN_TEST( test_zigzag );
         SERIALIZE_RUN_TEST( test_serialize );
         SERIALIZE_RUN_TEST( test_read_write );
@@ -5587,6 +6003,7 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_serialize_fixed_wide );
         SERIALIZE_RUN_TEST( test_serialize_fixed_wide_emulated );
         SERIALIZE_RUN_TEST( test_serialize_uint128 );
+        SERIALIZE_RUN_TEST( test_serialize_int128 );
         SERIALIZE_RUN_TEST( test_uint128_emulation );
         SERIALIZE_RUN_TEST( test_int128_emulation );
 #if defined(__SIZEOF_INT128__)

--- a/serialize.h
+++ b/serialize.h
@@ -136,8 +136,322 @@
 #include <wchar.h>      // wcslen
 #include <math.h>       // ceil, floor
 
-namespace serialize 
+// 128 bit unsigned integer support.
+//
+// serialize::uint128_t exists on every platform. Where the compiler provides native __int128
+// (gcc, clang, clang-cl) it is unsigned __int128: the fastest representation. On compilers
+// without it (pure MSVC), serialize defines the emulated mas_uint128_t below — a full unsigned
+// 128 bit integer type with standard semantics — and announces it with the MAS_UINT128_DEFINED
+// handshake macro.
+//
+// THE SHARING CONVENTION: single header libraries cannot include each other, so this definition
+// block is carried, verbatim, by sibling projects under the same handshake (the fixed point
+// library, and games built on these libraries). Whichever header is included first defines the
+// type; everyone after sees MAS_UINT128_DEFINED and aliases it, so the type is defined exactly
+// once per translation unit instead of two or three times. The copies exist by design; the
+// handshake makes them mutually exclusive per translation unit, and the differential test
+// against native __int128 in each C++ home is what keeps every copy honest — drift fails loudly.
+//
+// The block is dual language: in C the type is the bare POD struct of two uint64_t members,
+// low half then high half, matching little endian layout and the wire order. C projects add
+// their own function wrappers in their own tree. Everything else — constructors, the full
+// operator surface, the explicit uint64_t conversion — is C++ only, inside #ifdef __cplusplus.
+//
+// Semantics match native unsigned __int128 exactly, with two documented choices where native
+// has none: shift counts outside [0,127] yield zero (native shifts by 128 or more are undefined
+// behavior), and division or modulo by zero yields zero quotient and zero remainder (this block
+// has no assert dependency by design, and deterministic zero is the safest portable behavior).
+//
+// When tests are enabled the type is defined even where native __int128 exists, so the test
+// suite can prove the emulation agrees with native operator by operator and produces byte
+// identical wire.
+
+#if !defined( MAS_UINT128_DEFINED ) && ( !defined( __SIZEOF_INT128__ ) || SERIALIZE_ENABLE_TESTS )
+
+typedef struct mas_uint128_t
 {
+    uint64_t lo;            ///< the low 64 bits. first, matching the little endian layout and the wire order
+    uint64_t hi;            ///< the high 64 bits
+
+#ifdef __cplusplus
+
+    mas_uint128_t() = default;
+
+    mas_uint128_t( uint64_t value ) : lo( value ), hi( 0 ) {}
+
+    explicit operator uint64_t () const
+    {
+        return lo;
+    }
+
+    bool operator == ( mas_uint128_t other ) const
+    {
+        return lo == other.lo && hi == other.hi;
+    }
+
+    bool operator != ( mas_uint128_t other ) const
+    {
+        return ! ( *this == other );
+    }
+
+    bool operator < ( mas_uint128_t other ) const
+    {
+        return ( hi != other.hi ) ? ( hi < other.hi ) : ( lo < other.lo );
+    }
+
+    bool operator > ( mas_uint128_t other ) const
+    {
+        return other < *this;
+    }
+
+    bool operator <= ( mas_uint128_t other ) const
+    {
+        return ! ( other < *this );
+    }
+
+    bool operator >= ( mas_uint128_t other ) const
+    {
+        return ! ( *this < other );
+    }
+
+    mas_uint128_t operator ~ () const
+    {
+        mas_uint128_t result( 0 );
+        result.lo = ~lo;
+        result.hi = ~hi;
+        return result;
+    }
+
+    mas_uint128_t operator & ( mas_uint128_t other ) const
+    {
+        mas_uint128_t result( 0 );
+        result.lo = lo & other.lo;
+        result.hi = hi & other.hi;
+        return result;
+    }
+
+    mas_uint128_t operator | ( mas_uint128_t other ) const
+    {
+        mas_uint128_t result( 0 );
+        result.lo = lo | other.lo;
+        result.hi = hi | other.hi;
+        return result;
+    }
+
+    mas_uint128_t operator ^ ( mas_uint128_t other ) const
+    {
+        mas_uint128_t result( 0 );
+        result.lo = lo ^ other.lo;
+        result.hi = hi ^ other.hi;
+        return result;
+    }
+
+    mas_uint128_t operator << ( int shift ) const
+    {
+        // shifting a uint64 lane by 64 is undefined behavior, so the half boundary is an explicit
+        // branch. shift counts outside [0,127] yield zero, documented above.
+        mas_uint128_t result( 0 );
+        if ( shift == 0 )
+        {
+            result = *this;
+        }
+        else if ( shift > 0 && shift < 64 )
+        {
+            result.hi = ( hi << shift ) | ( lo >> ( 64 - shift ) );
+            result.lo = lo << shift;
+        }
+        else if ( shift >= 64 && shift < 128 )
+        {
+            result.hi = lo << ( shift - 64 );
+            result.lo = 0;
+        }
+        return result;
+    }
+
+    mas_uint128_t operator >> ( int shift ) const
+    {
+        // shifting a uint64 lane by 64 is undefined behavior, so the half boundary is an explicit
+        // branch. shift counts outside [0,127] yield zero, documented above.
+        mas_uint128_t result( 0 );
+        if ( shift == 0 )
+        {
+            result = *this;
+        }
+        else if ( shift > 0 && shift < 64 )
+        {
+            result.lo = ( lo >> shift ) | ( hi << ( 64 - shift ) );
+            result.hi = hi >> shift;
+        }
+        else if ( shift >= 64 && shift < 128 )
+        {
+            result.lo = hi >> ( shift - 64 );
+            result.hi = 0;
+        }
+        return result;
+    }
+
+    mas_uint128_t operator + ( mas_uint128_t other ) const
+    {
+        mas_uint128_t result( 0 );
+        result.lo = lo + other.lo;
+        result.hi = hi + other.hi + ( ( result.lo < lo ) ? 1 : 0 );         // carry out of the low lane
+        return result;
+    }
+
+    mas_uint128_t operator - ( mas_uint128_t other ) const
+    {
+        mas_uint128_t result( 0 );
+        result.lo = lo - other.lo;
+        result.hi = hi - other.hi - ( ( lo < other.lo ) ? 1 : 0 );          // borrow out of the low lane
+        return result;
+    }
+
+    mas_uint128_t operator * ( mas_uint128_t other ) const
+    {
+        // schoolbook multiplication in 32 bit limbs over the uint64 lanes: the low 64 x 64 product
+        // is computed exactly, then the cross products fold into the high lane modulo 2^64
+        const uint64_t a_low = lo & 0xFFFFFFFFULL;
+        const uint64_t a_high = lo >> 32;
+        const uint64_t b_low = other.lo & 0xFFFFFFFFULL;
+        const uint64_t b_high = other.lo >> 32;
+
+        const uint64_t product_ll = a_low * b_low;
+        const uint64_t product_lh = a_low * b_high;
+        const uint64_t product_hl = a_high * b_low;
+        const uint64_t product_hh = a_high * b_high;
+
+        const uint64_t carry = ( ( product_ll >> 32 ) + ( product_lh & 0xFFFFFFFFULL ) + ( product_hl & 0xFFFFFFFFULL ) ) >> 32;
+
+        mas_uint128_t result( 0 );
+        result.lo = product_ll + ( product_lh << 32 ) + ( product_hl << 32 );
+        result.hi = product_hh + ( product_lh >> 32 ) + ( product_hl >> 32 ) + carry;
+        result.hi += lo * other.hi + hi * other.lo;
+        return result;
+    }
+
+    static void DivMod( mas_uint128_t dividend, mas_uint128_t divisor, mas_uint128_t & quotient, mas_uint128_t & remainder )
+    {
+        // shift subtract long division. division by zero yields zero quotient and zero remainder,
+        // documented above: this block has no assert dependency by design.
+        quotient = mas_uint128_t( 0 );
+        remainder = mas_uint128_t( 0 );
+        if ( divisor == mas_uint128_t( 0 ) )
+        {
+            return;
+        }
+        if ( dividend.hi == 0 && divisor.hi == 0 )
+        {
+            quotient = mas_uint128_t( dividend.lo / divisor.lo );
+            remainder = mas_uint128_t( dividend.lo % divisor.lo );
+            return;
+        }
+        for ( int i = 127; i >= 0; i-- )
+        {
+            remainder = remainder << 1;
+            remainder.lo |= ( dividend >> i ).lo & 1;
+            if ( remainder >= divisor )
+            {
+                remainder = remainder - divisor;
+                quotient = quotient | ( mas_uint128_t( 1 ) << i );
+            }
+        }
+    }
+
+    mas_uint128_t operator / ( mas_uint128_t other ) const
+    {
+        mas_uint128_t quotient( 0 );
+        mas_uint128_t remainder( 0 );
+        DivMod( *this, other, quotient, remainder );
+        return quotient;
+    }
+
+    mas_uint128_t operator % ( mas_uint128_t other ) const
+    {
+        mas_uint128_t quotient( 0 );
+        mas_uint128_t remainder( 0 );
+        DivMod( *this, other, quotient, remainder );
+        return remainder;
+    }
+
+    mas_uint128_t operator + () const
+    {
+        return *this;
+    }
+
+    mas_uint128_t operator - () const
+    {
+        return mas_uint128_t( 0 ) - *this;
+    }
+
+    mas_uint128_t & operator += ( mas_uint128_t other ) { *this = *this + other; return *this; }
+    mas_uint128_t & operator -= ( mas_uint128_t other ) { *this = *this - other; return *this; }
+    mas_uint128_t & operator *= ( mas_uint128_t other ) { *this = *this * other; return *this; }
+    mas_uint128_t & operator /= ( mas_uint128_t other ) { *this = *this / other; return *this; }
+    mas_uint128_t & operator %= ( mas_uint128_t other ) { *this = *this % other; return *this; }
+    mas_uint128_t & operator &= ( mas_uint128_t other ) { *this = *this & other; return *this; }
+    mas_uint128_t & operator |= ( mas_uint128_t other ) { *this = *this | other; return *this; }
+    mas_uint128_t & operator ^= ( mas_uint128_t other ) { *this = *this ^ other; return *this; }
+    mas_uint128_t & operator <<= ( int shift )          { *this = *this << shift; return *this; }
+    mas_uint128_t & operator >>= ( int shift )          { *this = *this >> shift; return *this; }
+
+    mas_uint128_t & operator ++ ()
+    {
+        *this = *this + mas_uint128_t( 1 );
+        return *this;
+    }
+
+    mas_uint128_t operator ++ ( int )
+    {
+        mas_uint128_t before = *this;
+        ++( *this );
+        return before;
+    }
+
+    mas_uint128_t & operator -- ()
+    {
+        *this = *this - mas_uint128_t( 1 );
+        return *this;
+    }
+
+    mas_uint128_t operator -- ( int )
+    {
+        mas_uint128_t before = *this;
+        --( *this );
+        return before;
+    }
+
+#endif // #ifdef __cplusplus
+
+} mas_uint128_t;
+
+#define MAS_UINT128_DEFINED 1
+
+#endif // #if !defined( MAS_UINT128_DEFINED ) && ( !defined( __SIZEOF_INT128__ ) || SERIALIZE_ENABLE_TESTS )
+
+namespace serialize
+{
+#if defined(__SIZEOF_INT128__)
+
+    /**
+        Native 128 bit integer types, where the compiler provides them (gcc, clang, clang-cl).
+        int128_t is the storage type for wide fixed point (Q112.16 and friends). uint128_t is the 128 bit wire interchange type: native here, and the emulated ::mas_uint128_t on compilers without __int128, so serialize::uint128_t exists on every platform.
+        __extension__ keeps -Wpedantic quiet: __int128 is a language extension.
+     */
+
+    __extension__ typedef          __int128  int128_t;
+    __extension__ typedef unsigned __int128 uint128_t;
+
+#else // #if defined(__SIZEOF_INT128__)
+
+    /**
+        The 128 bit wire interchange type on compilers without native __int128: the emulated ::mas_uint128_t.
+        See the comment block on mas_uint128_t above for the sharing convention between projects.
+     */
+
+    typedef ::mas_uint128_t uint128_t;
+
+#endif // #if defined(__SIZEOF_INT128__)
+
     /**
         Calculates the population count of an unsigned 32 bit integer at compile time.
         Population count is the number of bits in the integer that set to 1.
@@ -187,6 +501,65 @@ namespace serialize
     {
         static const uint32_t result = ( min == max ) ? 0 : ( Log2<uint32_t(max-min)>::result + 1 );
     };
+
+    /**
+        Calculates the number of bits needed to represent an unsigned 64 bit integer at compile time.
+        This is floor( log2( x ) ) + 1, and zero for an input of zero.
+        @see serialize::BitsRequired64
+     */
+
+    template <uint64_t x> struct BitCount64
+    {
+        static const int result = 1 + BitCount64< ( x >> 1 ) >::result;
+    };
+
+    template <> struct BitCount64<0>
+    {
+        static const int result = 0;
+    };
+
+    /**
+        Calculates the number of bits required to serialize a 64 bit integer value in [min,max] at compile time.
+        The subtraction is performed in the unsigned domain, so ranges wider than 2^63 work.
+        @see serialize::BitsRequired
+        @see serialize::bits_required64
+     */
+
+    template <uint64_t min, uint64_t max> struct BitsRequired64
+    {
+        static const int result = BitCount64< max - min >::result;
+    };
+
+#if defined(__SIZEOF_INT128__)
+
+    /**
+        Calculates the number of bits needed to represent an unsigned 128 bit integer at compile time.
+        This is floor( log2( x ) ) + 1, and zero for an input of zero.
+        @see serialize::BitsRequired128
+     */
+
+    template <uint128_t x> struct BitCount128
+    {
+        static const int result = 1 + BitCount128< ( x >> 1 ) >::result;
+    };
+
+    template <> struct BitCount128<0>
+    {
+        static const int result = 0;
+    };
+
+    /**
+        Calculates the number of bits required to serialize a 128 bit integer value in [min,max] at compile time.
+        The subtraction is performed in the unsigned domain, so ranges wider than 2^127 work.
+        @see serialize::BitsRequired64
+     */
+
+    template <uint128_t min, uint128_t max> struct BitsRequired128
+    {
+        static const int result = BitCount128< max - min >::result;
+    };
+
+#endif // #if defined(__SIZEOF_INT128__)
 
     /**
         Calculates the population count of an unsigned 32 bit integer.
@@ -1668,6 +2041,53 @@ namespace serialize
     #define serialize_uint64( stream, value ) serialize_bits( stream, value, 64 )
 
     /**
+        Serialize a 128 bit unsigned integer (read/write/measure), templated over the 128 bit type.
+        The wire format is 128 bits raw: the low 64 bit half first, then the high half, following the lo-then-hi convention of serialize_bits.
+        UInt128 may be the native unsigned __int128 (see serialize::uint128_t) or an emulated 128 bit unsigned integer type on compilers without native support, such as pure MSVC.
+        The requirements on UInt128 are exactly: construction from uint64_t, operator\<\< and operator\>\> with int shift counts, operator|, and explicit conversion (static_cast) to uint64_t truncating to the low 64 bits.
+        This function is a template and only compiles when instantiated, so it is available on every compiler; only the serialize::uint128_t convenience typedef needs the __SIZEOF_INT128__ guard.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The 128 bit unsigned integer value.
+        @returns True if the serialize succeeded, false otherwise.
+     */
+
+    template <typename Stream, typename UInt128> bool serialize_uint128_internal( Stream & stream, UInt128 & value )
+    {
+        uint64_t low_half = 0;
+        uint64_t high_half = 0;
+        if ( Stream::IsWriting )
+        {
+            low_half = uint64_t( value );
+            high_half = uint64_t( value >> 64 );
+        }
+        serialize_bits( stream, low_half, 64 );
+        serialize_bits( stream, high_half, 64 );
+        if ( Stream::IsReading )
+        {
+            value = ( UInt128( high_half ) << 64 ) | UInt128( low_half );
+        }
+        return true;
+    }
+
+    /**
+        Serialize unsigned 128 bit integer (read/write/measure).
+        The wire format is 128 bits raw: the low 64 bit half first, then the high half, following the lo-then-hi convention of serialize_bits.
+        The value may be the native unsigned __int128 (serialize::uint128_t, behind the __SIZEOF_INT128__ guard) or any emulated 128 bit unsigned integer type meeting the requirements documented on serialize_uint128_internal, so the operation works on compilers without native 128 bit support too. All representations produce identical bytes.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The 128 bit unsigned integer value.
+     */
+
+    #define serialize_uint128( stream, value )                                      \
+        do                                                                          \
+        {                                                                           \
+            if ( !serialize::serialize_uint128_internal( stream, value ) )          \
+            {                                                                       \
+                return false;                                                       \
+            }                                                                       \
+        } while (0)
+
+    /**
         Serialize an array of bytes to the stream (read/write/measure).
         This is a helper macro to make unified serialize functions easier.
         Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
@@ -1962,6 +2382,267 @@ namespace serialize
             }                                                                               \
         } while (0)
 
+    /**
+        Compile time trait marking the integer types usable as fixed point storage.
+        Written locally because std::is_integral is not guaranteed to cover __int128 on every compiler, and this header does not include \<type_traits\>.
+     */
+
+    template <typename T> struct FixedPointInteger                  { enum { is_integer = 0, is_signed = 0 }; };
+    template <> struct FixedPointInteger<signed char>               { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<unsigned char>             { enum { is_integer = 1, is_signed = 0 }; };
+    template <> struct FixedPointInteger<short>                     { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<unsigned short>            { enum { is_integer = 1, is_signed = 0 }; };
+    template <> struct FixedPointInteger<int>                       { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<unsigned int>              { enum { is_integer = 1, is_signed = 0 }; };
+    template <> struct FixedPointInteger<long>                      { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<unsigned long>             { enum { is_integer = 1, is_signed = 0 }; };
+    template <> struct FixedPointInteger<long long>                 { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<unsigned long long>        { enum { is_integer = 1, is_signed = 0 }; };
+#if defined(__SIZEOF_INT128__)
+    template <> struct FixedPointInteger<int128_t>                  { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<uint128_t>                 { enum { is_integer = 1, is_signed = 0 }; };
+#endif // #if defined(__SIZEOF_INT128__)
+
+    /**
+        Fixed point codec, specialized on storage width.
+        The false specialization covers storage of 64 bits or fewer and works entirely in the 64 bit unsigned domain.
+        The true specialization covers 128 bit storage and lives behind the __SIZEOF_INT128__ guard, so compilers without __int128 never see 128 bit code.
+        Splitting on width keeps every shift and every compile time bit count valid for the domain it runs in.
+        IMPORTANT: Generally, you don't use this directly. Use the serialize_fixed, read_fixed and write_fixed macros instead.
+     */
+
+    template <bool WideStorage> struct FixedPointSerializer;
+
+    template <> struct FixedPointSerializer<false>
+    {
+        template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Stream, typename Storage>
+        static bool Serialize( Stream & stream, Storage & value )
+        {
+            // the whole unit capacity of the Q format. computed in the unsigned domain so the widest formats (Q64.0 and friends) cannot overflow signed arithmetic
+            const int64_t min_representable_units = FixedPointInteger<Storage>::is_signed ?
+                int64_t( uint64_t(0) - ( uint64_t(1) << ( IntegerBits - 1 ) ) ) : int64_t(0);
+            const int64_t max_representable_units = FixedPointInteger<Storage>::is_signed ?
+                int64_t( ( uint64_t(1) << ( IntegerBits - 1 ) ) - 1 ) :
+                ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( IntegerBits < 64 ? IntegerBits : 0 ) ) - 1 ) );
+
+            static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
+            static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
+
+            // shift the whole unit bounds into raw fixed point units in the unsigned domain, so negative bounds wrap two's complement instead of invoking undefined behavior.
+            // everything below is a compile time constant: the bounds, the range and the bit count all fold, so the call site carries no runtime bit width computation at all.
+            const uint64_t raw_min = uint64_t( MinUnits ) << FractionalBits;
+            const uint64_t raw_max = uint64_t( MaxUnits ) << FractionalBits;
+            const uint64_t raw_range = raw_max - raw_min;
+
+            const int bits = BitsRequired64<raw_min, raw_max>::result;
+
+            uint64_t offset = 0;
+
+            if ( Stream::IsWriting )
+            {
+                // subtract in the unsigned domain: raw - raw_min overflows signed arithmetic when the range is wider than 2^63
+                offset = uint64_t( value ) - raw_min;
+                serialize_assert( offset <= raw_range );        // the value must be within [min,max] whole units. all checking is performed by debug asserts on write
+            }
+
+            if ( bits <= 32 )
+            {
+                uint32_t unsigned_value = uint32_t( offset );
+                if ( !stream.SerializeBits( unsigned_value, bits ) )
+                {
+                    return false;
+                }
+                offset = unsigned_value;
+            }
+            else
+            {
+                // low dword first, then the high remainder: same convention as serialize_bits and serialize_int64
+                uint32_t low_half = uint32_t( offset & 0xFFFFFFFF );
+                uint32_t high_half = uint32_t( offset >> 32 );
+                if ( !stream.SerializeBits( low_half, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( high_half, bits - 32 ) )
+                {
+                    return false;
+                }
+                offset = ( uint64_t( high_half ) << 32 ) | low_half;
+            }
+
+            if ( Stream::IsReading )
+            {
+                // reject raw values outside [raw_min,raw_max] smuggled into the bit headroom. reject, never clamp
+                if ( offset > raw_range )
+                {
+                    return false;
+                }
+                // reconstruct in the unsigned domain, then convert: wraps two's complement for signed storage
+                value = Storage( raw_min + offset );
+            }
+
+            return true;
+        }
+    };
+
+#if defined(__SIZEOF_INT128__)
+
+    template <> struct FixedPointSerializer<true>
+    {
+        template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Stream, typename Storage>
+        static bool Serialize( Stream & stream, Storage & value )
+        {
+            // the whole unit capacity of the Q format. computed in the unsigned domain so the widest formats cannot overflow signed arithmetic
+            const int128_t min_representable_units = FixedPointInteger<Storage>::is_signed ?
+                int128_t( uint128_t(0) - ( uint128_t(1) << ( IntegerBits - 1 ) ) ) : int128_t(0);
+            const int128_t max_representable_units = FixedPointInteger<Storage>::is_signed ?
+                int128_t( ( uint128_t(1) << ( IntegerBits - 1 ) ) - 1 ) :
+                ( ( IntegerBits >= 64 ) ? int128_t( INT64_MAX ) : int128_t( ( uint128_t(1) << ( IntegerBits < 64 ? IntegerBits : 0 ) ) - 1 ) );
+
+            static_assert( int128_t( MinUnits ) >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
+            static_assert( int128_t( MaxUnits ) <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
+
+            // shift the whole unit bounds into raw fixed point units in the 128 bit unsigned domain, so negative bounds wrap two's complement instead of invoking undefined behavior.
+            // everything below is a compile time constant: the bounds, the range, the bit count and the group structure all fold.
+            const uint128_t raw_min = uint128_t( int128_t( MinUnits ) ) << FractionalBits;
+            const uint128_t raw_max = uint128_t( int128_t( MaxUnits ) ) << FractionalBits;
+            const uint128_t raw_range = raw_max - raw_min;
+
+            const int bits = BitsRequired128<raw_min, raw_max>::result;
+
+            uint128_t offset = 0;
+
+            if ( Stream::IsWriting )
+            {
+                // subtract in the unsigned domain: raw - raw_min overflows signed arithmetic when the range is wider than 2^127
+                offset = uint128_t( value ) - raw_min;
+                serialize_assert( offset <= raw_range );        // the value must be within [min,max] whole units. all checking is performed by debug asserts on write
+            }
+
+            // the offset is written in 32 bit groups, least significant group first: the same convention as serialize_bits.
+            // the group structure is selected at compile time, so each SerializeBits call receives a constant bit count.
+            uint32_t group0 = 0;
+            uint32_t group1 = 0;
+            uint32_t group2 = 0;
+            uint32_t group3 = 0;
+
+            if ( Stream::IsWriting )
+            {
+                group0 = uint32_t( uint64_t( offset )       & 0xFFFFFFFF );
+                group1 = uint32_t( uint64_t( offset >> 32 ) & 0xFFFFFFFF );
+                group2 = uint32_t( uint64_t( offset >> 64 ) & 0xFFFFFFFF );
+                group3 = uint32_t( uint64_t( offset >> 96 ) & 0xFFFFFFFF );
+            }
+
+            if ( bits <= 32 )
+            {
+                if ( !stream.SerializeBits( group0, bits ) )
+                {
+                    return false;
+                }
+            }
+            else if ( bits <= 64 )
+            {
+                if ( !stream.SerializeBits( group0, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group1, bits - 32 ) )
+                {
+                    return false;
+                }
+            }
+            else if ( bits <= 96 )
+            {
+                if ( !stream.SerializeBits( group0, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group1, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group2, bits - 64 ) )
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if ( !stream.SerializeBits( group0, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group1, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group2, 32 ) )
+                {
+                    return false;
+                }
+                if ( !stream.SerializeBits( group3, bits - 96 ) )
+                {
+                    return false;
+                }
+            }
+
+            if ( Stream::IsReading )
+            {
+                offset = ( uint128_t( group3 ) << 96 ) | ( uint128_t( group2 ) << 64 ) | ( uint128_t( group1 ) << 32 ) | group0;
+
+                // reject raw values outside [raw_min,raw_max] smuggled into the bit headroom. reject, never clamp
+                if ( offset > raw_range )
+                {
+                    return false;
+                }
+                // reconstruct in the unsigned domain, then convert: wraps two's complement for signed storage
+                value = Storage( raw_min + offset );
+            }
+
+            return true;
+        }
+    };
+
+#endif // #if defined(__SIZEOF_INT128__)
+
+    template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Stream, typename Storage>
+    bool serialize_fixed_internal( Stream & stream, Storage & value )
+    {
+        static_assert( FixedPointInteger<Storage>::is_integer == 1, "serialize_fixed storage must be an integer type" );
+        static_assert( IntegerBits >= 1, "serialize_fixed needs at least one integer bit. the sign bit counts for signed storage" );
+        static_assert( FractionalBits >= 0, "serialize_fixed fractional bits can't be negative" );
+        static_assert( IntegerBits + FractionalBits == 8 * (int) sizeof( Storage ), "serialize_fixed integer bits plus fractional bits must equal the number of bits in the storage type" );
+        static_assert( MinUnits < MaxUnits, "serialize_fixed min must be below max" );
+
+        return FixedPointSerializer< ( 8 * (int) sizeof( Storage ) > 64 ) >::template Serialize<IntegerBits, FractionalBits, MinUnits, MaxUnits>( stream, value );
+    }
+
+    /**
+        Serialize a fixed point value to the stream (read/write/measure).
+        This is a helper macro to make writing unified serialize functions easier.
+        The Q format and the bounds are compile time constants: integer_bits plus fraction_bits must equal the number of bits in the storage type, with the sign bit counting towards integer_bits for signed storage. For example, Q48.16 in an int64_t is ( 48, 16 ) and Q112.16 in an __int128 is ( 112, 16 ). Any integer storage type works, including __int128 where the compiler provides it.
+        The bounds are whole units and must be constant expressions: a runtime bound fails to compile, and bounds that don't fit the Q format fail with a static assert. The value is serialized as an offset from min in the minimal number of bits for the range — a constant of the call site — and the round trip is exact: fixed point values are integers underneath, so unlike compressed floats there is no quantization error and results are identical across platforms.
+        For storage of 64 bits or fewer the wire format is byte identical to serialize_int64 of the raw value over the raw bounds.
+        Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
+        IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
+        @param stream The stream object. May be a read, write or measure stream.
+        @param value The fixed point value to serialize, in [min,max] whole units. The storage type sets the width of the Q format.
+        @param integer_bits The number of integer bits in the Q format, including the sign bit for signed storage. Compile time constant.
+        @param fraction_bits The number of fractional bits in the Q format. Compile time constant.
+        @param min The minimum value in whole units. Compile time constant.
+        @param max The maximum value in whole units. Compile time constant.
+     */
+
+    #define serialize_fixed( stream, value, integer_bits, fraction_bits, min, max )                                 \
+        do                                                                                                          \
+        {                                                                                                           \
+            if ( !serialize::serialize_fixed_internal<integer_bits, fraction_bits, min, max>( stream, value ) )     \
+            {                                                                                                       \
+                return false;                                                                                       \
+            }                                                                                                       \
+        } while (0)
+
     // read macros corresponding to each serialize_*. useful when you want separate read and write functions.
 
     #define read_bits( stream, value, bits )                                                \
@@ -2026,11 +2707,33 @@ namespace serialize
             }                                                                               \
         } while (0)
 
+    #define read_fixed( stream, value, integer_bits, fraction_bits, min, max )                                  \
+        do                                                                                                      \
+        {                                                                                                       \
+            if ( !serialize::serialize_fixed_internal<integer_bits, fraction_bits, min, max>( stream, value ) ) \
+            {                                                                                                   \
+                return false;                                                                                   \
+            }                                                                                                   \
+        } while (0)
+
     #define read_bool( stream, value )      read_bits( stream, value, 1 )
     #define read_uint8( stream, value )     read_bits( stream, value, 8 )
     #define read_uint16( stream, value )    read_bits( stream, value, 16 )
     #define read_uint32( stream, value )    read_bits( stream, value, 32 )
     #define read_uint64( stream, value )    read_bits( stream, value, 64 )
+
+#if defined(__SIZEOF_INT128__)
+
+    #define read_uint128( stream, value )                                                   \
+        do                                                                                  \
+        {                                                                                   \
+            if ( !serialize::serialize_uint128_internal( stream, value ) )                  \
+            {                                                                               \
+                return false;                                                               \
+            }                                                                               \
+        } while (0)
+
+#endif // #if defined(__SIZEOF_INT128__)
 
     #define read_float                  serialize_float
     #define read_double                 serialize_double
@@ -2110,11 +2813,28 @@ namespace serialize
             stream.SerializeInteger64( int64_value, min, max );                             \
         } while (0)
 
+    #define write_fixed( stream, value, integer_bits, fraction_bits, min, max )                                 \
+        do                                                                                                      \
+        {                                                                                                       \
+            serialize::serialize_fixed_internal<integer_bits, fraction_bits, min, max>( stream, value );        \
+        } while (0)
+
     #define write_bool( stream, value )         write_bits( stream, value, 1 )
     #define write_uint8( stream, value )        write_bits( stream, value, 8 )
     #define write_uint16( stream, value )       write_bits( stream, value, 16 )
     #define write_uint32( stream, value )       write_bits( stream, value, 32 )
     #define write_uint64( stream, value )       write_bits( stream, value, 64 )
+
+#if defined(__SIZEOF_INT128__)
+
+    #define write_uint128( stream, value )                                                  \
+        do                                                                                  \
+        {                                                                                   \
+            serialize::uint128_t uint128_value = ( value );                                 \
+            serialize::serialize_uint128_internal( stream, uint128_value );                 \
+        } while (0)
+
+#endif // #if defined(__SIZEOF_INT128__)
 
     #define write_float( stream, value )                                                    \
         do                                                                                  \
@@ -2604,6 +3324,20 @@ bool ReadFunction( serialize::ReadStream & readStream )
     }
 
     {
+        int64_t value = 0;
+        read_fixed( readStream, value, 48, 16, -100000, +100000 );
+        serialize_check( value == int64_t( 12345 ) * 65536 + 32768 );       // 12345.5 in Q48.16
+    }
+
+#if defined(__SIZEOF_INT128__)
+    {
+        serialize::uint128_t value = 0;
+        read_uint128( readStream, value );
+        serialize_check( value == ( ( serialize::uint128_t( 0x0123456789ABCDEFULL ) << 64 ) | 0xFEDCBA9876543210ULL ) );
+    }
+#endif // #if defined(__SIZEOF_INT128__)
+
+    {
         float value;
         read_float( readStream, value );
         serialize_check( value == 100.0f );
@@ -2697,6 +3431,15 @@ inline void test_read_write()
         write_uint64( writeStream, 0xFFFFFFFFFFFFFFFFULL );
         write_int( writeStream, 55, 10, 90 );
         write_int64( writeStream, -50000000001LL, -60000000000LL, 60000000000LL );
+
+        int64_t fixed_point_value = int64_t( 12345 ) * 65536 + 32768;               // 12345.5 in Q48.16
+        write_fixed( writeStream, fixed_point_value, 48, 16, -100000, +100000 );
+
+#if defined(__SIZEOF_INT128__)
+        serialize::uint128_t big_value = ( serialize::uint128_t( 0x0123456789ABCDEFULL ) << 64 ) | 0xFEDCBA9876543210ULL;
+        write_uint128( writeStream, big_value );
+#endif // #if defined(__SIZEOF_INT128__)
+
         write_float( writeStream, 100.0f );
         write_double( writeStream, 1000000000.0f );
 
@@ -3111,6 +3854,407 @@ inline void test_compressed_float_validation()
     }
 }
 
+// Fixed point test helpers. Every configuration in the matrix runs the same case list, and every
+// round trip also runs the measure stream and requires exact agreement with the write stream:
+// fixed point serialization involves no alignment, so measure is exact, not just conservative.
+
+template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Storage>
+inline void check_fixed_round_trip( Storage raw_value )
+{
+    uint8_t buffer[32 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+    serialize::WriteStream writeStream( buffer, 32 );
+    Storage written = raw_value;
+    serialize_check( ( serialize::serialize_fixed_internal<IntegerBits, FractionalBits, MinUnits, MaxUnits>( writeStream, written ) ) == true );
+    writeStream.Flush();
+
+    serialize::MeasureStream measureStream;
+    Storage measured = raw_value;
+    serialize_check( ( serialize::serialize_fixed_internal<IntegerBits, FractionalBits, MinUnits, MaxUnits>( measureStream, measured ) ) == true );
+    serialize_check( measureStream.GetBitsProcessed() == writeStream.GetBitsProcessed() );
+
+    serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+    Storage read_back = 0;
+    serialize_check( ( serialize::serialize_fixed_internal<IntegerBits, FractionalBits, MinUnits, MaxUnits>( readStream, read_back ) ) == true );
+    serialize_check( read_back == raw_value );
+}
+
+template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Storage>
+inline void check_fixed_cases( Storage one_unit )
+{
+    const Storage raw_min = Storage( MinUnits * one_unit );
+    const Storage raw_max = Storage( MaxUnits * one_unit );
+
+    // exact raw bounds, and one raw step inside each
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( raw_min );
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( raw_max );
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( raw_min + 1 ) );
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( raw_max - 1 ) );
+
+    // whole unit values one unit inside each bound
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( ( MinUnits + 1 ) * one_unit ) );
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( ( MaxUnits - 1 ) * one_unit ) );
+
+    // a value with every fraction bit set
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( raw_min + one_unit - 1 ) );
+
+    // the middle of the range, computed without overflowing the storage type
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( raw_min / 2 + raw_max / 2 ) );
+
+    // zero, one and minus one whole units, where the bounds allow them
+    if ( MinUnits <= 0 && MaxUnits >= 0 )
+    {
+        check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( 0 ) );
+    }
+    if ( MinUnits <= 1 && MaxUnits >= 1 )
+    {
+        check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( one_unit );
+    }
+    if ( MinUnits <= -1 && MaxUnits >= -1 )
+    {
+        check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( Storage( 0 ) - one_unit ) );
+    }
+}
+
+template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Storage>
+inline void check_fixed_rejects_out_of_range( Storage )
+{
+    // recompute the wire parameters independently of the codec, then hand build a stream encoding
+    // an offset of exactly raw_range + 1: one raw step past raw_max, smuggled into the bit headroom
+    const uint64_t raw_range = ( uint64_t( MaxUnits ) << FractionalBits ) - ( uint64_t( MinUnits ) << FractionalBits );
+    const int bits = serialize::bits_required64( 0, raw_range );
+
+    const uint64_t max_encodable = ( bits < 64 ) ? ( ( uint64_t(1) << bits ) - 1 ) : 0xFFFFFFFFFFFFFFFFULL;
+    if ( raw_range == max_encodable )
+    {
+        return;                             // no headroom: every encoding decodes in range for this configuration
+    }
+
+    const uint64_t smuggled = raw_range + 1;
+
+    uint8_t buffer[16 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+    serialize::WriteStream writeStream( buffer, 16 );
+    if ( bits <= 32 )
+    {
+        writeStream.SerializeBits( uint32_t( smuggled ), bits );
+    }
+    else
+    {
+        writeStream.SerializeBits( uint32_t( smuggled & 0xFFFFFFFF ), 32 );
+        writeStream.SerializeBits( uint32_t( smuggled >> 32 ), bits - 32 );
+    }
+    writeStream.Flush();
+
+    serialize::ReadStream readStream( buffer, 16 );
+    Storage value = 0;
+    serialize_check( ( serialize::serialize_fixed_internal<IntegerBits, FractionalBits, MinUnits, MaxUnits>( readStream, value ) ) == false );
+}
+
+inline void test_serialize_fixed()
+{
+    // the storage x Q format matrix. every configuration runs the full case list in check_fixed_cases:
+    // exact raw bounds, one raw step inside each, whole unit values inside each bound, all fraction
+    // bits set, the middle of the range, and zero / +1.0 / -1.0 units where the bounds allow them.
+
+    // int16_t
+    check_fixed_cases<8, 8, -100, +100>( int16_t( 256 ) );
+    check_fixed_cases<12, 4, -2000, +2000>( int16_t( 16 ) );
+
+    // int32_t
+    check_fixed_cases<16, 16, -30000, +30000>( int32_t( 65536 ) );
+    check_fixed_cases<24, 8, -8000000, +8000000>( int32_t( 256 ) );
+    check_fixed_cases<32, 0, -100000, +100000>( int32_t( 1 ) );                                 // pure integer Q: fraction_bits == 0 is legal
+
+    // int64_t
+    check_fixed_cases<48, 16, -100000000000LL, +100000000000LL>( int64_t( 65536 ) );
+    check_fixed_cases<32, 32, -1000000, +1000000>( int64_t( 1 ) << 32 );
+    check_fixed_cases<64, 0, -5000000000LL, +5000000000LL>( int64_t( 1 ) );                     // pure integer Q at full width
+
+    // unsigned storage
+    check_fixed_cases<16, 0, 0, 60000>( uint16_t( 1 ) );
+    check_fixed_cases<16, 16, 0, 60000>( uint32_t( 65536 ) );
+    check_fixed_cases<48, 16, 0, 1000000000>( uint64_t( 65536 ) );
+
+    // single unit range: the whole wire is the fractional part
+    check_fixed_cases<16, 16, 0, 1>( int32_t( 65536 ) );
+
+    // asymmetric bounds
+    check_fixed_cases<48, 16, -3, +100000>( int64_t( 65536 ) );
+
+    // the wire cost is a compile time constant of the call site. pin a few
+    {
+        uint8_t buffer[16];
+        serialize::WriteStream stream( buffer, 16 );
+        int64_t value = int64_t( 12345 ) * 65536 + 32768;                                       // 12345.5 in Q48.16
+        serialize_check( ( serialize::serialize_fixed_internal<48, 16, -100000, +100000>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 34 );         // 200000 << 16 raw values needs 34 bits
+    }
+    {
+        uint8_t buffer[8];
+        serialize::WriteStream stream( buffer, 8 );
+        int32_t value = 65536 / 2;                                                              // 0.5 in Q16.16
+        serialize_check( ( serialize::serialize_fixed_internal<16, 16, 0, 1>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 17 );         // 1 << 16 raw values needs 17 bits
+    }
+    {
+        uint8_t buffer[8];
+        serialize::WriteStream stream( buffer, 8 );
+        int16_t value = -832;                                                                   // -3.25 in Q8.8
+        serialize_check( ( serialize::serialize_fixed_internal<8, 8, -100, +100>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 16 );         // 200 << 8 raw values needs 16 bits
+    }
+
+    // compile time refusals. each of the following fails with a static_assert, which is the point.
+    // kept as comments because a compile failure can't run inside the suite: uncomment one to verify.
+    //
+    //     int32_t value = 0;
+    //     serialize::serialize_fixed_internal<16, 8, 0, 100>( stream, value );                 // 16 + 8 != 32: the Q format doesn't fill the storage type
+    //     serialize::serialize_fixed_internal<16, 16, -40000, +40000>( stream, value );        // bounds exceed the Q16.16 whole unit capacity [-32768,32767]
+    //     serialize::serialize_fixed_internal<16, 16, 100, 100>( stream, value );              // min must be below max
+    //     float not_an_integer = 0.0f;
+    //     serialize::serialize_fixed_internal<16, 16, 0, 100>( stream, not_an_integer );       // storage must be an integer type
+    //     int runtime_bound = 100;
+    //     serialize_fixed( stream, value, 16, 16, 0, runtime_bound );                          // bounds must be compile time constants
+}
+
+inline void test_serialize_fixed_validation()
+{
+    // a malicious packet can smuggle a raw value past raw_max into the bit headroom of the offset
+    // encoding. reads must reject one raw step past the top of the range, on every configuration
+    // in the matrix that has headroom.
+    check_fixed_rejects_out_of_range<8, 8, -100, +100>( int16_t( 0 ) );
+    check_fixed_rejects_out_of_range<12, 4, -2000, +2000>( int16_t( 0 ) );
+    check_fixed_rejects_out_of_range<16, 16, -30000, +30000>( int32_t( 0 ) );
+    check_fixed_rejects_out_of_range<24, 8, -8000000, +8000000>( int32_t( 0 ) );
+    check_fixed_rejects_out_of_range<32, 0, -100000, +100000>( int32_t( 0 ) );
+    check_fixed_rejects_out_of_range<48, 16, -100000000000LL, +100000000000LL>( int64_t( 0 ) );
+    check_fixed_rejects_out_of_range<32, 32, -1000000, +1000000>( int64_t( 0 ) );
+    check_fixed_rejects_out_of_range<64, 0, -5000000000LL, +5000000000LL>( int64_t( 0 ) );
+    check_fixed_rejects_out_of_range<16, 0, 0, 60000>( uint16_t( 0 ) );
+    check_fixed_rejects_out_of_range<16, 16, 0, 60000>( uint32_t( 0 ) );
+    check_fixed_rejects_out_of_range<48, 16, 0, 1000000000>( uint64_t( 0 ) );
+    check_fixed_rejects_out_of_range<16, 16, 0, 1>( int32_t( 0 ) );
+    check_fixed_rejects_out_of_range<48, 16, -3, +100000>( int64_t( 0 ) );
+
+    // reads past the end of the buffer must fail cleanly
+    {
+        uint8_t buffer[4 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::ReadStream readStream( buffer, 2 );
+        int64_t value = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<48, 16, -100000000000LL, +100000000000LL>( readStream, value ) ) == false );
+    }
+}
+
+inline void test_serialize_fixed_matches_int64()
+{
+    // fraction_bits == 0 is pure integer Q, and for storage of 64 bits or fewer the fixed point
+    // wire format is byte identical to serialize_int64 of the raw value over the raw bounds.
+    // sweep values and require identical bytes and identical bit counts: this equivalence binds
+    // the new path to the proven one.
+
+    const int64_t values[] = { -5000000000LL, -4999999999LL, -1, 0, +1, 12345678, 4999999999LL, 5000000000LL };
+
+    for ( int i = 0; i < (int) ( sizeof( values ) / sizeof( values[0] ) ); i++ )
+    {
+        uint8_t fixed_buffer[16] = { 0 };
+        serialize::WriteStream fixedStream( fixed_buffer, 16 );
+        int64_t fixed_value = values[i];
+        serialize_check( ( serialize::serialize_fixed_internal<64, 0, -5000000000LL, +5000000000LL>( fixedStream, fixed_value ) ) == true );
+        fixedStream.Flush();
+
+        uint8_t int64_buffer[16] = { 0 };
+        serialize::WriteStream int64Stream( int64_buffer, 16 );
+        serialize_check( int64Stream.SerializeInteger64( values[i], -5000000000LL, +5000000000LL ) == true );
+        int64Stream.Flush();
+
+        serialize_check( fixedStream.GetBitsProcessed() == int64Stream.GetBitsProcessed() );
+        serialize_check( memcmp( fixed_buffer, int64_buffer, sizeof( fixed_buffer ) ) == 0 );
+    }
+}
+
+#if defined(__SIZEOF_INT128__)
+
+template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Storage>
+inline void check_fixed_wide_rejects_out_of_range( Storage )
+{
+    // recompute the wire parameters independently of the codec, then hand build a stream encoding
+    // an offset of exactly raw_range + 1: one raw step past raw_max, smuggled into the bit headroom
+    const serialize::uint128_t raw_min = serialize::uint128_t( serialize::int128_t( MinUnits ) ) << FractionalBits;
+    const serialize::uint128_t raw_max = serialize::uint128_t( serialize::int128_t( MaxUnits ) ) << FractionalBits;
+    const serialize::uint128_t raw_range = raw_max - raw_min;
+
+    int bits = 0;
+    for ( serialize::uint128_t x = raw_range; x != 0; x >>= 1 )
+    {
+        bits++;
+    }
+
+    const serialize::uint128_t max_encodable = ( bits < 128 ) ? ( ( serialize::uint128_t( 1 ) << bits ) - 1 ) : ~( serialize::uint128_t( 0 ) );
+    if ( raw_range == max_encodable )
+    {
+        return;                             // no headroom: every encoding decodes in range for this configuration
+    }
+
+    serialize::uint128_t smuggled = raw_range + 1;
+
+    uint8_t buffer[24 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+    serialize::WriteStream writeStream( buffer, 24 );
+    int bits_left = bits;
+    while ( bits_left > 0 )
+    {
+        const int group_bits = ( bits_left < 32 ) ? bits_left : 32;
+        writeStream.SerializeBits( uint32_t( uint64_t( smuggled ) & 0xFFFFFFFF ), group_bits );
+        smuggled >>= group_bits;
+        bits_left -= group_bits;
+    }
+    writeStream.Flush();
+
+    serialize::ReadStream readStream( buffer, 24 );
+    Storage value = 0;
+    serialize_check( ( serialize::serialize_fixed_internal<IntegerBits, FractionalBits, MinUnits, MaxUnits>( readStream, value ) ) == false );
+}
+
+inline void test_serialize_fixed_wide()
+{
+    // compile time bit counts in the 128 bit domain
+    serialize_check( ( serialize::BitsRequired128<0, 0>::result ) == 0 );
+    serialize_check( ( serialize::BitsRequired128<0, 1>::result ) == 1 );
+    serialize_check( ( serialize::BitsRequired128<0, ( serialize::uint128_t( 1 ) << 64 )>::result ) == 65 );
+    serialize_check( ( serialize::BitsRequired128<0, ~( serialize::uint128_t( 0 ) )>::result ) == 128 );
+
+    // the matrix, wide: Q112.16 with a raw range past 64 bits (three groups on the wire), Q112.16
+    // with a small range (a single group on wide storage), Q64.64 (the fraction alone spans 64 bits),
+    // Q64.64 over the full unit range (128 bits on the wire, four groups), and the unsigned wide case.
+    check_fixed_cases<112, 16, -1152921504606846976LL, +1152921504606846976LL>( serialize::int128_t( 65536 ) );     // ±2^60 units: 78 bits on the wire
+    check_fixed_cases<112, 16, -2, +2>( serialize::int128_t( 65536 ) );
+    check_fixed_cases<64, 64, -1000, +1000>( serialize::int128_t( 1 ) << 64 );
+    check_fixed_cases<64, 64, INT64_MIN, INT64_MAX>( serialize::int128_t( 1 ) << 64 );                              // full unit range: 128 bits on the wire
+    check_fixed_cases<112, 16, 0, 2305843009213693952LL>( serialize::uint128_t( 65536 ) );                          // 2^61 units, unsigned
+
+    // the wire cost is a compile time constant of the call site, wide paths included. pin a few
+    {
+        uint8_t buffer[16];
+        serialize::WriteStream stream( buffer, 16 );
+        serialize::int128_t value = serialize::int128_t( 12345 ) * 65536;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 78 );         // 2^61 << 16 raw values needs 78 bits
+    }
+    {
+        uint8_t buffer[24];
+        serialize::WriteStream stream( buffer, 24 );
+        serialize::int128_t value = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<64, 64, INT64_MIN, INT64_MAX>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 128 );        // the full unit range costs the full storage width
+    }
+
+    // one raw step past raw_max must be rejected on read, through every group structure
+    check_fixed_wide_rejects_out_of_range<112, 16, -1152921504606846976LL, +1152921504606846976LL>( serialize::int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -2, +2>( serialize::int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<64, 64, -1000, +1000>( serialize::int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, 0, 2305843009213693952LL>( serialize::uint128_t( 0 ) );
+
+    // reads past the end of the buffer must fail cleanly
+    {
+        uint8_t buffer[4 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::ReadStream readStream( buffer, 4 );
+        serialize::int128_t value = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( readStream, value ) ) == false );
+    }
+}
+
+inline void test_serialize_uint128()
+{
+    // round trips across the value patterns: zero, max, each half alone, alternating bits, distinct halves
+    {
+        const serialize::uint128_t values[] = {
+            0,
+            ~( serialize::uint128_t( 0 ) ),
+            serialize::uint128_t( 0xFFFFFFFFFFFFFFFFULL ) << 64,                                // high half only
+            serialize::uint128_t( 0xFFFFFFFFFFFFFFFFULL ),                                      // low half only
+            ( serialize::uint128_t( 0xAAAAAAAAAAAAAAAAULL ) << 64 ) | 0x5555555555555555ULL,    // alternating bits
+            ( serialize::uint128_t( 0x0123456789ABCDEFULL ) << 64 ) | 0xFEDCBA9876543210ULL,    // distinct halves
+        };
+
+        for ( int i = 0; i < (int) ( sizeof( values ) / sizeof( values[0] ) ); i++ )
+        {
+            uint8_t buffer[16 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+            serialize::WriteStream writeStream( buffer, 16 );
+            serialize::uint128_t written = values[i];
+            serialize_check( serialize::serialize_uint128_internal( writeStream, written ) == true );
+            writeStream.Flush();
+
+            serialize::MeasureStream measureStream;
+            serialize::uint128_t measured = values[i];
+            serialize_check( serialize::serialize_uint128_internal( measureStream, measured ) == true );
+            serialize_check( measureStream.GetBitsProcessed() == writeStream.GetBitsProcessed() );
+            serialize_check( writeStream.GetBitsProcessed() == 128 );
+
+            serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+            serialize::uint128_t read_back = 0;
+            serialize_check( serialize::serialize_uint128_internal( readStream, read_back ) == true );
+            serialize_check( read_back == values[i] );
+        }
+    }
+
+    // cross form consistency: serialize_uint128 must be byte identical to two serialize_uint64
+    // operations on the halves, low half first. this is the portability story: an implementation
+    // without a 128 bit type reproduces the wire exactly with two 64 bit operations.
+    {
+        const uint64_t low_half = 0xFEDCBA9876543210ULL;
+        const uint64_t high_half = 0x0123456789ABCDEFULL;
+
+        uint8_t uint128_buffer[16 + 8] = { 0 };
+        serialize::WriteStream uint128Stream( uint128_buffer, 16 );
+        serialize::uint128_t value = ( serialize::uint128_t( high_half ) << 64 ) | low_half;
+        serialize_check( serialize::serialize_uint128_internal( uint128Stream, value ) == true );
+        uint128Stream.Flush();
+
+        uint8_t halves_buffer[16 + 8] = { 0 };
+        serialize::WriteStream halvesStream( halves_buffer, 16 );
+        write_uint64( halvesStream, low_half );
+        write_uint64( halvesStream, high_half );
+        halvesStream.Flush();
+
+        serialize_check( uint128Stream.GetBitsProcessed() == halvesStream.GetBitsProcessed() );
+        serialize_check( memcmp( uint128_buffer, halves_buffer, 16 ) == 0 );
+    }
+
+    // golden pin: the wire format for a uint128 is its 16 bytes in little endian order, low half
+    // first. pinned forever. additive: the platform independent golden test above is untouched,
+    // because this pin needs a 128 bit type to produce and so lives behind the compiler guard.
+    {
+        static const uint8_t golden_uint128_bytes[] =
+        {
+            0x10, 0x32, 0x54, 0x76, 0x98, 0xBA, 0xDC, 0xFE,
+            0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01
+        };
+
+        const serialize::uint128_t golden_value = ( serialize::uint128_t( 0x0123456789ABCDEFULL ) << 64 ) | 0xFEDCBA9876543210ULL;
+
+        uint8_t buffer[16 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+
+        serialize::WriteStream writeStream( buffer, 16 );
+        serialize::uint128_t written = golden_value;
+        serialize_check( serialize::serialize_uint128_internal( writeStream, written ) == true );
+        writeStream.Flush();
+        serialize_check( writeStream.GetBytesProcessed() == 16 );
+        serialize_check( memcmp( buffer, golden_uint128_bytes, 16 ) == 0 );
+
+        memcpy( buffer, golden_uint128_bytes, 16 );
+        serialize::ReadStream readStream( buffer, 16 );
+        serialize::uint128_t read_back = 0;
+        serialize_check( serialize::serialize_uint128_internal( readStream, read_back ) == true );
+        serialize_check( read_back == golden_value );
+    }
+}
+
+#endif // #if defined(__SIZEOF_INT128__)
+
 // Golden wire format test. The exact bytes produced by the serializer are pinned down here and must never change.
 // If this test fails, the wire format has changed and previously written data no longer decodes: a breaking change.
 // The values below are chosen so every platform quantizes identically (see the compressed float: 5.0 in [0,10]
@@ -3137,6 +4281,10 @@ struct GoldenWireData
     uint8_t bytes[7];
     char string[16];
     wchar_t wstring[8];
+    int16_t fixed_q8_8;
+    int32_t fixed_q16_16;
+    int64_t fixed_q48_16;
+    uint32_t fixed_q16_16_unsigned;
 };
 
 inline void GoldenWireInit( GoldenWireData & data )
@@ -3164,6 +4312,10 @@ inline void GoldenWireInit( GoldenWireData & data )
     // built from explicit code points so the source file encoding can never change the golden bytes
     const wchar_t golden_wide_string[4] = { 0x043C, 0x0438, 0x0440, 0 };            // cyrillic, BMP only
     serialize_copy_wstring( data.wstring, golden_wide_string, sizeof( data.wstring ) / sizeof( wchar_t ) );
+    data.fixed_q8_8 = int16_t( -( 3 * 256 + 64 ) );                                 // -3.25 in Q8.8
+    data.fixed_q16_16 = 1234 * 65536 + 32768;                                       // 1234.5 in Q16.16
+    data.fixed_q48_16 = -( int64_t( 54321 ) * 65536 + 12345 );                      // -54321.1883... in Q48.16
+    data.fixed_q16_16_unsigned = 29999u * 65536 + 65535;                            // 29999.99998... in Q16.16: every fraction bit set
 }
 
 template <typename Stream> bool GoldenWireSerialize( Stream & stream, GoldenWireData & data )
@@ -3189,6 +4341,11 @@ template <typename Stream> bool GoldenWireSerialize( Stream & stream, GoldenWire
     serialize_bytes( stream, data.bytes, (int) sizeof( data.bytes ) );
     serialize_string( stream, data.string, (int) sizeof( data.string ) );
     serialize_wstring( stream, data.wstring, (int) ( sizeof( data.wstring ) / sizeof( wchar_t ) ) );
+    serialize_align( stream );                  // the fixed point section starts byte aligned, so every byte pinned above it stays put
+    serialize_fixed( stream, data.fixed_q8_8, 8, 8, -100, +100 );
+    serialize_fixed( stream, data.fixed_q16_16, 16, 16, -2000, +2000 );
+    serialize_fixed( stream, data.fixed_q48_16, 48, 16, -100000, +100000 );
+    serialize_fixed( stream, data.fixed_q16_16_unsigned, 16, 16, 0, 30000 );
     return true;
 }
 
@@ -3199,7 +4356,9 @@ static const uint8_t golden_wire_bytes[] =
     0x55, 0x55, 0xFF, 0xFC, 0xD1, 0x48, 0xE0, 0x59, 0xD1, 0x48, 0xC0, 0x7B,
     0xF3, 0x6A, 0xE2, 0x59, 0xD1, 0x48, 0x84, 0xB7, 0x06, 0xDE, 0xAD, 0xBE,
     0xEF, 0xCA, 0xFE, 0x01, 0x06, 0x67, 0x6F, 0x6C, 0x64, 0x65, 0x6E, 0xE3,
-    0x21, 0x00, 0x00, 0xC0, 0x21, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00
+    0x21, 0x00, 0x00, 0xC0, 0x21, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00,
+    0xC0, 0x60, 0x00, 0x80, 0xA2, 0x7C, 0xFC, 0xEC, 0x26, 0xCB, 0xFF, 0xFF,
+    0x4B, 0x1D
 };
 
 inline void test_golden_wire_format()
@@ -3248,6 +4407,10 @@ inline void test_golden_wire_format()
         serialize_check( memcmp( data.bytes, expected.bytes, sizeof( data.bytes ) ) == 0 );
         serialize_check( strcmp( data.string, expected.string ) == 0 );
         serialize_check( wcscmp( data.wstring, expected.wstring ) == 0 );
+        serialize_check( data.fixed_q8_8 == expected.fixed_q8_8 );
+        serialize_check( data.fixed_q16_16 == expected.fixed_q16_16 );
+        serialize_check( data.fixed_q48_16 == expected.fixed_q48_16 );
+        serialize_check( data.fixed_q16_16_unsigned == expected.fixed_q16_16_unsigned );
     }
 }
 
@@ -3374,6 +4537,13 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_wstring_validation );
         SERIALIZE_RUN_TEST( test_int_relative_validation );
         SERIALIZE_RUN_TEST( test_compressed_float_validation );
+        SERIALIZE_RUN_TEST( test_serialize_fixed );
+        SERIALIZE_RUN_TEST( test_serialize_fixed_validation );
+        SERIALIZE_RUN_TEST( test_serialize_fixed_matches_int64 );
+#if defined(__SIZEOF_INT128__)
+        SERIALIZE_RUN_TEST( test_serialize_fixed_wide );
+        SERIALIZE_RUN_TEST( test_serialize_uint128 );
+#endif // #if defined(__SIZEOF_INT128__)
         SERIALIZE_RUN_TEST( test_golden_wire_format );
         SERIALIZE_RUN_TEST( test_unaligned_writer );
         SERIALIZE_RUN_TEST( test_large_buffer );

--- a/serialize.h
+++ b/serialize.h
@@ -136,33 +136,37 @@
 #include <wchar.h>      // wcslen
 #include <math.h>       // ceil, floor
 
-// 128 bit unsigned integer support.
+// 128 bit integer support.
 //
-// serialize::uint128_t exists on every platform. Where the compiler provides native __int128
-// (gcc, clang, clang-cl) it is unsigned __int128: the fastest representation. On compilers
-// without it (pure MSVC), serialize defines the emulated mas_uint128_t below — a full unsigned
-// 128 bit integer type with standard semantics — and announces it with the MAS_UINT128_DEFINED
-// handshake macro.
+// serialize::uint128_t and serialize::int128_t exist on every platform. Where the compiler
+// provides native __int128 (gcc, clang, clang-cl) they are unsigned __int128 and __int128: the
+// fastest representation. On compilers without it (pure MSVC), serialize defines the emulated
+// pair below — mas_uint128_t and mas_int128_t, full 128 bit integer types with standard
+// semantics — and announces them with the MAS_UINT128_DEFINED handshake macro. The two structs
+// are one facility: one announce macro covers the pair, and copies are carried whole, never
+// just one half.
 //
 // THE SHARING CONVENTION: single header libraries cannot include each other, so this definition
 // block is carried, verbatim, by sibling projects under the same handshake (the fixed point
 // library, and games built on these libraries). Whichever header is included first defines the
-// type; everyone after sees MAS_UINT128_DEFINED and aliases it, so the type is defined exactly
-// once per translation unit instead of two or three times. The copies exist by design; the
-// handshake makes them mutually exclusive per translation unit, and the differential test
-// against native __int128 in each C++ home is what keeps every copy honest — drift fails loudly.
+// pair; everyone after sees MAS_UINT128_DEFINED and aliases them, so the types are defined
+// exactly once per translation unit instead of two or three times. The copies exist by design;
+// the handshake makes them mutually exclusive per translation unit, and the differential tests
+// against native __int128 in each C++ home are what keep every copy honest — drift fails loudly.
 //
-// The block is dual language: in C the type is the bare POD struct of two uint64_t members,
+// The block is dual language: in C the types are bare POD structs of two uint64_t members,
 // low half then high half, matching little endian layout and the wire order. C projects add
 // their own function wrappers in their own tree. Everything else — constructors, the full
-// operator surface, the explicit uint64_t conversion — is C++ only, inside #ifdef __cplusplus.
+// operator surface, the explicit conversions — is C++ only, inside #ifdef __cplusplus.
 //
-// Semantics match native unsigned __int128 exactly, with two documented choices where native
-// has none: shift counts outside [0,127] yield zero (native shifts by 128 or more are undefined
-// behavior), and division or modulo by zero yields zero quotient and zero remainder (this block
-// has no assert dependency by design, and deterministic zero is the safest portable behavior).
+// Semantics match native __int128 exactly, with documented choices where native has none:
+// shift counts outside [0,127] yield zero (all sign bits for the signed arithmetic right
+// shift; native shifts by 128 or more are undefined behavior), division or modulo by zero
+// yields zero quotient and zero remainder (this block has no assert dependency by design, and
+// deterministic zero is the safest portable behavior), and signed INT128_MIN over -1 wraps to
+// INT128_MIN, the bit pattern native hardware produces.
 //
-// When tests are enabled the type is defined even where native __int128 exists, so the test
+// When tests are enabled the pair is defined even where native __int128 exists, so the test
 // suite can prove the emulation agrees with native operator by operator and produces byte
 // identical wire.
 
@@ -424,6 +428,212 @@ typedef struct mas_uint128_t
 
 } mas_uint128_t;
 
+/**
+    The emulated signed 128 bit integer: a thin two's complement layer over the unsigned lanes.
+    Addition, subtraction, multiplication and the bitwise operators produce the same bit patterns
+    as the unsigned type (two's complement), so they delegate to it instead of duplicating the
+    arithmetic. The signed specific pieces are the comparisons (the high lane compares signed),
+    operator>> (ARITHMETIC shift: vacated bits fill with the sign), division and modulo (sign
+    extraction, unsigned divmod on the magnitudes, sign application — C++ truncation toward zero
+    with the remainder sign following the dividend), unary minus, the sign extending int64_t
+    constructor, and the bit preserving conversions to and from the unsigned type.
+    Documented choices where native has none: shift counts outside [0,127] yield zero for <<
+    and all sign bits for >> (the limit of shifting further); division or modulo by zero yields
+    zero quotient and zero remainder, matching the unsigned type; and the one overflowing
+    division, INT128_MIN over -1, wraps to INT128_MIN quotient and zero remainder — the same bit
+    pattern native two's complement hardware produces.
+    This struct is part of the mas_uint128_t definition block above and is carried with it: the
+    two types are one facility, announced together by the single MAS_UINT128_DEFINED handshake
+    macro and defined exactly once per translation unit. Copies in sibling projects carry the
+    whole pair, never just one half.
+ */
+
+typedef struct mas_int128_t
+{
+    uint64_t lo;            ///< the low 64 bits. first, matching the little endian layout and the wire order
+    uint64_t hi;            ///< the high 64 bits. the top bit is the sign
+
+#ifdef __cplusplus
+
+    mas_int128_t() = default;
+
+    mas_int128_t( int64_t value ) : lo( uint64_t( value ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}     // sign extending
+
+    explicit mas_int128_t( mas_uint128_t value ) : lo( value.lo ), hi( value.hi ) {}        // bit preserving
+
+    explicit operator mas_uint128_t () const                                                // bit preserving
+    {
+        mas_uint128_t result( 0 );
+        result.lo = lo;
+        result.hi = hi;
+        return result;
+    }
+
+    explicit operator int64_t () const
+    {
+        return int64_t( lo );               // the low lane, wrapping two's complement like a native narrowing conversion
+    }
+
+    bool IsNegative() const
+    {
+        return ( hi >> 63 ) != 0;
+    }
+
+    bool operator == ( mas_int128_t other ) const
+    {
+        return lo == other.lo && hi == other.hi;
+    }
+
+    bool operator != ( mas_int128_t other ) const
+    {
+        return ! ( *this == other );
+    }
+
+    bool operator < ( mas_int128_t other ) const
+    {
+        // signed ordering: the high lanes compare signed, the low lanes break ties unsigned
+        if ( hi != other.hi )
+        {
+            return int64_t( hi ) < int64_t( other.hi );
+        }
+        return lo < other.lo;
+    }
+
+    bool operator > ( mas_int128_t other ) const
+    {
+        return other < *this;
+    }
+
+    bool operator <= ( mas_int128_t other ) const
+    {
+        return ! ( other < *this );
+    }
+
+    bool operator >= ( mas_int128_t other ) const
+    {
+        return ! ( *this < other );
+    }
+
+    // two's complement: addition, subtraction, multiplication and the bitwise operators are the
+    // same bit patterns as unsigned, so they delegate to the unsigned type. signed overflow wraps
+    // by construction, exactly like the underlying hardware.
+
+    mas_int128_t operator + ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) + mas_uint128_t( other ) ); }
+    mas_int128_t operator - ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) - mas_uint128_t( other ) ); }
+    mas_int128_t operator * ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) * mas_uint128_t( other ) ); }
+
+    mas_int128_t operator ~ () const                     { return mas_int128_t( ~mas_uint128_t( *this ) ); }
+    mas_int128_t operator & ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) & mas_uint128_t( other ) ); }
+    mas_int128_t operator | ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) | mas_uint128_t( other ) ); }
+    mas_int128_t operator ^ ( mas_int128_t other ) const { return mas_int128_t( mas_uint128_t( *this ) ^ mas_uint128_t( other ) ); }
+
+    mas_int128_t operator << ( int shift ) const
+    {
+        // a logical shift of the bit pattern, matching what native two's complement hardware does.
+        // shift counts outside [0,127] yield zero, matching the unsigned type
+        return mas_int128_t( mas_uint128_t( *this ) << shift );
+    }
+
+    mas_int128_t operator >> ( int shift ) const
+    {
+        // ARITHMETIC shift right: the vacated high bits fill with the sign. shift counts outside
+        // [0,127] yield all sign bits — 0 for non negative values, -1 for negative ones — which is
+        // the limit of shifting further, documented above
+        if ( shift < 0 || shift >= 128 )
+        {
+            return IsNegative() ? mas_int128_t( -1 ) : mas_int128_t( 0 );
+        }
+        mas_uint128_t result = mas_uint128_t( *this ) >> shift;
+        if ( IsNegative() && shift > 0 )
+        {
+            result = result | ( ~mas_uint128_t( 0 ) << ( 128 - shift ) );
+        }
+        return mas_int128_t( result );
+    }
+
+    mas_int128_t operator + () const
+    {
+        return *this;
+    }
+
+    mas_int128_t operator - () const
+    {
+        return mas_int128_t( -mas_uint128_t( *this ) );                 // two's complement negation. -INT128_MIN wraps to itself, like native
+    }
+
+    static void DivMod( mas_int128_t dividend, mas_int128_t divisor, mas_int128_t & quotient, mas_int128_t & remainder )
+    {
+        // sign extraction, unsigned shift subtract division on the magnitudes, then sign
+        // application: C++ semantics, truncation toward zero with the remainder sign following
+        // the dividend. the documented edge choices live in the comment block above.
+        const bool dividend_negative = dividend.IsNegative();
+        const bool divisor_negative = divisor.IsNegative();
+        const mas_uint128_t dividend_magnitude = dividend_negative ? -mas_uint128_t( dividend ) : mas_uint128_t( dividend );
+        const mas_uint128_t divisor_magnitude = divisor_negative ? -mas_uint128_t( divisor ) : mas_uint128_t( divisor );
+        mas_uint128_t unsigned_quotient( 0 );
+        mas_uint128_t unsigned_remainder( 0 );
+        mas_uint128_t::DivMod( dividend_magnitude, divisor_magnitude, unsigned_quotient, unsigned_remainder );
+        quotient = mas_int128_t( ( dividend_negative != divisor_negative ) ? -unsigned_quotient : unsigned_quotient );
+        remainder = mas_int128_t( dividend_negative ? -unsigned_remainder : unsigned_remainder );
+    }
+
+    mas_int128_t operator / ( mas_int128_t other ) const
+    {
+        mas_int128_t quotient( 0 );
+        mas_int128_t remainder( 0 );
+        DivMod( *this, other, quotient, remainder );
+        return quotient;
+    }
+
+    mas_int128_t operator % ( mas_int128_t other ) const
+    {
+        mas_int128_t quotient( 0 );
+        mas_int128_t remainder( 0 );
+        DivMod( *this, other, quotient, remainder );
+        return remainder;
+    }
+
+    mas_int128_t & operator += ( mas_int128_t other ) { *this = *this + other; return *this; }
+    mas_int128_t & operator -= ( mas_int128_t other ) { *this = *this - other; return *this; }
+    mas_int128_t & operator *= ( mas_int128_t other ) { *this = *this * other; return *this; }
+    mas_int128_t & operator /= ( mas_int128_t other ) { *this = *this / other; return *this; }
+    mas_int128_t & operator %= ( mas_int128_t other ) { *this = *this % other; return *this; }
+    mas_int128_t & operator &= ( mas_int128_t other ) { *this = *this & other; return *this; }
+    mas_int128_t & operator |= ( mas_int128_t other ) { *this = *this | other; return *this; }
+    mas_int128_t & operator ^= ( mas_int128_t other ) { *this = *this ^ other; return *this; }
+    mas_int128_t & operator <<= ( int shift )         { *this = *this << shift; return *this; }
+    mas_int128_t & operator >>= ( int shift )         { *this = *this >> shift; return *this; }
+
+    mas_int128_t & operator ++ ()
+    {
+        *this = *this + mas_int128_t( 1 );
+        return *this;
+    }
+
+    mas_int128_t operator ++ ( int )
+    {
+        mas_int128_t before = *this;
+        ++( *this );
+        return before;
+    }
+
+    mas_int128_t & operator -- ()
+    {
+        *this = *this - mas_int128_t( 1 );
+        return *this;
+    }
+
+    mas_int128_t operator -- ( int )
+    {
+        mas_int128_t before = *this;
+        --( *this );
+        return before;
+    }
+
+#endif // #ifdef __cplusplus
+
+} mas_int128_t;
+
 #define MAS_UINT128_DEFINED 1
 
 #endif // #if !defined( MAS_UINT128_DEFINED ) && ( !defined( __SIZEOF_INT128__ ) || SERIALIZE_ENABLE_TESTS )
@@ -434,7 +644,7 @@ namespace serialize
 
     /**
         Native 128 bit integer types, where the compiler provides them (gcc, clang, clang-cl).
-        int128_t is the storage type for wide fixed point (Q112.16 and friends). uint128_t is the 128 bit wire interchange type: native here, and the emulated ::mas_uint128_t on compilers without __int128, so serialize::uint128_t exists on every platform.
+        int128_t is the storage type for wide fixed point (Q112.16 and friends). uint128_t is the 128 bit wire interchange type. On compilers without __int128 both fall back to the emulated pair below, so serialize::int128_t and serialize::uint128_t exist on every platform.
         __extension__ keeps -Wpedantic quiet: __int128 is a language extension.
      */
 
@@ -444,10 +654,11 @@ namespace serialize
 #else // #if defined(__SIZEOF_INT128__)
 
     /**
-        The 128 bit wire interchange type on compilers without native __int128: the emulated ::mas_uint128_t.
+        The 128 bit integer types on compilers without native __int128: the emulated ::mas_uint128_t and ::mas_int128_t pair.
         See the comment block on mas_uint128_t above for the sharing convention between projects.
      */
 
+    typedef ::mas_int128_t   int128_t;
     typedef ::mas_uint128_t uint128_t;
 
 #endif // #if defined(__SIZEOF_INT128__)
@@ -2072,7 +2283,7 @@ namespace serialize
     /**
         Serialize unsigned 128 bit integer (read/write/measure).
         The wire format is 128 bits raw: the low 64 bit half first, then the high half, following the lo-then-hi convention of serialize_bits.
-        The value may be the native unsigned __int128 (serialize::uint128_t, behind the __SIZEOF_INT128__ guard) or any emulated 128 bit unsigned integer type meeting the requirements documented on serialize_uint128_internal, so the operation works on compilers without native 128 bit support too. All representations produce identical bytes.
+        The value may be serialize::uint128_t — which exists on every platform: native unsigned __int128 where the compiler provides it, the emulated mas_uint128_t elsewhere — or any 128 bit unsigned integer type meeting the requirements documented on serialize_uint128_internal. All representations produce identical bytes.
         IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
         @param stream The stream object. May be a read, write or measure stream.
         @param value The 128 bit unsigned integer value.
@@ -2402,11 +2613,37 @@ namespace serialize
     template <> struct FixedPointInteger<int128_t>                  { enum { is_integer = 1, is_signed = 1 }; };
     template <> struct FixedPointInteger<uint128_t>                 { enum { is_integer = 1, is_signed = 0 }; };
 #endif // #if defined(__SIZEOF_INT128__)
+#if defined(MAS_UINT128_DEFINED)
+    // the emulated pair works as storage too. without native __int128 these ARE the serialize
+    // typedefs; with it they are a distinct set of types (present when tests are enabled, or
+    // when a sibling header defined the block first), so the specializations never collide
+    template <> struct FixedPointInteger<::mas_int128_t>            { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger<::mas_uint128_t>           { enum { is_integer = 1, is_signed = 0 }; };
+#endif // #if defined(MAS_UINT128_DEFINED)
+
+    /**
+        Compile time map from a 128 bit fixed point storage type to its unsigned counterpart,
+        in which the wide codec runs its raw offset math. Both the native and the emulated types
+        map to their unsigned partner; two's complement wrap around is exact in both, so the
+        codec is representation generic and wide fixed point works on compilers without native
+        __int128.
+     */
+
+    template <typename T> struct FixedPointUnsigned;
+
+#if defined(__SIZEOF_INT128__)
+    template <> struct FixedPointUnsigned<int128_t>                 { typedef uint128_t type; };
+    template <> struct FixedPointUnsigned<uint128_t>                { typedef uint128_t type; };
+#endif // #if defined(__SIZEOF_INT128__)
+#if defined(MAS_UINT128_DEFINED)
+    template <> struct FixedPointUnsigned<::mas_int128_t>           { typedef ::mas_uint128_t type; };
+    template <> struct FixedPointUnsigned<::mas_uint128_t>          { typedef ::mas_uint128_t type; };
+#endif // #if defined(MAS_UINT128_DEFINED)
 
     /**
         Fixed point codec, specialized on storage width.
         The false specialization covers storage of 64 bits or fewer and works entirely in the 64 bit unsigned domain.
-        The true specialization covers 128 bit storage and lives behind the __SIZEOF_INT128__ guard, so compilers without __int128 never see 128 bit code.
+        The true specialization covers 128 bit storage. It is representation generic — the raw offset math runs in the storage type's unsigned counterpart via FixedPointUnsigned, and its compile time constants live in the 64 bit domain — so it works with native __int128 storage and with the emulated pair alike, and wide fixed point is available on every platform.
         Splitting on width keeps every shift and every compile time bit count valid for the domain it runs in.
         IMPORTANT: Generally, you don't use this directly. Use the serialize_fixed, read_fixed and write_fixed macros instead.
      */
@@ -2485,37 +2722,47 @@ namespace serialize
         }
     };
 
-#if defined(__SIZEOF_INT128__)
-
     template <> struct FixedPointSerializer<true>
     {
         template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Stream, typename Storage>
         static bool Serialize( Stream & stream, Storage & value )
         {
-            // the whole unit capacity of the Q format. computed in the unsigned domain so the widest formats cannot overflow signed arithmetic
-            const int128_t min_representable_units = FixedPointInteger<Storage>::is_signed ?
-                int128_t( uint128_t(0) - ( uint128_t(1) << ( IntegerBits - 1 ) ) ) : int128_t(0);
-            const int128_t max_representable_units = FixedPointInteger<Storage>::is_signed ?
-                int128_t( ( uint128_t(1) << ( IntegerBits - 1 ) ) - 1 ) :
-                ( ( IntegerBits >= 64 ) ? int128_t( INT64_MAX ) : int128_t( ( uint128_t(1) << ( IntegerBits < 64 ? IntegerBits : 0 ) ) - 1 ) );
+            // the unsigned counterpart of the storage type: native unsigned __int128 for native
+            // storage, the emulated mas_uint128_t for emulated storage. all raw offset math runs
+            // in this type, where wrap around is exact two's complement in both representations,
+            // so this codec is representation generic and needs no compiler guard at all.
+            typedef typename FixedPointUnsigned<Storage>::type Unsigned;
 
-            static_assert( int128_t( MinUnits ) >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
-            static_assert( int128_t( MaxUnits ) <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
+            // the whole unit capacity of the Q format, in the 64 bit compile time domain: with 65
+            // or more integer bits the capacity covers any int64 bound, and below that the
+            // capacity math fits 64 bits. the inner clamps keep the unselected ternary arms free
+            // of invalid shift counts.
+            const int64_t min_representable_units = FixedPointInteger<Storage>::is_signed ?
+                ( ( IntegerBits >= 65 ) ? INT64_MIN : int64_t( uint64_t(0) - ( uint64_t(1) << ( ( IntegerBits <= 64 ? IntegerBits : 1 ) - 1 ) ) ) ) : int64_t(0);
+            const int64_t max_representable_units = FixedPointInteger<Storage>::is_signed ?
+                ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( ( IntegerBits < 64 ? IntegerBits : 1 ) - 1 ) ) - 1 ) ) :
+                ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( IntegerBits < 64 ? IntegerBits : 0 ) ) - 1 ) );
 
-            // shift the whole unit bounds into raw fixed point units in the 128 bit unsigned domain, so negative bounds wrap two's complement instead of invoking undefined behavior.
-            // everything below is a compile time constant: the bounds, the range, the bit count and the group structure all fold.
-            const uint128_t raw_min = uint128_t( int128_t( MinUnits ) ) << FractionalBits;
-            const uint128_t raw_max = uint128_t( int128_t( MaxUnits ) ) << FractionalBits;
-            const uint128_t raw_range = raw_max - raw_min;
+            static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
+            static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
 
-            const int bits = BitsRequired128<raw_min, raw_max>::result;
+            // shift the whole unit bounds into raw fixed point units in the unsigned 128 bit domain, so negative bounds wrap two's complement instead of invoking undefined behavior.
+            // the storage constructor sign extends the int64 bounds for signed storage. everything below folds: the bounds, the range, the bit count and the group structure.
+            const Unsigned raw_min = Unsigned( Storage( MinUnits ) ) << FractionalBits;
+            const Unsigned raw_max = Unsigned( Storage( MaxUnits ) ) << FractionalBits;
+            const Unsigned raw_range = raw_max - raw_min;
 
-            uint128_t offset = 0;
+            // the wire cost, computed in the 64 bit compile time domain: the range in whole units
+            // is exact in a uint64, and shifting it left by FractionalBits adds exactly
+            // FractionalBits to its bit length.
+            const int bits = BitsRequired64< uint64_t( MinUnits ), uint64_t( MaxUnits ) >::result + FractionalBits;
+
+            Unsigned offset = 0;
 
             if ( Stream::IsWriting )
             {
                 // subtract in the unsigned domain: raw - raw_min overflows signed arithmetic when the range is wider than 2^127
-                offset = uint128_t( value ) - raw_min;
+                offset = Unsigned( value ) - raw_min;
                 serialize_assert( offset <= raw_range );        // the value must be within [min,max] whole units. all checking is performed by debug asserts on write
             }
 
@@ -2589,7 +2836,7 @@ namespace serialize
 
             if ( Stream::IsReading )
             {
-                offset = ( uint128_t( group3 ) << 96 ) | ( uint128_t( group2 ) << 64 ) | ( uint128_t( group1 ) << 32 ) | group0;
+                offset = ( Unsigned( group3 ) << 96 ) | ( Unsigned( group2 ) << 64 ) | ( Unsigned( group1 ) << 32 ) | Unsigned( group0 );
 
                 // reject raw values outside [raw_min,raw_max] smuggled into the bit headroom. reject, never clamp
                 if ( offset > raw_range )
@@ -2603,8 +2850,6 @@ namespace serialize
             return true;
         }
     };
-
-#endif // #if defined(__SIZEOF_INT128__)
 
     template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Stream, typename Storage>
     bool serialize_fixed_internal( Stream & stream, Storage & value )
@@ -2621,7 +2866,7 @@ namespace serialize
     /**
         Serialize a fixed point value to the stream (read/write/measure).
         This is a helper macro to make writing unified serialize functions easier.
-        The Q format and the bounds are compile time constants: integer_bits plus fraction_bits must equal the number of bits in the storage type, with the sign bit counting towards integer_bits for signed storage. For example, Q48.16 in an int64_t is ( 48, 16 ) and Q112.16 in an __int128 is ( 112, 16 ). Any integer storage type works, including __int128 where the compiler provides it.
+        The Q format and the bounds are compile time constants: integer_bits plus fraction_bits must equal the number of bits in the storage type, with the sign bit counting towards integer_bits for signed storage. For example, Q48.16 in an int64_t is ( 48, 16 ) and Q112.16 in a serialize::int128_t is ( 112, 16 ). Any integer storage type works, including 128 bit storage on every platform: native __int128 where the compiler provides it, the emulated pair where it doesn't.
         The bounds are whole units and must be constant expressions: a runtime bound fails to compile, and bounds that don't fit the Q format fail with a static assert. The value is serialized as an offset from min in the minimal number of bits for the range — a constant of the call site — and the round trip is exact: fixed point values are integers underneath, so unlike compressed floats there is no quantization error and results are identical across platforms.
         For storage of 64 bits or fewer the wire format is byte identical to serialize_int64 of the raw value over the raw bounds.
         Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
@@ -2722,8 +2967,6 @@ namespace serialize
     #define read_uint32( stream, value )    read_bits( stream, value, 32 )
     #define read_uint64( stream, value )    read_bits( stream, value, 64 )
 
-#if defined(__SIZEOF_INT128__)
-
     #define read_uint128( stream, value )                                                   \
         do                                                                                  \
         {                                                                                   \
@@ -2732,8 +2975,6 @@ namespace serialize
                 return false;                                                               \
             }                                                                               \
         } while (0)
-
-#endif // #if defined(__SIZEOF_INT128__)
 
     #define read_float                  serialize_float
     #define read_double                 serialize_double
@@ -2825,16 +3066,12 @@ namespace serialize
     #define write_uint32( stream, value )       write_bits( stream, value, 32 )
     #define write_uint64( stream, value )       write_bits( stream, value, 64 )
 
-#if defined(__SIZEOF_INT128__)
-
     #define write_uint128( stream, value )                                                  \
         do                                                                                  \
         {                                                                                   \
             serialize::uint128_t uint128_value = ( value );                                 \
             serialize::serialize_uint128_internal( stream, uint128_value );                 \
         } while (0)
-
-#endif // #if defined(__SIZEOF_INT128__)
 
     #define write_float( stream, value )                                                    \
         do                                                                                  \
@@ -3329,13 +3566,11 @@ bool ReadFunction( serialize::ReadStream & readStream )
         serialize_check( value == int64_t( 12345 ) * 65536 + 32768 );       // 12345.5 in Q48.16
     }
 
-#if defined(__SIZEOF_INT128__)
     {
         serialize::uint128_t value = 0;
         read_uint128( readStream, value );
         serialize_check( value == ( ( serialize::uint128_t( 0x0123456789ABCDEFULL ) << 64 ) | 0xFEDCBA9876543210ULL ) );
     }
-#endif // #if defined(__SIZEOF_INT128__)
 
     {
         float value;
@@ -3435,10 +3670,8 @@ inline void test_read_write()
         int64_t fixed_point_value = int64_t( 12345 ) * 65536 + 32768;               // 12345.5 in Q48.16
         write_fixed( writeStream, fixed_point_value, 48, 16, -100000, +100000 );
 
-#if defined(__SIZEOF_INT128__)
         serialize::uint128_t big_value = ( serialize::uint128_t( 0x0123456789ABCDEFULL ) << 64 ) | 0xFEDCBA9876543210ULL;
         write_uint128( writeStream, big_value );
-#endif // #if defined(__SIZEOF_INT128__)
 
         write_float( writeStream, 100.0f );
         write_double( writeStream, 1000000000.0f );
@@ -3882,8 +4115,10 @@ inline void check_fixed_round_trip( Storage raw_value )
 template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Storage>
 inline void check_fixed_cases( Storage one_unit )
 {
-    const Storage raw_min = Storage( MinUnits * one_unit );
-    const Storage raw_max = Storage( MaxUnits * one_unit );
+    // the multiplications keep the Storage typed operand on the left, so the emulated 128 bit
+    // types (member operators only) work as Storage here too
+    const Storage raw_min = Storage( one_unit * Storage( MinUnits ) );
+    const Storage raw_max = Storage( one_unit * Storage( MaxUnits ) );
 
     // exact raw bounds, and one raw step inside each
     check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( raw_min );
@@ -3892,8 +4127,8 @@ inline void check_fixed_cases( Storage one_unit )
     check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( raw_max - 1 ) );
 
     // whole unit values one unit inside each bound
-    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( ( MinUnits + 1 ) * one_unit ) );
-    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( ( MaxUnits - 1 ) * one_unit ) );
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( one_unit * Storage( MinUnits + 1 ) ) );
+    check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( one_unit * Storage( MaxUnits - 1 ) ) );
 
     // a value with every fraction bit set
     check_fixed_round_trip<IntegerBits, FractionalBits, MinUnits, MaxUnits>( Storage( raw_min + one_unit - 1 ) );
@@ -4058,6 +4293,7 @@ inline void test_serialize_fixed_matches_int64()
 
     for ( int i = 0; i < (int) ( sizeof( values ) / sizeof( values[0] ) ); i++ )
     {
+        // > 32 bit range: the two group path
         uint8_t fixed_buffer[16] = { 0 };
         serialize::WriteStream fixedStream( fixed_buffer, 16 );
         int64_t fixed_value = values[i];
@@ -4072,9 +4308,49 @@ inline void test_serialize_fixed_matches_int64()
         serialize_check( fixedStream.GetBitsProcessed() == int64Stream.GetBitsProcessed() );
         serialize_check( memcmp( fixed_buffer, int64_buffer, sizeof( fixed_buffer ) ) == 0 );
     }
-}
 
-#if defined(__SIZEOF_INT128__)
+    // <= 32 bit range: the single group path, on 32 bit storage
+    const int32_t narrow_values[] = { -100000, -99999, -1, 0, +1, 54321, 99999, 100000 };
+
+    for ( int i = 0; i < (int) ( sizeof( narrow_values ) / sizeof( narrow_values[0] ) ); i++ )
+    {
+        uint8_t fixed_buffer[16] = { 0 };
+        serialize::WriteStream fixedStream( fixed_buffer, 16 );
+        int32_t fixed_value = narrow_values[i];
+        serialize_check( ( serialize::serialize_fixed_internal<32, 0, -100000, +100000>( fixedStream, fixed_value ) ) == true );
+        fixedStream.Flush();
+
+        uint8_t int64_buffer[16] = { 0 };
+        serialize::WriteStream int64Stream( int64_buffer, 16 );
+        serialize_check( int64Stream.SerializeInteger64( narrow_values[i], -100000, +100000 ) == true );
+        int64Stream.Flush();
+
+        serialize_check( fixedStream.GetBitsProcessed() == int64Stream.GetBitsProcessed() );
+        serialize_check( memcmp( fixed_buffer, int64_buffer, sizeof( fixed_buffer ) ) == 0 );
+    }
+
+    // the equivalence is not limited to fraction_bits == 0: for any Q format the wire is
+    // serialize_int64 of the raw value over the raw bounds. fixed point adds no wire structure,
+    // only the compile time scaling convention.
+    const int32_t q16_16_raw_values[] = { -30000 * 65536, -( 3 * 65536 + 16384 ), 0, 65536 / 2, 12345 * 65536 + 1, 30000 * 65536 };
+
+    for ( int i = 0; i < (int) ( sizeof( q16_16_raw_values ) / sizeof( q16_16_raw_values[0] ) ); i++ )
+    {
+        uint8_t fixed_buffer[16] = { 0 };
+        serialize::WriteStream fixedStream( fixed_buffer, 16 );
+        int32_t fixed_value = q16_16_raw_values[i];
+        serialize_check( ( serialize::serialize_fixed_internal<16, 16, -30000, +30000>( fixedStream, fixed_value ) ) == true );
+        fixedStream.Flush();
+
+        uint8_t int64_buffer[16] = { 0 };
+        serialize::WriteStream int64Stream( int64_buffer, 16 );
+        serialize_check( int64Stream.SerializeInteger64( q16_16_raw_values[i], int64_t( -30000 ) * 65536, int64_t( +30000 ) * 65536 ) == true );
+        int64Stream.Flush();
+
+        serialize_check( fixedStream.GetBitsProcessed() == int64Stream.GetBitsProcessed() );
+        serialize_check( memcmp( fixed_buffer, int64_buffer, sizeof( fixed_buffer ) ) == 0 );
+    }
+}
 
 template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Storage>
 inline void check_fixed_wide_rejects_out_of_range( Storage )
@@ -4119,11 +4395,14 @@ inline void check_fixed_wide_rejects_out_of_range( Storage )
 
 inline void test_serialize_fixed_wide()
 {
-    // compile time bit counts in the 128 bit domain
+#if defined(__SIZEOF_INT128__)
+    // compile time bit counts in the 128 bit domain. the metafunction needs native __int128
+    // template parameters, so these checks are the one native only piece of this test
     serialize_check( ( serialize::BitsRequired128<0, 0>::result ) == 0 );
     serialize_check( ( serialize::BitsRequired128<0, 1>::result ) == 1 );
     serialize_check( ( serialize::BitsRequired128<0, ( serialize::uint128_t( 1 ) << 64 )>::result ) == 65 );
     serialize_check( ( serialize::BitsRequired128<0, ~( serialize::uint128_t( 0 ) )>::result ) == 128 );
+#endif // #if defined(__SIZEOF_INT128__)
 
     // the matrix, wide: Q112.16 with a raw range past 64 bits (three groups on the wire), Q112.16
     // with a small range (a single group on wide storage), Q64.64 (the fraction alone spans 64 bits),
@@ -4164,6 +4443,53 @@ inline void test_serialize_fixed_wide()
         serialize::int128_t value = 0;
         serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( readStream, value ) ) == false );
     }
+}
+
+inline void test_serialize_fixed_wide_emulated()
+{
+    // the wide codec is representation generic: the emulated 128 bit pair works as storage, which
+    // is what makes wide fixed point available on compilers without native __int128. run the wide
+    // case list through the emulated types explicitly, on every platform — where native exists
+    // this doubles as proof that both representations drive the same codec.
+    check_fixed_cases<112, 16, -1152921504606846976LL, +1152921504606846976LL>( ::mas_int128_t( 65536 ) );
+    check_fixed_cases<112, 16, -2, +2>( ::mas_int128_t( 65536 ) );
+    check_fixed_cases<64, 64, -1000, +1000>( ::mas_int128_t( 1 ) << 64 );
+    check_fixed_cases<64, 64, INT64_MIN, INT64_MAX>( ::mas_int128_t( 1 ) << 64 );
+    check_fixed_cases<112, 16, 0, 2305843009213693952LL>( ::mas_uint128_t( 65536 ) );
+
+    // one raw step past raw_max must be rejected through the emulated read path too
+    check_fixed_wide_rejects_out_of_range<112, 16, -1152921504606846976LL, +1152921504606846976LL>( ::mas_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<64, 64, -1000, +1000>( ::mas_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, 0, 2305843009213693952LL>( ::mas_uint128_t( 0 ) );
+
+#if defined(__SIZEOF_INT128__)
+    // cross representation wire identity: native and emulated storage must produce byte identical
+    // wire through the same configuration, and each must read the other's bytes back exactly
+    {
+        const int64_t raw = -( int64_t( 54321 ) * 65536 + 12345 );
+
+        uint8_t native_buffer[16 + 8] = { 0 };          // + 8: read buffer allocations extend 8 bytes past the data
+        serialize::WriteStream nativeStream( native_buffer, 16 );
+        serialize::int128_t native_value = raw;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( nativeStream, native_value ) ) == true );
+        nativeStream.Flush();
+
+        uint8_t emulated_buffer[16 + 8] = { 0 };
+        serialize::WriteStream emulatedStream( emulated_buffer, 16 );
+        ::mas_int128_t emulated_value( raw );
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( emulatedStream, emulated_value ) ) == true );
+        emulatedStream.Flush();
+
+        serialize_check( nativeStream.GetBitsProcessed() == emulatedStream.GetBitsProcessed() );
+        serialize_check( memcmp( native_buffer, emulated_buffer, 16 ) == 0 );
+
+        // read the native bytes back through emulated storage
+        serialize::ReadStream readStream( native_buffer, nativeStream.GetBytesProcessed() );
+        ::mas_int128_t read_back( 0 );
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -1152921504606846976LL, +1152921504606846976LL>( readStream, read_back ) ) == true );
+        serialize_check( read_back == ::mas_int128_t( raw ) );
+    }
+#endif // #if defined(__SIZEOF_INT128__)
 }
 
 inline void test_serialize_uint128()
@@ -4225,8 +4551,9 @@ inline void test_serialize_uint128()
     }
 
     // golden pin: the wire format for a uint128 is its 16 bytes in little endian order, low half
-    // first. pinned forever. additive: the platform independent golden test above is untouched,
-    // because this pin needs a 128 bit type to produce and so lives behind the compiler guard.
+    // first. pinned forever. additive: the pre-existing golden test below is untouched, and this
+    // pin runs on every platform — serialize::uint128_t exists everywhere, so the native and
+    // emulated representations must both reproduce exactly these bytes.
     {
         static const uint8_t golden_uint128_bytes[] =
         {
@@ -4251,6 +4578,594 @@ inline void test_serialize_uint128()
         serialize_check( serialize::serialize_uint128_internal( readStream, read_back ) == true );
         serialize_check( read_back == golden_value );
     }
+}
+
+// builds an emulated 128 bit value from its two lanes. the emulated type is defined on every
+// platform when tests are enabled — where native __int128 exists it coexists with it, so the
+// tests below run everywhere and the differential test can compare the two representations.
+
+inline ::mas_uint128_t uint128_emulated( uint64_t hi, uint64_t lo )
+{
+    ::mas_uint128_t result( lo );
+    result.hi = hi;
+    return result;
+}
+
+inline void test_uint128_emulation()
+{
+    // known answer checks for the emulated 128 bit unsigned integer, unguarded so they run on
+    // every platform — including the ones with no native __int128, where the emulation is the
+    // only implementation and the differential test below cannot run.
+
+    const uint64_t lo = 0xFEDCBA9876543210ULL;
+    const uint64_t hi = 0x0123456789ABCDEFULL;
+
+    // construction from uint64_t fills the low lane. explicit conversion truncates back to it
+    {
+        ::mas_uint128_t value( lo );
+        serialize_check( value.lo == lo && value.hi == 0 );
+        serialize_check( uint64_t( value ) == lo );
+        serialize_check( uint64_t( uint128_emulated( hi, lo ) ) == lo );
+    }
+
+    // all six comparisons, driven by the high lane, the low lane, and equality
+    {
+        const ::mas_uint128_t a = uint128_emulated( 1, 0 );
+        const ::mas_uint128_t b = uint128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL );
+        const ::mas_uint128_t c = uint128_emulated( 1, 1 );
+        serialize_check( a > b );                                       // the high lane dominates
+        serialize_check( b < a );
+        serialize_check( c > a );                                       // the low lane breaks ties
+        serialize_check( a >= b && a <= a && a >= a );
+        serialize_check( b <= a && b != a && a == a );
+        serialize_check( !( a < b ) && !( a == b ) && !( a != a ) );
+    }
+
+    // left shift edges: 0, 1, 63, 64, 65, 127, and out of range counts
+    {
+        const ::mas_uint128_t value = uint128_emulated( hi, lo );
+        serialize_check( ( value << 0 ) == value );
+        serialize_check( ( value << 1 ) == uint128_emulated( ( hi << 1 ) | ( lo >> 63 ), lo << 1 ) );
+        serialize_check( ( value << 63 ) == uint128_emulated( ( hi << 63 ) | ( lo >> 1 ), lo << 63 ) );
+        serialize_check( ( value << 64 ) == uint128_emulated( lo, 0 ) );                    // the low lane becomes the high lane
+        serialize_check( ( value << 65 ) == uint128_emulated( lo << 1, 0 ) );
+        serialize_check( ( value << 127 ) == uint128_emulated( lo << 63, 0 ) );
+        serialize_check( ( value << 128 ) == ::mas_uint128_t( 0 ) );                        // >= 128 yields zero, documented
+        serialize_check( ( value << 200 ) == ::mas_uint128_t( 0 ) );
+    }
+
+    // right shift edges: the mirror image
+    {
+        const ::mas_uint128_t value = uint128_emulated( hi, lo );
+        serialize_check( ( value >> 0 ) == value );
+        serialize_check( ( value >> 1 ) == uint128_emulated( hi >> 1, ( lo >> 1 ) | ( hi << 63 ) ) );
+        serialize_check( ( value >> 63 ) == uint128_emulated( hi >> 63, ( lo >> 63 ) | ( hi << 1 ) ) );
+        serialize_check( ( value >> 64 ) == uint128_emulated( 0, hi ) );                    // the high lane becomes the low lane
+        serialize_check( ( value >> 65 ) == uint128_emulated( 0, hi >> 1 ) );
+        serialize_check( ( value >> 127 ) == uint128_emulated( 0, hi >> 63 ) );
+        serialize_check( ( value >> 128 ) == ::mas_uint128_t( 0 ) );                        // >= 128 yields zero, documented
+        serialize_check( ( value >> 200 ) == ::mas_uint128_t( 0 ) );
+    }
+
+    // addition carries out of the low lane, subtraction borrows back into it
+    {
+        const ::mas_uint128_t max64( 0xFFFFFFFFFFFFFFFFULL );
+        const ::mas_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( max64 + ::mas_uint128_t( 1 ) == uint128_emulated( 1, 0 ) );        // carry
+        serialize_check( all_ones + ::mas_uint128_t( 1 ) == ::mas_uint128_t( 0 ) );         // wraps modulo 2^128
+        serialize_check( ::mas_uint128_t( 0 ) - ::mas_uint128_t( 1 ) == all_ones );         // borrow wraps back
+        serialize_check( uint128_emulated( 1, 0 ) - ::mas_uint128_t( 1 ) == max64 );        // borrow out of the high lane
+
+        ::mas_uint128_t accumulator( 0xFFFFFFFFFFFFFFFFULL );
+        accumulator += ::mas_uint128_t( 1 );
+        serialize_check( accumulator == uint128_emulated( 1, 0 ) );
+        accumulator -= ::mas_uint128_t( 1 );
+        serialize_check( accumulator == max64 );
+    }
+
+    // increment and decrement, both forms, across the lane boundary
+    {
+        ::mas_uint128_t value( 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( value++ == ::mas_uint128_t( 0xFFFFFFFFFFFFFFFFULL ) );             // post returns the value before
+        serialize_check( value == uint128_emulated( 1, 0 ) );
+        serialize_check( ++value == uint128_emulated( 1, 1 ) );                             // pre returns the value after
+        serialize_check( value-- == uint128_emulated( 1, 1 ) );
+        serialize_check( --value == ::mas_uint128_t( 0xFFFFFFFFFFFFFFFFULL ) );
+    }
+
+    // multiplication: lane crossing products with known answers
+    {
+        const ::mas_uint128_t two_to_32( uint64_t( 1 ) << 32 );
+        const ::mas_uint128_t max64( 0xFFFFFFFFFFFFFFFFULL );
+        const ::mas_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( ::mas_uint128_t( 3 ) * ::mas_uint128_t( 5 ) == ::mas_uint128_t( 15 ) );
+        serialize_check( two_to_32 * two_to_32 == uint128_emulated( 1, 0 ) );                                       // 2^64 crosses into the high lane
+        serialize_check( max64 * max64 == uint128_emulated( 0xFFFFFFFFFFFFFFFEULL, 1 ) );                           // 2^128 - 2^65 + 1
+        serialize_check( uint128_emulated( 1, 0 ) * ::mas_uint128_t( 5 ) == uint128_emulated( 5, 0 ) );             // the high lane path
+        serialize_check( all_ones * all_ones == ::mas_uint128_t( 1 ) );                                             // ( 2^128 - 1 )^2 mod 2^128
+
+        ::mas_uint128_t accumulator( 3 );
+        accumulator *= ::mas_uint128_t( 5 );
+        serialize_check( accumulator == ::mas_uint128_t( 15 ) );
+    }
+
+    // division and modulo: the small fast path, wide dividends, wide divisors, and the
+    // documented division by zero choice — zero quotient, zero remainder
+    {
+        const ::mas_uint128_t all_ones = uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( ::mas_uint128_t( 100 ) / ::mas_uint128_t( 7 ) == ::mas_uint128_t( 14 ) );
+        serialize_check( ::mas_uint128_t( 100 ) % ::mas_uint128_t( 7 ) == ::mas_uint128_t( 2 ) );
+        serialize_check( uint128_emulated( 1, 7 ) / ::mas_uint128_t( 16 ) == ::mas_uint128_t( uint64_t( 1 ) << 60 ) );      // 2^64 + 7 over 16
+        serialize_check( uint128_emulated( 1, 7 ) % ::mas_uint128_t( 16 ) == ::mas_uint128_t( 7 ) );
+        serialize_check( uint128_emulated( uint64_t( 1 ) << 63, 0 ) / uint128_emulated( 1, 0 ) == ::mas_uint128_t( uint64_t( 1 ) << 63 ) );     // 2^127 over 2^64
+        serialize_check( all_ones / ::mas_uint128_t( 3 ) == uint128_emulated( 0x5555555555555555ULL, 0x5555555555555555ULL ) );
+        serialize_check( all_ones % ::mas_uint128_t( 3 ) == ::mas_uint128_t( 0 ) );
+        serialize_check( ::mas_uint128_t( 7 ) / uint128_emulated( 1, 0 ) == ::mas_uint128_t( 0 ) );                 // dividend below divisor
+        serialize_check( ::mas_uint128_t( 7 ) % uint128_emulated( 1, 0 ) == ::mas_uint128_t( 7 ) );
+        serialize_check( all_ones / ::mas_uint128_t( 0 ) == ::mas_uint128_t( 0 ) );                                 // division by zero: zero, documented
+        serialize_check( all_ones % ::mas_uint128_t( 0 ) == ::mas_uint128_t( 0 ) );
+
+        ::mas_uint128_t accumulator( 100 );
+        accumulator /= ::mas_uint128_t( 7 );
+        serialize_check( accumulator == ::mas_uint128_t( 14 ) );
+        accumulator = ::mas_uint128_t( 100 );
+        accumulator %= ::mas_uint128_t( 7 );
+        serialize_check( accumulator == ::mas_uint128_t( 2 ) );
+    }
+
+    // bitwise operators work lane by lane
+    {
+        const ::mas_uint128_t a = uint128_emulated( 0xF0F0F0F0F0F0F0F0ULL, 0xAAAAAAAAAAAAAAAAULL );
+        const ::mas_uint128_t b = uint128_emulated( 0xFF00FF00FF00FF00ULL, 0xCCCCCCCCCCCCCCCCULL );
+        serialize_check( ( a & b ) == uint128_emulated( 0xF000F000F000F000ULL, 0x8888888888888888ULL ) );
+        serialize_check( ( a | b ) == uint128_emulated( 0xFFF0FFF0FFF0FFF0ULL, 0xEEEEEEEEEEEEEEEEULL ) );
+        serialize_check( ( a ^ b ) == uint128_emulated( 0x0FF00FF00FF00FF0ULL, 0x6666666666666666ULL ) );
+        serialize_check( ~a == uint128_emulated( 0x0F0F0F0F0F0F0F0FULL, 0x5555555555555555ULL ) );
+
+        ::mas_uint128_t accumulator = a;
+        accumulator &= b;
+        serialize_check( accumulator == ( a & b ) );
+        accumulator = a;
+        accumulator |= b;
+        serialize_check( accumulator == ( a | b ) );
+        accumulator = a;
+        accumulator ^= b;
+        serialize_check( accumulator == ( a ^ b ) );
+        accumulator = a;
+        accumulator <<= 64;
+        serialize_check( accumulator == ( a << 64 ) );
+        accumulator = a;
+        accumulator >>= 64;
+        serialize_check( accumulator == ( a >> 64 ) );
+    }
+
+    // unary plus is the identity, unary minus is two's complement negation
+    {
+        const ::mas_uint128_t value = uint128_emulated( hi, lo );
+        serialize_check( +value == value );
+        serialize_check( -::mas_uint128_t( 0 ) == ::mas_uint128_t( 0 ) );
+        serialize_check( -::mas_uint128_t( 1 ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( -value + value == ::mas_uint128_t( 0 ) );
+    }
+}
+
+inline ::mas_int128_t int128_emulated( uint64_t hi, uint64_t lo )
+{
+    ::mas_int128_t result( 0 );
+    result.hi = hi;
+    result.lo = lo;
+    return result;
+}
+
+inline void test_int128_emulation()
+{
+    // known answer checks for the emulated signed 128 bit integer, unguarded so they run on every
+    // platform. the signed type is a thin two's complement layer over the unsigned lanes, so these
+    // concentrate on the signed specific pieces: sign extension, signed ordering, the arithmetic
+    // right shift, division sign quadrants, and the documented edge choices.
+
+    const ::mas_int128_t int128_min = int128_emulated( 0x8000000000000000ULL, 0 );
+    const ::mas_int128_t int128_max = int128_emulated( 0x7FFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL );
+
+    // the int64_t constructor sign extends into the high lane; the explicit conversion truncates
+    // back to the low lane; the unsigned conversions preserve the bit pattern both ways
+    {
+        serialize_check( ::mas_int128_t( -1 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::mas_int128_t( INT64_MIN ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0x8000000000000000ULL ) );
+        serialize_check( ::mas_int128_t( INT64_MAX ) == int128_emulated( 0, 0x7FFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::mas_int128_t( 1 ) == int128_emulated( 0, 1 ) );
+        serialize_check( int64_t( ::mas_int128_t( -5 ) ) == -5 );
+        serialize_check( int64_t( ::mas_int128_t( INT64_MIN ) ) == INT64_MIN );
+
+        const ::mas_uint128_t bit_pattern = ::mas_uint128_t( ::mas_int128_t( -1 ) );
+        serialize_check( bit_pattern.lo == 0xFFFFFFFFFFFFFFFFULL && bit_pattern.hi == 0xFFFFFFFFFFFFFFFFULL );
+        serialize_check( ::mas_int128_t( bit_pattern ) == ::mas_int128_t( -1 ) );
+    }
+
+    // signed ordering: negatives below positives, the high lane compares signed, the low lane
+    // breaks ties unsigned
+    {
+        serialize_check( ::mas_int128_t( -1 ) < ::mas_int128_t( 0 ) );
+        serialize_check( ::mas_int128_t( 0 ) < ::mas_int128_t( 1 ) );
+        serialize_check( int128_min < ::mas_int128_t( INT64_MIN ) );
+        serialize_check( int128_min < ::mas_int128_t( -1 ) );
+        serialize_check( int128_max > ::mas_int128_t( INT64_MAX ) );
+        serialize_check( int128_min < int128_max );
+        serialize_check( int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 5 ) < int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 7 ) );       // low lane tiebreak among negatives
+        serialize_check( ::mas_int128_t( -3 ) <= ::mas_int128_t( -3 ) && ::mas_int128_t( -3 ) >= ::mas_int128_t( -3 ) );
+        serialize_check( ::mas_int128_t( -3 ) != ::mas_int128_t( 3 ) );
+        serialize_check( !( ::mas_int128_t( 1 ) < ::mas_int128_t( -1 ) ) );
+    }
+
+    // addition, subtraction and multiplication with mixed signs, and the documented wrap
+    {
+        serialize_check( ::mas_int128_t( -3 ) + ::mas_int128_t( 5 ) == ::mas_int128_t( 2 ) );
+        serialize_check( ::mas_int128_t( 3 ) - ::mas_int128_t( 5 ) == ::mas_int128_t( -2 ) );
+        serialize_check( ::mas_int128_t( -3 ) * ::mas_int128_t( 5 ) == ::mas_int128_t( -15 ) );
+        serialize_check( ::mas_int128_t( -3 ) * ::mas_int128_t( -5 ) == ::mas_int128_t( 15 ) );
+        serialize_check( int128_max + ::mas_int128_t( 1 ) == int128_min );                          // wraps two's complement, documented
+        serialize_check( int128_min - ::mas_int128_t( 1 ) == int128_max );
+        serialize_check( ::mas_int128_t( INT64_MAX ) * ::mas_int128_t( 4 ) == int128_emulated( 1, 0xFFFFFFFFFFFFFFFCULL ) );        // crosses the lane boundary
+    }
+
+    // the arithmetic right shift fills with the sign: edges 0, 1, 63, 64, 65, 127 and out of range
+    {
+        serialize_check( ( int128_min >> 0 ) == int128_min );
+        serialize_check( ( int128_min >> 1 ) == int128_emulated( 0xC000000000000000ULL, 0 ) );
+        serialize_check( ( int128_min >> 63 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0 ) );                             // -2^64
+        serialize_check( ( int128_min >> 64 ) == ::mas_int128_t( INT64_MIN ) );
+        serialize_check( ( int128_min >> 65 ) == ::mas_int128_t( INT64_MIN / 2 ) );
+        serialize_check( ( int128_min >> 127 ) == ::mas_int128_t( -1 ) );
+        serialize_check( ( int128_min >> 128 ) == ::mas_int128_t( -1 ) );                           // all sign bits, documented
+        serialize_check( ( int128_min >> 200 ) == ::mas_int128_t( -1 ) );
+        serialize_check( ( ::mas_int128_t( -7 ) >> 1 ) == ::mas_int128_t( -4 ) );                   // arithmetic shift rounds toward negative infinity
+        serialize_check( ( int128_max >> 127 ) == ::mas_int128_t( 0 ) );
+        serialize_check( ( int128_max >> 128 ) == ::mas_int128_t( 0 ) );                            // non negative: sign fill is zero
+        serialize_check( ( ( ::mas_int128_t( 1 ) << 100 ) >> 100 ) == ::mas_int128_t( 1 ) );
+    }
+
+    // the left shift moves the bit pattern like hardware: negative values included
+    {
+        serialize_check( ( ::mas_int128_t( -1 ) << 1 ) == ::mas_int128_t( -2 ) );
+        serialize_check( ( ::mas_int128_t( -1 ) << 64 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0 ) );
+        serialize_check( ( ::mas_int128_t( 1 ) << 127 ) == int128_min );
+        serialize_check( ( ::mas_int128_t( -1 ) << 128 ) == ::mas_int128_t( 0 ) );                  // out of range yields zero, documented
+    }
+
+    // division and modulo: all four sign quadrants, truncation toward zero, the remainder sign
+    // follows the dividend, and the documented edge choices
+    {
+        serialize_check( ::mas_int128_t( 7 ) / ::mas_int128_t( 3 ) == ::mas_int128_t( 2 ) );
+        serialize_check( ::mas_int128_t( 7 ) % ::mas_int128_t( 3 ) == ::mas_int128_t( 1 ) );
+        serialize_check( ::mas_int128_t( -7 ) / ::mas_int128_t( 3 ) == ::mas_int128_t( -2 ) );
+        serialize_check( ::mas_int128_t( -7 ) % ::mas_int128_t( 3 ) == ::mas_int128_t( -1 ) );
+        serialize_check( ::mas_int128_t( 7 ) / ::mas_int128_t( -3 ) == ::mas_int128_t( -2 ) );
+        serialize_check( ::mas_int128_t( 7 ) % ::mas_int128_t( -3 ) == ::mas_int128_t( 1 ) );
+        serialize_check( ::mas_int128_t( -7 ) / ::mas_int128_t( -3 ) == ::mas_int128_t( 2 ) );
+        serialize_check( ::mas_int128_t( -7 ) % ::mas_int128_t( -3 ) == ::mas_int128_t( -1 ) );
+        serialize_check( ::mas_int128_t( -1 ) / ::mas_int128_t( 2 ) == ::mas_int128_t( 0 ) );       // truncation toward zero, not the floor
+        serialize_check( ::mas_int128_t( -1 ) % ::mas_int128_t( 2 ) == ::mas_int128_t( -1 ) );
+        serialize_check( int128_min / ::mas_int128_t( 2 ) == int128_emulated( 0xC000000000000000ULL, 0 ) );
+        serialize_check( int128_min / ::mas_int128_t( 1 ) == int128_min );
+        serialize_check( int128_min / ::mas_int128_t( -1 ) == int128_min );                         // the one overflowing case wraps, documented
+        serialize_check( int128_min % ::mas_int128_t( -1 ) == ::mas_int128_t( 0 ) );
+        serialize_check( int128_max / ::mas_int128_t( 0 ) == ::mas_int128_t( 0 ) );                 // division by zero: zero, documented
+        serialize_check( int128_max % ::mas_int128_t( 0 ) == ::mas_int128_t( 0 ) );
+    }
+
+    // unary minus is two's complement negation; ~ and the bitwise operators work on the pattern
+    {
+        serialize_check( -::mas_int128_t( 5 ) == ::mas_int128_t( -5 ) );
+        serialize_check( -::mas_int128_t( -5 ) == ::mas_int128_t( 5 ) );
+        serialize_check( -int128_min == int128_min );                                               // -INT128_MIN wraps to itself, documented
+        serialize_check( +::mas_int128_t( -5 ) == ::mas_int128_t( -5 ) );
+        serialize_check( ~::mas_int128_t( 0 ) == ::mas_int128_t( -1 ) );
+        serialize_check( ( ::mas_int128_t( -1 ) & ::mas_int128_t( 5 ) ) == ::mas_int128_t( 5 ) );
+        serialize_check( ( ::mas_int128_t( 0 ) | ::mas_int128_t( -1 ) ) == ::mas_int128_t( -1 ) );
+        serialize_check( ( ::mas_int128_t( -1 ) ^ ::mas_int128_t( -1 ) ) == ::mas_int128_t( 0 ) );
+    }
+
+    // increment and decrement, both forms, across zero and across the lane boundary
+    {
+        ::mas_int128_t value( -1 );
+        serialize_check( ++value == ::mas_int128_t( 0 ) );
+        serialize_check( value++ == ::mas_int128_t( 0 ) );
+        serialize_check( value == ::mas_int128_t( 1 ) );
+        serialize_check( --value == ::mas_int128_t( 0 ) );
+        serialize_check( value-- == ::mas_int128_t( 0 ) );
+        serialize_check( value == ::mas_int128_t( -1 ) );
+
+        ::mas_int128_t boundary = int128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL );                      // 2^64 - 1
+        serialize_check( ++boundary == int128_emulated( 1, 0 ) );
+
+        ::mas_int128_t accumulator( -10 );
+        accumulator += ::mas_int128_t( 4 );  serialize_check( accumulator == ::mas_int128_t( -6 ) );
+        accumulator -= ::mas_int128_t( -6 ); serialize_check( accumulator == ::mas_int128_t( 0 ) );
+        accumulator = ::mas_int128_t( -3 );
+        accumulator *= ::mas_int128_t( -3 ); serialize_check( accumulator == ::mas_int128_t( 9 ) );
+        accumulator /= ::mas_int128_t( -2 ); serialize_check( accumulator == ::mas_int128_t( -4 ) );
+        accumulator %= ::mas_int128_t( 3 );  serialize_check( accumulator == ::mas_int128_t( -1 ) );
+        accumulator <<= 64;                  serialize_check( accumulator == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0 ) );
+        accumulator >>= 64;                  serialize_check( accumulator == ::mas_int128_t( -1 ) );
+        accumulator &= ::mas_int128_t( 6 );  serialize_check( accumulator == ::mas_int128_t( 6 ) );
+        accumulator |= ::mas_int128_t( 1 );  serialize_check( accumulator == ::mas_int128_t( 7 ) );
+        accumulator ^= ::mas_int128_t( -1 ); serialize_check( accumulator == ::mas_int128_t( -8 ) );
+    }
+}
+
+#if defined(__SIZEOF_INT128__)
+
+inline serialize::uint128_t uint128_native_from_emulated( ::mas_uint128_t value )
+{
+    return ( serialize::uint128_t( value.hi ) << 64 ) | value.lo;
+}
+
+inline void check_uint128_agree( ::mas_uint128_t emulated, serialize::uint128_t native )
+{
+    serialize_check( emulated.lo == uint64_t( native ) );
+    serialize_check( emulated.hi == uint64_t( native >> 64 ) );
+}
+
+inline void test_uint128_differential()
+{
+    // where native __int128 exists, the emulated type is proven against it operator by operator:
+    // a fixed seed LCG generates operand pairs, and every operator must agree exactly. this is
+    // the test that keeps the sibling copies of the emulation block honest — drift fails loudly.
+
+    uint64_t lcg = 0x123456789ABCDEF0ULL;
+
+    #define serialize_test_next_lcg() ( lcg = lcg * 6364136223846793005ULL + 1442695040888963407ULL )
+
+    for ( int i = 0; i < 400; i++ )
+    {
+        uint64_t a_hi = serialize_test_next_lcg();
+        uint64_t a_lo = serialize_test_next_lcg();
+        uint64_t b_hi = serialize_test_next_lcg();
+        uint64_t b_lo = serialize_test_next_lcg();
+
+        // bias some operands toward the interesting edges: empty lanes, saturated lanes, equal operands
+        switch ( i % 8 )
+        {
+            case 1: a_hi = 0; break;
+            case 2: a_lo = 0; break;
+            case 3: b_hi = 0; break;
+            case 4: b_lo = 0; break;
+            case 5: a_hi = 0xFFFFFFFFFFFFFFFFULL; a_lo = 0xFFFFFFFFFFFFFFFFULL; break;
+            case 6: b_hi = 0; b_lo = uint64_t( 1 ) << ( i % 63 ); break;                    // powers of two divide cleanly
+            case 7: b_hi = a_hi; b_lo = a_lo; break;
+            default: break;
+        }
+
+        const ::mas_uint128_t ea = uint128_emulated( a_hi, a_lo );
+        const ::mas_uint128_t eb = uint128_emulated( b_hi, b_lo );
+        const serialize::uint128_t na = ( serialize::uint128_t( a_hi ) << 64 ) | a_lo;
+        const serialize::uint128_t nb = ( serialize::uint128_t( b_hi ) << 64 ) | b_lo;
+
+        check_uint128_agree( ea + eb, na + nb );
+        check_uint128_agree( ea - eb, na - nb );
+        check_uint128_agree( ea * eb, na * nb );
+        check_uint128_agree( ea & eb, na & nb );
+        check_uint128_agree( ea | eb, na | nb );
+        check_uint128_agree( ea ^ eb, na ^ nb );
+        check_uint128_agree( ~ea, ~na );
+        check_uint128_agree( -ea, serialize::uint128_t( 0 ) - na );
+        check_uint128_agree( +ea, na );
+
+        if ( eb != ::mas_uint128_t( 0 ) )
+        {
+            check_uint128_agree( ea / eb, na / nb );            // native division by zero is undefined; the emulated choice is pinned in test_uint128_emulation
+            check_uint128_agree( ea % eb, na % nb );
+        }
+
+        const int shift = int( b_lo % 128 );                    // native shifts of 128 or more are undefined; the emulated choice is pinned in test_uint128_emulation
+        check_uint128_agree( ea << shift, na << shift );
+        check_uint128_agree( ea >> shift, na >> shift );
+
+        serialize_check( ( ea == eb ) == ( na == nb ) );
+        serialize_check( ( ea != eb ) == ( na != nb ) );
+        serialize_check( ( ea <  eb ) == ( na <  nb ) );
+        serialize_check( ( ea >  eb ) == ( na >  nb ) );
+        serialize_check( ( ea <= eb ) == ( na <= nb ) );
+        serialize_check( ( ea >= eb ) == ( na >= nb ) );
+
+        ::mas_uint128_t emulated_accumulator = ea;
+        serialize::uint128_t native_accumulator = na;
+        check_uint128_agree( ++emulated_accumulator, ++native_accumulator );
+        check_uint128_agree( emulated_accumulator++, native_accumulator++ );
+        check_uint128_agree( emulated_accumulator, native_accumulator );
+        check_uint128_agree( --emulated_accumulator, --native_accumulator );
+        check_uint128_agree( emulated_accumulator--, native_accumulator-- );
+        check_uint128_agree( emulated_accumulator, native_accumulator );
+
+        emulated_accumulator = ea;
+        native_accumulator = na;
+        emulated_accumulator += eb; native_accumulator += nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator -= eb; native_accumulator -= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator *= eb; native_accumulator *= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator &= eb; native_accumulator &= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator |= eb; native_accumulator |= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator ^= eb; native_accumulator ^= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator <<= shift; native_accumulator <<= shift; check_uint128_agree( emulated_accumulator, native_accumulator );
+        emulated_accumulator >>= shift; native_accumulator >>= shift; check_uint128_agree( emulated_accumulator, native_accumulator );
+        if ( eb != ::mas_uint128_t( 0 ) )
+        {
+            emulated_accumulator = ea; native_accumulator = na;
+            emulated_accumulator /= eb; native_accumulator /= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+            emulated_accumulator = ea; native_accumulator = na;
+            emulated_accumulator %= eb; native_accumulator %= nb; check_uint128_agree( emulated_accumulator, native_accumulator );
+        }
+    }
+
+    #undef serialize_test_next_lcg
+
+    // cross representation wire identity: the emulated type and native __int128 must produce
+    // byte identical wire through serialize_uint128, and each must read the other's bytes back
+    // exactly. this is what makes the emulation a drop in replacement on compilers without
+    // native 128 bit support.
+    {
+        const uint64_t lanes[][2] =                             // { hi, lo }
+        {
+            { 0, 0 },
+            { 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL },
+            { 0xFFFFFFFFFFFFFFFFULL, 0 },                                       // high half only
+            { 0, 0xFFFFFFFFFFFFFFFFULL },                                       // low half only
+            { 0x0123456789ABCDEFULL, 0xFEDCBA9876543210ULL },                   // distinct halves
+        };
+
+        for ( int i = 0; i < (int) ( sizeof( lanes ) / sizeof( lanes[0] ) ); i++ )
+        {
+            ::mas_uint128_t emulated = uint128_emulated( lanes[i][0], lanes[i][1] );
+            serialize::uint128_t native = uint128_native_from_emulated( emulated );
+
+            uint8_t emulated_buffer[16 + 8] = { 0 };            // + 8: read buffer allocations extend 8 bytes past the data
+            serialize::WriteStream emulatedStream( emulated_buffer, 16 );
+            serialize_check( serialize::serialize_uint128_internal( emulatedStream, emulated ) == true );
+            emulatedStream.Flush();
+
+            uint8_t native_buffer[16 + 8] = { 0 };
+            serialize::WriteStream nativeStream( native_buffer, 16 );
+            serialize_check( serialize::serialize_uint128_internal( nativeStream, native ) == true );
+            nativeStream.Flush();
+
+            serialize_check( emulatedStream.GetBitsProcessed() == nativeStream.GetBitsProcessed() );
+            serialize_check( memcmp( emulated_buffer, native_buffer, 16 ) == 0 );
+
+            // read the native bytes back through the emulated type
+            serialize::ReadStream readStream( native_buffer, 16 );
+            ::mas_uint128_t read_back( 0 );
+            serialize_check( serialize::serialize_uint128_internal( readStream, read_back ) == true );
+            serialize_check( read_back == uint128_emulated( lanes[i][0], lanes[i][1] ) );
+        }
+    }
+}
+
+inline serialize::int128_t int128_native_from_emulated( ::mas_int128_t value )
+{
+    return serialize::int128_t( ( serialize::uint128_t( value.hi ) << 64 ) | value.lo );
+}
+
+inline void check_int128_agree( ::mas_int128_t emulated, serialize::int128_t native )
+{
+    serialize_check( emulated.lo == uint64_t( serialize::uint128_t( native ) ) );
+    serialize_check( emulated.hi == uint64_t( serialize::uint128_t( native ) >> 64 ) );
+}
+
+inline void test_int128_differential()
+{
+    // the signed counterpart of test_uint128_differential: a fixed seed LCG generates operand
+    // pairs biased toward the sign boundaries, and every operator must agree exactly with native
+    // signed __int128. where the native operation would be undefined behavior — signed overflow
+    // in + - * << and unary minus — the native expectation is computed in the unsigned domain,
+    // which is the defined spelling of the two's complement wrap the emulation implements.
+
+    const serialize::int128_t native_int128_min = serialize::int128_t( serialize::uint128_t( 1 ) << 127 );
+
+    uint64_t lcg = 0xFEDCBA9876543210ULL;
+
+    #define serialize_test_next_lcg() ( lcg = lcg * 6364136223846793005ULL + 1442695040888963407ULL )
+
+    for ( int i = 0; i < 400; i++ )
+    {
+        uint64_t a_hi = serialize_test_next_lcg();
+        uint64_t a_lo = serialize_test_next_lcg();
+        uint64_t b_hi = serialize_test_next_lcg();
+        uint64_t b_lo = serialize_test_next_lcg();
+
+        // bias operands toward the sign boundaries: zero, ±1, INT64_MIN/MAX sign extended,
+        // INT128_MIN/MAX, negated and equal pairs
+        switch ( i % 10 )
+        {
+            case 1: a_hi = 0; a_lo = 0; break;
+            case 2: a_hi = 0xFFFFFFFFFFFFFFFFULL; a_lo = 0xFFFFFFFFFFFFFFFFULL; break;              // -1
+            case 3: a_hi = 0xFFFFFFFFFFFFFFFFULL; a_lo = 0x8000000000000000ULL; break;              // INT64_MIN sign extended
+            case 4: a_hi = 0; a_lo = 0x7FFFFFFFFFFFFFFFULL; break;                                  // INT64_MAX
+            case 5: a_hi = 0x8000000000000000ULL; a_lo = 0; break;                                  // INT128_MIN
+            case 6: a_hi = 0x7FFFFFFFFFFFFFFFULL; a_lo = 0xFFFFFFFFFFFFFFFFULL; break;              // INT128_MAX
+            case 7: b_hi = 0xFFFFFFFFFFFFFFFFULL; b_lo = 0xFFFFFFFFFFFFFFFFULL; break;              // -1: the overflowing divisor
+            case 8: b_hi = ~a_hi; b_lo = ~a_lo; break;                                              // ~a: b = -a - 1, mixed signs
+            case 9: b_hi = a_hi; b_lo = a_lo; break;
+            default: break;
+        }
+
+        const ::mas_int128_t ea = int128_emulated( a_hi, a_lo );
+        const ::mas_int128_t eb = int128_emulated( b_hi, b_lo );
+        const serialize::uint128_t ua = ( serialize::uint128_t( a_hi ) << 64 ) | a_lo;
+        const serialize::uint128_t ub = ( serialize::uint128_t( b_hi ) << 64 ) | b_lo;
+        const serialize::int128_t na = serialize::int128_t( ua );
+        const serialize::int128_t nb = serialize::int128_t( ub );
+
+        // + - * and unary minus: native expectations via the unsigned domain, avoiding native
+        // signed overflow, which is undefined behavior. the wrap is the semantics under test.
+        check_int128_agree( ea + eb, serialize::int128_t( ua + ub ) );
+        check_int128_agree( ea - eb, serialize::int128_t( ua - ub ) );
+        check_int128_agree( ea * eb, serialize::int128_t( ua * ub ) );
+        check_int128_agree( -ea, serialize::int128_t( serialize::uint128_t( 0 ) - ua ) );
+        check_int128_agree( +ea, na );
+
+        check_int128_agree( ea & eb, na & nb );
+        check_int128_agree( ea | eb, na | nb );
+        check_int128_agree( ea ^ eb, na ^ nb );
+        check_int128_agree( ~ea, ~na );
+
+        if ( nb != 0 && ! ( na == native_int128_min && nb == -1 ) )
+        {
+            check_int128_agree( ea / eb, na / nb );         // the excluded case is native undefined behavior; the emulated wrap is pinned in test_int128_emulation
+            check_int128_agree( ea % eb, na % nb );
+        }
+
+        const int shift = int( b_lo % 128 );                // native shifts of 128 or more are undefined; the emulated choice is pinned in test_int128_emulation
+        check_int128_agree( ea >> shift, na >> shift );                                             // native >> on negatives is the arithmetic shift on every target compiler
+        check_int128_agree( ea << shift, serialize::int128_t( ua << shift ) );                      // native << on negatives is undefined pre C++20: the unsigned domain is the defined spelling
+
+        serialize_check( ( ea == eb ) == ( na == nb ) );
+        serialize_check( ( ea != eb ) == ( na != nb ) );
+        serialize_check( ( ea <  eb ) == ( na <  nb ) );
+        serialize_check( ( ea >  eb ) == ( na >  nb ) );
+        serialize_check( ( ea <= eb ) == ( na <= nb ) );
+        serialize_check( ( ea >= eb ) == ( na >= nb ) );
+
+        // increments and decrements via the unsigned domain, since native ++ overflows at INT128_MAX
+        ::mas_int128_t incremented = ea;
+        ++incremented;
+        check_int128_agree( incremented, serialize::int128_t( ua + 1 ) );
+        incremented--;
+        check_int128_agree( incremented, na );
+        ::mas_int128_t decremented = ea;
+        --decremented;
+        check_int128_agree( decremented, serialize::int128_t( ua - 1 ) );
+
+        // conversions: the sign extending constructor and the truncating conversion match native
+        const int64_t seed64 = int64_t( a_lo );
+        check_int128_agree( ::mas_int128_t( seed64 ), serialize::int128_t( seed64 ) );
+        serialize_check( int64_t( ea ) == int64_t( uint64_t( ua ) ) );
+
+        // compound forms via the unsigned domain where overflow could occur
+        ::mas_int128_t accumulator = ea;
+        accumulator += eb; check_int128_agree( accumulator, serialize::int128_t( ua + ub ) );
+        accumulator = ea;
+        accumulator -= eb; check_int128_agree( accumulator, serialize::int128_t( ua - ub ) );
+        accumulator = ea;
+        accumulator *= eb; check_int128_agree( accumulator, serialize::int128_t( ua * ub ) );
+        accumulator = ea;
+        accumulator &= eb; check_int128_agree( accumulator, na & nb );
+        accumulator = ea;
+        accumulator |= eb; check_int128_agree( accumulator, na | nb );
+        accumulator = ea;
+        accumulator ^= eb; check_int128_agree( accumulator, na ^ nb );
+        accumulator = ea;
+        accumulator >>= shift; check_int128_agree( accumulator, na >> shift );
+        accumulator = ea;
+        accumulator <<= shift; check_int128_agree( accumulator, serialize::int128_t( ua << shift ) );
+        if ( nb != 0 && ! ( na == native_int128_min && nb == -1 ) )
+        {
+            accumulator = ea;
+            accumulator /= eb; check_int128_agree( accumulator, na / nb );
+            accumulator = ea;
+            accumulator %= eb; check_int128_agree( accumulator, na % nb );
+        }
+    }
+
+    #undef serialize_test_next_lcg
 }
 
 #endif // #if defined(__SIZEOF_INT128__)
@@ -4540,9 +5455,14 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_serialize_fixed );
         SERIALIZE_RUN_TEST( test_serialize_fixed_validation );
         SERIALIZE_RUN_TEST( test_serialize_fixed_matches_int64 );
-#if defined(__SIZEOF_INT128__)
         SERIALIZE_RUN_TEST( test_serialize_fixed_wide );
+        SERIALIZE_RUN_TEST( test_serialize_fixed_wide_emulated );
         SERIALIZE_RUN_TEST( test_serialize_uint128 );
+        SERIALIZE_RUN_TEST( test_uint128_emulation );
+        SERIALIZE_RUN_TEST( test_int128_emulation );
+#if defined(__SIZEOF_INT128__)
+        SERIALIZE_RUN_TEST( test_uint128_differential );
+        SERIALIZE_RUN_TEST( test_int128_differential );
 #endif // #if defined(__SIZEOF_INT128__)
         SERIALIZE_RUN_TEST( test_golden_wire_format );
         SERIALIZE_RUN_TEST( test_unaligned_writer );

--- a/serialize.h
+++ b/serialize.h
@@ -181,7 +181,18 @@ typedef struct mas_uint128_t
 
     mas_uint128_t() = default;
 
-    mas_uint128_t( uint64_t value ) : lo( value ), hi( 0 ) {}
+    // construction mirrors native conversion to unsigned __int128 exactly: unsigned sources zero
+    // extend, signed sources sign extend (a negative value wraps modulo 2^128, so the high lane
+    // fills with ones). one constructor per standard integer type keeps every call an exact match
+    // after integer promotion — a lone uint64_t constructor would zero extend negative int64
+    // values where native sign extends, silently diverging the wire between representations.
+
+    mas_uint128_t( int value )                : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    mas_uint128_t( long value )               : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    mas_uint128_t( long long value )          : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    mas_uint128_t( unsigned int value )       : lo( value ), hi( 0 ) {}
+    mas_uint128_t( unsigned long value )      : lo( value ), hi( 0 ) {}
+    mas_uint128_t( unsigned long long value ) : lo( value ), hi( 0 ) {}
 
     explicit operator uint64_t () const
     {
@@ -457,7 +468,19 @@ typedef struct mas_int128_t
 
     mas_int128_t() = default;
 
-    mas_int128_t( int64_t value ) : lo( uint64_t( value ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}     // sign extending
+    // construction mirrors native conversion to __int128 exactly: signed sources sign extend,
+    // unsigned sources zero extend (any uint64 is below 2^127, so the conversion is value
+    // preserving with a zero high lane). one constructor per standard integer type keeps every
+    // call an exact match after integer promotion — a lone int64_t constructor would wrap large
+    // uint64 values negative where native keeps them positive, silently diverging the wire
+    // between representations.
+
+    mas_int128_t( int value )                : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    mas_int128_t( long value )               : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    mas_int128_t( long long value )          : lo( uint64_t( int64_t( value ) ) ), hi( ( value < 0 ) ? 0xFFFFFFFFFFFFFFFFULL : 0 ) {}
+    mas_int128_t( unsigned int value )       : lo( value ), hi( 0 ) {}
+    mas_int128_t( unsigned long value )      : lo( value ), hi( 0 ) {}
+    mas_int128_t( unsigned long long value ) : lo( value ), hi( 0 ) {}
 
     explicit mas_int128_t( mas_uint128_t value ) : lo( value.lo ), hi( value.hi ) {}        // bit preserving
 
@@ -2264,6 +2287,10 @@ namespace serialize
 
     template <typename Stream, typename UInt128> bool serialize_uint128_internal( Stream & stream, UInt128 & value )
     {
+        // refuse narrower types at compile time: a uint64_t here would shift by 64 — undefined
+        // behavior — and silently is not the 128 bit operation the caller asked for
+        static_assert( sizeof( UInt128 ) == 16, "serialize_uint128 requires a 128 bit type (did you mean serialize_uint64?)" );
+
         uint64_t low_half = 0;
         uint64_t high_half = 0;
         if ( Stream::IsWriting )
@@ -4413,6 +4440,12 @@ inline void test_serialize_fixed_wide()
     check_fixed_cases<64, 64, INT64_MIN, INT64_MAX>( serialize::int128_t( 1 ) << 64 );                              // full unit range: 128 bits on the wire
     check_fixed_cases<112, 16, 0, 2305843009213693952LL>( serialize::uint128_t( 65536 ) );                          // 2^61 units, unsigned
 
+    // the 33..64 bit two group band on wide storage: both boundaries exactly, plus the example's
+    // own Q112.16 ±1e11 shape (54 bits), which used to live only in example.cpp and not in CI
+    check_fixed_cases<112, 16, -32768, +32768>( serialize::int128_t( 65536 ) );                                     // 33 bits: the band's low edge
+    check_fixed_cases<112, 16, -100000000000LL, +100000000000LL>( serialize::int128_t( 65536 ) );                   // 54 bits: the example's shape
+    check_fixed_cases<112, 16, -140737488355328LL, +140737488355327LL>( serialize::int128_t( 65536 ) );             // 64 bits: the band's high edge
+
     // the wire cost is a compile time constant of the call site, wide paths included. pin a few
     {
         uint8_t buffer[16];
@@ -4428,12 +4461,37 @@ inline void test_serialize_fixed_wide()
         serialize_check( ( serialize::serialize_fixed_internal<64, 64, INT64_MIN, INT64_MAX>( stream, value ) ) == true );
         serialize_check( stream.GetBitsProcessed() == 128 );        // the full unit range costs the full storage width
     }
+    {
+        uint8_t buffer[16];
+        serialize::WriteStream stream( buffer, 16 );
+        serialize::int128_t value = serialize::int128_t( 12345678901LL ) * serialize::int128_t( 65536 );
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -100000000000LL, +100000000000LL>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 54 );         // the example's shape: 2e11 << 16 raw values needs 54 bits, inside the two group band
+    }
+    {
+        uint8_t buffer[16];
+        serialize::WriteStream stream( buffer, 16 );
+        serialize::int128_t value = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -32768, +32768>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 33 );         // the band's low edge
+    }
+    {
+        uint8_t buffer[16];
+        serialize::WriteStream stream( buffer, 16 );
+        serialize::int128_t value = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -140737488355328LL, +140737488355327LL>( stream, value ) ) == true );
+        serialize_check( stream.GetBitsProcessed() == 64 );         // the band's high edge
+    }
 
-    // one raw step past raw_max must be rejected on read, through every group structure
+    // one raw step past raw_max must be rejected on read, through every group structure —
+    // the 33..64 bit two group band included
     check_fixed_wide_rejects_out_of_range<112, 16, -1152921504606846976LL, +1152921504606846976LL>( serialize::int128_t( 0 ) );
     check_fixed_wide_rejects_out_of_range<112, 16, -2, +2>( serialize::int128_t( 0 ) );
     check_fixed_wide_rejects_out_of_range<64, 64, -1000, +1000>( serialize::int128_t( 0 ) );
     check_fixed_wide_rejects_out_of_range<112, 16, 0, 2305843009213693952LL>( serialize::uint128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -32768, +32768>( serialize::int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -100000000000LL, +100000000000LL>( serialize::int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -140737488355328LL, +140737488355327LL>( serialize::int128_t( 0 ) );
 
     // reads past the end of the buffer must fail cleanly
     {
@@ -4457,10 +4515,18 @@ inline void test_serialize_fixed_wide_emulated()
     check_fixed_cases<64, 64, INT64_MIN, INT64_MAX>( ::mas_int128_t( 1 ) << 64 );
     check_fixed_cases<112, 16, 0, 2305843009213693952LL>( ::mas_uint128_t( 65536 ) );
 
+    // the 33..64 bit two group band on emulated wide storage: both boundaries and the example's shape
+    check_fixed_cases<112, 16, -32768, +32768>( ::mas_int128_t( 65536 ) );
+    check_fixed_cases<112, 16, -100000000000LL, +100000000000LL>( ::mas_int128_t( 65536 ) );
+    check_fixed_cases<112, 16, -140737488355328LL, +140737488355327LL>( ::mas_int128_t( 65536 ) );
+
     // one raw step past raw_max must be rejected through the emulated read path too
     check_fixed_wide_rejects_out_of_range<112, 16, -1152921504606846976LL, +1152921504606846976LL>( ::mas_int128_t( 0 ) );
     check_fixed_wide_rejects_out_of_range<64, 64, -1000, +1000>( ::mas_int128_t( 0 ) );
     check_fixed_wide_rejects_out_of_range<112, 16, 0, 2305843009213693952LL>( ::mas_uint128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -32768, +32768>( ::mas_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -100000000000LL, +100000000000LL>( ::mas_int128_t( 0 ) );
+    check_fixed_wide_rejects_out_of_range<112, 16, -140737488355328LL, +140737488355327LL>( ::mas_int128_t( 0 ) );
 
 #if defined(__SIZEOF_INT128__)
     // cross representation wire identity: native and emulated storage must produce byte identical
@@ -4606,6 +4672,19 @@ inline void test_uint128_emulation()
         serialize_check( value.lo == lo && value.hi == 0 );
         serialize_check( uint64_t( value ) == lo );
         serialize_check( uint64_t( uint128_emulated( hi, lo ) ) == lo );
+    }
+
+    // construction from every standard integer type mirrors native conversion: signed sources
+    // sign extend (negatives wrap modulo 2^128), unsigned sources zero extend. these are the
+    // exact cross signed cases that diverged before the per-type constructors existed.
+    {
+        serialize_check( ::mas_uint128_t( int64_t( -1 ) ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::mas_uint128_t( INT64_MIN ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0x8000000000000000ULL ) );
+        serialize_check( ::mas_uint128_t( uint64_t( 1 ) << 63 ) == uint128_emulated( 0, 0x8000000000000000ULL ) );
+        serialize_check( ::mas_uint128_t( UINT64_MAX ) == uint128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::mas_uint128_t( -5 ) == uint128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFBULL ) );       // int: sign extends
+        serialize_check( ::mas_uint128_t( 3000000000U ) == uint128_emulated( 0, 3000000000ULL ) );                          // unsigned: zero extends
+        serialize_check( ::mas_uint128_t( int64_t( 7 ) ) == uint128_emulated( 0, 7 ) );                                     // non negative signed: zero high lane
     }
 
     // all six comparisons, driven by the high lane, the low lane, and equality
@@ -4776,6 +4855,16 @@ inline void test_int128_emulation()
         serialize_check( ::mas_int128_t( 1 ) == int128_emulated( 0, 1 ) );
         serialize_check( int64_t( ::mas_int128_t( -5 ) ) == -5 );
         serialize_check( int64_t( ::mas_int128_t( INT64_MIN ) ) == INT64_MIN );
+
+        // unsigned sources are value preserving with a zero high lane, exactly like native: a
+        // uint64 with the top bit set stays a large positive value, it does NOT wrap negative.
+        // these are the exact cross signed cases that diverged before the per-type constructors.
+        serialize_check( ::mas_int128_t( uint64_t( 1 ) << 63 ) == int128_emulated( 0, 0x8000000000000000ULL ) );
+        serialize_check( ::mas_int128_t( uint64_t( 1 ) << 63 ) > ::mas_int128_t( 0 ) );
+        serialize_check( ::mas_int128_t( UINT64_MAX ) == int128_emulated( 0, 0xFFFFFFFFFFFFFFFFULL ) );
+        serialize_check( ::mas_int128_t( UINT64_MAX ) > ::mas_int128_t( 0 ) );
+        serialize_check( ::mas_int128_t( -5 ) == int128_emulated( 0xFFFFFFFFFFFFFFFFULL, 0xFFFFFFFFFFFFFFFBULL ) );     // int: sign extends
+        serialize_check( ::mas_int128_t( 3000000000U ) == int128_emulated( 0, 3000000000ULL ) );                        // unsigned: zero extends
 
         const ::mas_uint128_t bit_pattern = ::mas_uint128_t( ::mas_int128_t( -1 ) );
         serialize_check( bit_pattern.lo == 0xFFFFFFFFFFFFFFFFULL && bit_pattern.hi == 0xFFFFFFFFFFFFFFFFULL );
@@ -4968,6 +5057,10 @@ inline void test_uint128_differential()
         serialize_check( ( ea <= eb ) == ( na <= nb ) );
         serialize_check( ( ea >= eb ) == ( na >= nb ) );
 
+        // construction agreement from both signednesses of the drawn lanes
+        check_uint128_agree( ::mas_uint128_t( a_lo ), serialize::uint128_t( a_lo ) );
+        check_uint128_agree( ::mas_uint128_t( int64_t( a_lo ) ), serialize::uint128_t( int64_t( a_lo ) ) );
+
         ::mas_uint128_t emulated_accumulator = ea;
         serialize::uint128_t native_accumulator = na;
         check_uint128_agree( ++emulated_accumulator, ++native_accumulator );
@@ -4997,6 +5090,17 @@ inline void test_uint128_differential()
     }
 
     #undef serialize_test_next_lcg
+
+    // construction differential: the exact cross signed cases the audit proved uncovered.
+    // identical source expressions must construct identical values in both representations.
+    {
+        check_uint128_agree( ::mas_uint128_t( int64_t( -1 ) ),       serialize::uint128_t( int64_t( -1 ) ) );
+        check_uint128_agree( ::mas_uint128_t( INT64_MIN ),           serialize::uint128_t( INT64_MIN ) );
+        check_uint128_agree( ::mas_uint128_t( uint64_t( 1 ) << 63 ), serialize::uint128_t( uint64_t( 1 ) << 63 ) );
+        check_uint128_agree( ::mas_uint128_t( UINT64_MAX ),          serialize::uint128_t( UINT64_MAX ) );
+        check_uint128_agree( ::mas_uint128_t( -5 ),                  serialize::uint128_t( -5 ) );
+        check_uint128_agree( ::mas_uint128_t( 3000000000U ),         serialize::uint128_t( 3000000000U ) );
+    }
 
     // cross representation wire identity: the emulated type and native __int128 must produce
     // byte identical wire through serialize_uint128, and each must read the other's bytes back
@@ -5134,9 +5238,11 @@ inline void test_int128_differential()
         --decremented;
         check_int128_agree( decremented, serialize::int128_t( ua - 1 ) );
 
-        // conversions: the sign extending constructor and the truncating conversion match native
+        // conversions: the sign extending and value preserving constructors and the truncating
+        // conversion match native, from both signednesses of the drawn lane
         const int64_t seed64 = int64_t( a_lo );
         check_int128_agree( ::mas_int128_t( seed64 ), serialize::int128_t( seed64 ) );
+        check_int128_agree( ::mas_int128_t( a_lo ), serialize::int128_t( a_lo ) );
         serialize_check( int64_t( ea ) == int64_t( uint64_t( ua ) ) );
 
         // compound forms via the unsigned domain where overflow could occur
@@ -5166,6 +5272,17 @@ inline void test_int128_differential()
     }
 
     #undef serialize_test_next_lcg
+
+    // construction differential: the exact cross signed cases the audit proved uncovered.
+    // identical source expressions must construct identical values in both representations.
+    {
+        check_int128_agree( ::mas_int128_t( int64_t( -1 ) ),       serialize::int128_t( int64_t( -1 ) ) );
+        check_int128_agree( ::mas_int128_t( INT64_MIN ),           serialize::int128_t( INT64_MIN ) );
+        check_int128_agree( ::mas_int128_t( uint64_t( 1 ) << 63 ), serialize::int128_t( uint64_t( 1 ) << 63 ) );
+        check_int128_agree( ::mas_int128_t( UINT64_MAX ),          serialize::int128_t( UINT64_MAX ) );
+        check_int128_agree( ::mas_int128_t( -5 ),                  serialize::int128_t( -5 ) );
+        check_int128_agree( ::mas_int128_t( 3000000000U ),         serialize::int128_t( 3000000000U ) );
+    }
 }
 
 #endif // #if defined(__SIZEOF_INT128__)
@@ -5200,6 +5317,8 @@ struct GoldenWireData
     int32_t fixed_q16_16;
     int64_t fixed_q48_16;
     uint32_t fixed_q16_16_unsigned;
+    serialize::int128_t fixed_q112_16_wide;
+    serialize::int128_t fixed_q64_64_wide;
 };
 
 inline void GoldenWireInit( GoldenWireData & data )
@@ -5231,6 +5350,9 @@ inline void GoldenWireInit( GoldenWireData & data )
     data.fixed_q16_16 = 1234 * 65536 + 32768;                                       // 1234.5 in Q16.16
     data.fixed_q48_16 = -( int64_t( 54321 ) * 65536 + 12345 );                      // -54321.1883... in Q48.16
     data.fixed_q16_16_unsigned = 29999u * 65536 + 65535;                            // 29999.99998... in Q16.16: every fraction bit set
+    data.fixed_q112_16_wide = serialize::int128_t( -( int64_t( 98765432109LL ) * 65536 + 4321 ) );      // -98765432109.066 in Q112.16: 75 bits on the wire, three groups
+    data.fixed_q64_64_wide = ( serialize::int128_t( 0x0123456789ABCDEFLL ) << 64 )
+                           + serialize::int128_t( 0x0FEDCBA987654321LL );           // Q64.64 over the full unit range: 128 bits, four groups, every group distinct
 }
 
 template <typename Stream> bool GoldenWireSerialize( Stream & stream, GoldenWireData & data )
@@ -5261,6 +5383,9 @@ template <typename Stream> bool GoldenWireSerialize( Stream & stream, GoldenWire
     serialize_fixed( stream, data.fixed_q16_16, 16, 16, -2000, +2000 );
     serialize_fixed( stream, data.fixed_q48_16, 48, 16, -100000, +100000 );
     serialize_fixed( stream, data.fixed_q16_16_unsigned, 16, 16, 0, 30000 );
+    serialize_align( stream );                  // the wide fixed section starts byte aligned, so every byte pinned above it stays put
+    serialize_fixed( stream, data.fixed_q112_16_wide, 112, 16, -144115188075855872LL, +144115188075855872LL );      // ±2^57 units: 75 bits, the three group structure
+    serialize_fixed( stream, data.fixed_q64_64_wide, 64, 64, INT64_MIN, INT64_MAX );                                // full unit range: 128 bits, the four group structure
     return true;
 }
 
@@ -5273,7 +5398,9 @@ static const uint8_t golden_wire_bytes[] =
     0xEF, 0xCA, 0xFE, 0x01, 0x06, 0x67, 0x6F, 0x6C, 0x64, 0x65, 0x6E, 0xE3,
     0x21, 0x00, 0x00, 0xC0, 0x21, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00,
     0xC0, 0x60, 0x00, 0x80, 0xA2, 0x7C, 0xFC, 0xEC, 0x26, 0xCB, 0xFF, 0xFF,
-    0x4B, 0x1D
+    0x4B, 0x1D, 0x1F, 0xEF, 0xD2, 0x1A, 0x1F, 0x01, 0xE9, 0xFF, 0xFF, 0x09,
+    0x19, 0x2A, 0x3B, 0x4C, 0x5D, 0x6E, 0x7F, 0x78, 0x6F, 0x5E, 0x4D, 0x3C,
+    0x2B, 0x1A, 0x09, 0x04
 };
 
 inline void test_golden_wire_format()
@@ -5326,6 +5453,8 @@ inline void test_golden_wire_format()
         serialize_check( data.fixed_q16_16 == expected.fixed_q16_16 );
         serialize_check( data.fixed_q48_16 == expected.fixed_q48_16 );
         serialize_check( data.fixed_q16_16_unsigned == expected.fixed_q16_16_unsigned );
+        serialize_check( data.fixed_q112_16_wide == expected.fixed_q112_16_wide );
+        serialize_check( data.fixed_q64_64_wide == expected.fixed_q64_64_wide );
     }
 }
 

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -16,8 +16,11 @@ It is a hand-verified byte-exact snapshot of a message exercising every
 primitive: all four raw bit widths, a narrow and a full-range ranged int, a
 bool, a float, a quantized compressed float, a double, four unsigned widths,
 both interesting tiers of the relative-integer ladder, a byte block, a narrow
-string and a wide string. If a decoder written from the document reproduces all
+string, a wide string, and four fixed point fields across signed, unsigned,
+16/32/64-bit storage. If a decoder written from the document reproduces all
 of them and consumes exactly the right number of bits, the document is right.
+The library's second, additive pin — `golden_uint128_bytes` — is decoded the
+same way to verify the uint128 half order.
 
 The final check — that decoding consumed exactly the golden byte count — is the
 one that catches alignment errors. Fields can decode correctly while the bit

--- a/tools/conformance/verify_standard.py
+++ b/tools/conformance/verify_standard.py
@@ -116,6 +116,11 @@ def main():
     eq("fixed q16.16 (1234.5 in ±2000 units)", fixed(r, 16, -2000, 2000), 1234 * 65536 + 32768)
     eq("fixed q48.16 (in ±100000 units)", fixed(r, 16, -100000, 100000), -(54321 * 65536 + 12345))
     eq("fixed q16.16 unsigned (every fraction bit set)", fixed(r, 16, 0, 30000), 29999 * 65536 + 65535)
+    r.align()
+    eq("fixed q112.16 wide (75 bits: the 3-group structure)",
+       fixed(r, 16, -(2**57), 2**57), -(98765432109 * 65536 + 4321))
+    eq("fixed q64.64 wide (128 bits: the 4-group structure)",
+       fixed(r, 64, -(2**63), 2**63 - 1), (0x0123456789ABCDEF << 64) + 0x0FEDCBA987654321)
     eq("consumed exactly the golden bytes", math.ceil(r.i / 8), len(data))
 
     # STANDARD.md, 'uint128': 128 raw bits, low 64-bit half first, each half as

--- a/tools/conformance/verify_standard.py
+++ b/tools/conformance/verify_standard.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Check serialize/STANDARD.md against the implementation.
 
-Decodes the library's own golden wire-format vector using ONLY what
+Decodes the library's own golden wire-format vectors using ONLY what
 STANDARD.md states — the bit packing, the ranged-integer widths, the alignment
-rules, the relative-integer ladder — and asserts every field of the golden
-message. Nothing here consults serialize.h's implementation; the golden array
-and the expected values are read out of the header as data.
+rules, the relative-integer ladder, the fixed-point offset encoding, the
+uint128 half order — and asserts every field of the golden message plus the
+additive uint128 pin. Nothing here consults serialize.h's implementation; the
+golden arrays and the expected values are read out of the header as data.
 
 usage: python3 tools/conformance/verify_standard.py
 exit:  0 = the document matches the implementation, 1 = it does not
@@ -52,15 +53,28 @@ def relative(r, prev):
     return prev + r.bits(32)
 
 
-def golden_bytes():
+def hex_array(name):
     src = open(HDR).read()
-    m = re.search(r"golden_wire_bytes\[\]\s*=\s*\{(.*?)\};", src, re.S)
-    if not m: raise SystemExit("golden_wire_bytes not found in serialize.h")
+    m = re.search(name + r"\[\]\s*=\s*\{(.*?)\};", src, re.S)
+    if not m: raise SystemExit(name + " not found in serialize.h")
     return bytes(int(x, 16) for x in re.findall(r"0x([0-9A-Fa-f]{2})", m.group(1)))
 
 
+def fixed(r, fraction_bits, lo, hi):
+    """STANDARD.md, 'fixed': offset encoding over the raw (scaled) bounds,
+    written in 32-bit groups from least significant upward."""
+    raw_lo, raw_hi = lo << fraction_bits, hi << fraction_bits
+    n = bits_required(raw_lo, raw_hi)
+    v = 0
+    for g in range(0, n, 32):
+        v |= r.bits(min(32, n - g)) << g
+    if v > raw_hi - raw_lo:
+        raise ValueError("fixed offset out of range")
+    return v + raw_lo
+
+
 def main():
-    data = golden_bytes()
+    data = hex_array("golden_wire_bytes")
     r = BitReader(data)
     fails, n = [], 0
 
@@ -97,7 +111,20 @@ def main():
     ln = sint(r, 0, 7)
     eq("wstring (32 bits per char, NO alignment)",
        [r.bits(32) for _ in range(ln)], [0x043C, 0x0438, 0x0440])
+    r.align()
+    eq("fixed q8.8 (-3.25 in ±100 units)", fixed(r, 8, -100, 100), -(3 * 256 + 64))
+    eq("fixed q16.16 (1234.5 in ±2000 units)", fixed(r, 16, -2000, 2000), 1234 * 65536 + 32768)
+    eq("fixed q48.16 (in ±100000 units)", fixed(r, 16, -100000, 100000), -(54321 * 65536 + 12345))
+    eq("fixed q16.16 unsigned (every fraction bit set)", fixed(r, 16, 0, 30000), 29999 * 65536 + 65535)
     eq("consumed exactly the golden bytes", math.ceil(r.i / 8), len(data))
+
+    # STANDARD.md, 'uint128': 128 raw bits, low 64-bit half first, each half as
+    # serialize_bits( half, 64 ). Verified against the library's second, additive pin.
+    u = BitReader(hex_array("golden_uint128_bytes"))
+    lo = u.bits(32) | (u.bits(32) << 32)
+    hi = u.bits(32) | (u.bits(32) << 32)
+    eq("uint128 (low half first, little endian bytes)",
+       (hi << 64) | lo, 0x0123456789ABCDEF_FEDCBA9876543210)
 
     print(f"{n} checks against STANDARD.md, {len(fails)} failures")
     for f in fails: print("  FAIL " + f)

--- a/tools/conformance/verify_standard.py
+++ b/tools/conformance/verify_standard.py
@@ -73,6 +73,23 @@ def fixed(r, fraction_bits, lo, hi):
     return v + raw_lo
 
 
+def ranged128(r, lo, hi):
+    """STANDARD.md, 'int128 (ranged)': offset encoding computed in the unsigned
+    128-bit domain, written in 32-bit groups from least significant upward with
+    the final group carrying the remainder."""
+    mask = (1 << 128) - 1
+    lo &= mask
+    hi &= mask
+    n = 0 if lo == hi else ((hi - lo) & mask).bit_length()
+    v = 0
+    for g in range(0, n, 32):
+        v |= r.bits(min(32, n - g)) << g
+    if v > ((hi - lo) & mask):
+        raise ValueError("int128 offset out of range")
+    out = (v + lo) & mask
+    return out - (1 << 128) if out >= (1 << 127) else out
+
+
 def main():
     data = hex_array("golden_wire_bytes")
     r = BitReader(data)
@@ -130,6 +147,14 @@ def main():
     hi = u.bits(32) | (u.bits(32) << 32)
     eq("uint128 (low half first, little endian bytes)",
        (hi << 64) | lo, 0x0123456789ABCDEF_FEDCBA9876543210)
+
+    # STANDARD.md, 'int128 (ranged)': offset encoding over the unsigned 128-bit
+    # domain in 32-bit groups. Bounds of +/- 2^70 need 72 bits, so this pin
+    # load-bears the THREE-group structure — 32, 32, then an 8-bit remainder.
+    s = BitReader(hex_array("golden_int128_bytes"))
+    eq("int128 ranged (3-group structure, +/- 2^70 bounds)",
+       ranged128(s, -(1 << 70), 1 << 70), -0x0123456789ABCDEF)
+    eq("int128 ranged consumed exactly 72 bits", s.i, 72)
 
     print(f"{n} checks against STANDARD.md, {len(fails)} failures")
     for f in fails: print("  FAIL " + f)


### PR DESCRIPTION
Fixed-point and 128-bit integer serialization — exact, deterministic, compile-time-parameterized, on every platform.

## What's here

- **`serialize_fixed` / `read_fixed` / `write_fixed`**: fixed-point serialization with the Q format *and* bounds as compile-time template parameters — `serialize_fixed( stream, value, 48, 16, -8192, 8192 )` — whole-unit bounds shifted to raw by integer math (no float anywhere), offset encoding in a constexpr bit count, reject-on-read. Exact round trip: the deterministic twin of `serialize_compressed_float`. Storage deduced: int16/int32/int64, unsigned, and 128-bit wide (Q112.16) on **every** platform, including pure MSVC via the emulated storage below.
- **`serialize_uint128` / `read_uint128` / `write_uint128`**: raw 128 bits, lo-then-hi halves, duck-typed over native `__int128` or any conforming emulation; `static_assert` width refusal against the uint64 slip.
- **`serialize::uint128_t` / `serialize::int128_t` everywhere**: native where the compiler has `__int128`, else the shipped emulated pair `mas_uint128_t` / `mas_int128_t` — full operator surface, native-exact semantics (construction included, per-type constructors), dual-language POD block (C-compatible layout, C++ operators guarded) under the `MAS_UINT128_DEFINED` handshake so serialize, fixed, and the game define it once per TU.
- **Tests**: 28 native / 26 emulated-world; differential-vs-native harnesses for both emulated types (400 LCG operand pairs per type, every operator, construction from both signednesses); comprehensive fixed matrix incl. the 33/54/64-bit wide band edges; smuggled-out-of-range rejection per codec path; golden pins extended additively (72-byte prefix untouched, byte-for-byte) with load-bearing 75-bit and 128-bit wide fields whose expected bytes were derived independently from STANDARD.md in Python; conformance checker now 27 checks with mutation-proven wide-group coverage; example PacketF through the exact memcmp path with no tolerance carve-out (the contrast with compressed floats is the point).
- **Docs**: STANDARD.md wire sections (fixed, uint128, the portability story), README, CLAUDE.md anchors re-derived and programmatically verified.

## Verification story

Full suite green in three worlds: native (Debug, Release, ASan+UBSan), emulated (`-U__SIZEOF_INT128__`, the MSVC-shaped path), and 300k sanitized fuzz-driver inputs in both. An adversarial audit round (13 agents, six lenses, refute-by-default verification) returned **zero wire defects** — the encoding survived independent re-derivation from STANDARD.md alone and exhaustive bit-pattern sweeps — and its 7 confirmed findings (cross-signed construction divergence, a missing width refusal, two fault-injection-proven coverage gaps, stale doc anchors) are all repaired and re-verified in this branch. CI's windows-2025 job is the first true MSVC compile of the guards.

## Open questions for the author

1. **Ratify the names**: `mas_uint128_t`, `mas_int128_t`, and the single `MAS_UINT128_DEFINED` announcing the pair (sibling copies in fixed and the game must carry the block whole — the construction differentials are what catch a stale copy).
2. Division/modulo by zero yields zero,zero (no assert dependency in the shared block) — confirm.
3. `serialize::int128_t` is now public API on every platform — confirm.
4. `BitsRequired128` is no longer used by the codec (kept for tests, native-only) — keep or drop?
5. `INT128_MIN / −1` wraps, documented, matching hardware — confirm the stance.

Sequencing per the author: ports and yojimbo vendoring only once completely happy with the C++. No version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
