### PR TITLE
WriteBytes: pack head and tail bytes as whole values instead of byte-at-a-time WriteBits

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -1118,6 +1118,7 @@ namespace serialize
             Write an array of bytes to the bit stream.
             Use this when you have to copy a large block of data into your bitstream.
             Faster than just writing each byte to the bit stream via BitWriter::WriteBits( value, 8 ), because it aligns to byte index and copies into the buffer without bitpacking.
+            Implementation: the head bytes that complete the partial scratch word are packed as one value (not byte-at-a-time), whole words are copied with memcpy, and the tail bytes land in the empty scratch as one value. At most two shift/or operations and one memcpy per call.
             @param data The byte array data to write to the bit stream.
             @param bytes The number of bytes to write.
             @see BitReader::ReadBytes
@@ -1129,17 +1130,40 @@ namespace serialize
             serialize_assert( GetAlignBits() == 0 );
             serialize_assert( uint64_t(m_bitsWritten) + uint64_t(bytes) * 8 <= uint64_t(m_numBits) );
             serialize_assert( ( m_bitsWritten % 8 ) == 0 );
+            serialize_assert( ( m_scratchBits % 8 ) == 0 );                             // byte aligned, so the scratch holds whole bytes
 
-            int64_t headBytes = ( 8 - ( m_bitsWritten % 64 ) / 8 ) % 8;
+            // head: the bytes that complete the partial scratch word, packed as a single value.
+            // assembling least significant byte first matches the wire format on every platform, because scratch words are stored through host_to_network.
+
+            int64_t headBytes = ( ( 64 - m_scratchBits ) / 8 ) % 8;
             if ( headBytes > bytes )
                 headBytes = bytes;
-            for ( int64_t i = 0; i < headBytes; ++i )
-                WriteBits( data[i], 8 );
+            if ( headBytes > 0 )
+            {
+                uint64_t head = 0;
+                for ( int64_t i = 0; i < headBytes; ++i )
+                    head |= uint64_t( data[i] ) << ( 8 * i );
+                m_scratch |= head << m_scratchBits;
+                const int newScratchBits = m_scratchBits + (int) headBytes * 8;
+                serialize_assert( newScratchBits <= 64 );
+                if ( newScratchBits == 64 )
+                {
+                    const uint64_t word = host_to_network( m_scratch );
+                    memcpy( m_data + (size_t) m_wordIndex * 8, &word, sizeof( word ) );
+                    m_wordIndex++;
+                    m_scratch = 0;
+                    m_scratchBits = 0;
+                }
+                else
+                {
+                    m_scratchBits = newScratchBits;
+                }
+                m_bitsWritten += headBytes * 8;
+            }
             if ( headBytes == bytes )
                 return;
 
-            serialize_assert( GetAlignBits() == 0 );
-            serialize_assert( ( m_bitsWritten % 64 ) == 0 && m_scratchBits == 0 );      // the head bytes flushed the scratch at the word boundary
+            serialize_assert( ( m_bitsWritten % 64 ) == 0 && m_scratchBits == 0 && m_scratch == 0 );        // the head bytes filled the scratch to the word boundary
 
             int64_t numWords = ( bytes - headBytes ) / 8;
             if ( numWords > 0 )
@@ -1147,16 +1171,22 @@ namespace serialize
                 memcpy( m_data + (size_t) m_wordIndex * 8, data + headBytes, (size_t) ( numWords * 8 ) );
                 m_bitsWritten += numWords * 64;
                 m_wordIndex += numWords;
-                m_scratch = 0;
             }
 
-            serialize_assert( GetAlignBits() == 0 );
+            // tail: the remaining bytes land in the empty scratch as a single value
 
             int64_t tailStart = headBytes + numWords * 8;
             int64_t tailBytes = bytes - tailStart;
             serialize_assert( tailBytes >= 0 && tailBytes < 8 );
-            for ( int64_t i = 0; i < tailBytes; ++i )
-                WriteBits( data[tailStart+i], 8 );
+            if ( tailBytes > 0 )
+            {
+                uint64_t tail = 0;
+                for ( int64_t i = 0; i < tailBytes; ++i )
+                    tail |= uint64_t( data[tailStart+i] ) << ( 8 * i );
+                m_scratch = tail;
+                m_scratchBits = (int) tailBytes * 8;
+                m_bitsWritten += tailBytes * 8;
+            }
 
             serialize_assert( GetAlignBits() == 0 );
 


### PR DESCRIPTION
# WriteBytes: pack head and tail bytes as whole values instead of byte-at-a-time WriteBits

## Branch note

Branched off `origin/fixed-point` (PR #26 @ 6ad407d), not main, so this lands cleanly on
post-merge main once #26 goes in — the diff is one function in `serialize.h` and touches
nothing #25/#26 touch. **GitHub Actions is in an outage today; every verification below ran
locally (arm64 macOS M2 + x86_64 Linux EPYC 9124 over ssh).** The s390x big-endian golden
job should run when Actions recovers; the change is endian-safe by construction (the
head/tail values are assembled least-significant-byte-first, which is wire order on every
platform, and the store goes through the same `host_to_network` as `WriteBits`).

## The profile conviction (EPYC 9124, perf, schema bench-harness @ 2568056, serialize @ 6ad407d)

Hotspot 3 of today's bench pass said the byte/string paths are bytes-loop bound. The perf
evidence, before any change:

- **clang 18, whole 12-benchmark run:** `serialize::BitWriter::WriteBytes` stays **outlined
  at 2.07%** of total cycles (`perf report`), and inside it the bulk word copy is nearly
  free — `0.83 : 133fe: call memcpy@plt` — while the samples pile on the per-byte
  head/tail `WriteBits` chains (line histogram: serialize.h:1095/:1136/:1081/:1087/:1158 —
  the scratch-spill machinery and the two per-byte loops).
- **g++ 13:** WriteBytes is inlined but the same chains dominate `WriteChat` (4.76% of the
  run; hot lines serialize.h:1077/:1081/:1088 = WriteBits body, :1136/:1158 = the head/tail
  loops). `BitWriter::WriteBits` itself is the top symbol at 8.37% (that is hotspot 2,
  const-params territory, not this PR).
- **What serialize can NOT fix:** ~58% of `WriteTestData` self-cycles sit in the generated
  17x `write_bits(...,8)` loop for the `fixed_bytes` field, and ~57% of `ReadTestData`
  self-cycles in the unrolled 17x `read_bits(8)`; the string interior-null re-walk is only
  5.5% of `ReadTestData`. Those are schema emitter findings (per-byte loops in generated
  code) — recorded for the schema repo, untouchable from this header. The read-side byte
  path here was already a straight memcpy (`ReadStream::SerializeBytes` 0.72% clang / 0.03%
  g++) and is untouched.

## The fix

`WriteBytes` runs byte-aligned (`SerializeBytes` aligns first; the entry assert requires
it), so the scratch holds whole bytes. The rewrite:

- **head**: the bytes that complete the partial scratch word are assembled into one value
  (LSB-first) and packed with one shift/or and at most one qword store — was up to 7 full
  `WriteBits` calls, each paying the spill check, `m_bitsWritten` update and possible store;
- **bulk**: the whole-word memcpy is unchanged;
- **tail**: the remaining <8 bytes land in the empty scratch as one assembled value, no
  store — was up to 7 more `WriteBits` calls.

No force-inline attribute: the repo has no such convention (checked — `serialize_restrict`
is the only compiler-abstraction macro), and inventing one was not convicted: g++ 13 and
Apple clang 21 inline the rewritten function on their own (checked via objdump — `WriteChat`
carried a call to WriteBytes before, none after), and where Linux clang 18 still outlines
it the function now does a fraction of the per-call work (testdata write +8.8% there). If
the last few percent on short strings under Linux clang matter, a force-inline convention
is its own discussion — flagged in the numbers section rather than smuggled in here.

## Wire bytes unchanged — proven four ways

1. `test_golden_wire_format` (the exact-byte pin) green in every build below.
2. `python3 tools/conformance/verify_standard.py` → **"29 checks against STANDARD.md, 0
   failures"** (includes the fixed-point/128-bit checks on this branch).
3. Differential fuzz smoke (write→read round trip traps any asymmetry), clang 18 on the
   EPYC: `./build-fuzz/bin/fuzz -max_total_time=60` → **1,377,136 execs, no findings**.
4. A before/after sweep dumping the wire for every byte-aligned scratch offset x payload
   length 0..24 (57 x 25 = 1425 buffers): `cmp` byte-identical.
5. The schema harness's own golden gate: every benched after-binary (M2 clang, EPYC g++ 13
   and clang 18) byte-compared the pinned corpus against `testdata/wire/*.bin` and
   round-tripped it before benching — a mismatch refuses to bench; all runs benched.

## Full suite (all local, commands as run)

| host | build | result |
|---|---|---|
| M2 (arm64 macOS) | `cmake -B build-release -DCMAKE_BUILD_TYPE=Release && cmake --build build-release && ctest --test-dir build-release` | 100% pass |
| M2 | same, `build-debug` Debug (asserts live) | 100% pass |
| M2 | `-DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer"` Debug | 100% pass |
| EPYC (x86_64 Linux) | Release + Debug (g++ 13) | 100% pass |
| EPYC | ASan+UBSan (clang 18, same flags) | 100% pass |
| EPYC | fuzz smoke (clang 18, `-DSERIALIZE_FUZZ=ON`, 60 s) | no findings |
| both | `tools/conformance/verify_standard.py` | 29/29 |

## Numbers (predictions banked before measuring; refutations stated plainly)

Methodology: paired before (= `origin/fixed-point` @ 6ad407d) / after, interleaved runs,
medians; schema harness @ `bench-harness` 2568056 (no harness changes landed today between
my before/after — both sides benched the same harness state). M2 is quiet; the EPYC benches
`taskset -c 0` on the shared core **beside a running game server — NOISY, much heavier than
this morning's baseline** (absolute rates are ~2-3x below the baseline CSVs; paired ratios
are the meaningful numbers, and rows whose ratio spread straddles 1.0 are reported as
unmeasurable rather than claimed).

### serialize's own bench.cpp (MB/s, median of interleaved runs: 7 pairs M2, 15 pairs EPYC)

| metric | M2 before | M2 after | Δ | EPYC before | EPYC after | Δ |
|---|---:|---:|---:|---:|---:|---:|
| bitpacker write | 3643.1 | 3637.8 | -0.1% | 1253.5 | 1251.8 | 0.0% |
| bitpacker read | 5646.4 | 5665.9 | +0.3% | 1051.6 | 1044.2 | -0.7% |
| stream write | 1684.6 | 1734.1 | **+2.9%** | 2066.6 | 1951.3 | unmeasurable (pairwise IQR 0.82-1.04) |
| stream read | 4993.0 | 5004.2 | +0.2% | — | — | unmeasurable (pairwise IQR 0.69-2.43) |
| stream measure | 821.0 | 821.1 | 0.0% | — | — | — |

The bench.cpp packet's 17-byte blob lands word-aligned by construction (249 bits of fields,
then align), so head/tail work was already minimal there — the +2.9% M2 stream write is the
removed tail `WriteBits` plus codegen; the bitpacker rows never touch `WriteBytes` and hold
exactly flat, as predicted.

### schema harness, byte/string rows (M msg/s, medians)

| bench | path | M2 before | M2 after | Δ | EPYC g++ Δ | EPYC clang Δ |
|---|---|---:|---:|---:|---:|---:|
| chat (the pure string-path bench) | write | 102.88 | 116.37 | **+13.1%** | **+22.9%** (11.84→14.56, spreads 2.5/4.3%) | +0.2% |
| chat | read | 128.85 | 135.31 | +5.0% (30% after-spread) | +4.6% (spreads 33/15%) | -0.6% |
| testdata | write | 17.25 | 17.55 | +1.7% | +6.9% | **+8.8%** |
| testdata | read | 15.11 | 15.36 | +1.6% | -0.5% | -1.3% |
| message_batch | write | 81.51 | 80.54 | -1.2% (spreads 9/4%) | +2.4% | +4.0% |
| message_batch | read | 68.74 | 67.27 | -2.1% (spreads 8/6%) | -4.2% (spreads 7/15%) | -1.9% |

EPYC g++ figures are the first back-to-back pair (each side median-of-7); the later
3x-interleaved g++ pairs were discarded whole because runs 2-3 show every row — byte paths
and untouched raw-bit paths alike — moving ~2x/~0.5x with the box's load (their run 1
corroborates: chat write +16.9%). EPYC clang figures are the median pairwise ratio across
3 interleaved full runs (they landed in a calmer window; ratios cluster at 1.00 +/- 0.05
on untouched rows).

The compiler split is real and explains itself: g++ 13 and Apple clang 21 inline the
rewritten WriteBytes into the chat write path (checked via objdump: `WriteChat` had
`bl/call WriteBytes` before, none after on the M2), so the 13-byte chat text gets the full
benefit; Linux clang 18 keeps WriteBytes outlined in both binaries, so short-payload chat
keeps paying the call and shows ~0%, while testdata's longer text still gains +8.8% from
the removed per-byte work inside the function.

All other rows on the quiet M2 are within noise (biggest mover, rigidbody_moving write
+14%, had a 27% before-spread — a descheduled run, not a signal; probebits read -3.4% with
tight spreads is binary-layout jitter on an untouched path).

### Predictions vs outcomes (banked in the session scratchpad before profiling)

- *WriteBytes outlined under clang, self time in per-byte head/tail, memcpy small* — **held** (2.07%, 0.83% memcpy line).
- *Most testdata cycles unreachable from serialize.h (generated per-byte loops)* — **held** (58%/57% of Write/ReadTestData self).
- *Read side near-flat* — **held** (testdata read +1.6%; the read path is untouched).
- *serialize bench stream write +5-15%* — **refuted low**: +2.9% on M2. The blob is
  word-aligned in that packet, so the old per-byte head path barely ran there.
- *testdata write +3-10%* — mixed: +1.7% M2 (below band), +6.9% g++ / +8.8% clang on the
  EPYC (in band). The text field is one field among many; the fixed_bytes loop dominates
  and is generated code.
- *chat write not explicitly banded* — the +13-23% where the compiler inlines is the
  cleanest statement of the fix; the Linux clang 18 ~0% (still outlined, 13 B payload) is
  reported as measured.
- *String-read null re-walk a major read cost* — **refuted**: 5.5% of ReadTestData self.
  Recorded so the emitter follow-up prioritizes the per-byte loops, not the scan.

## Follow-up recorded for the schema repo (not this PR)

The emitter writes `fixed_bytes`/`bytes(N)` element loops as per-byte `write_bits(...,8)` /
`read_bits(8)` instead of `write_bytes`/`read_bytes` after the align it already emits, and
re-walks strings for the interior-null scan after `read_bytes`. That is where the majority
of testdata's remaining cycles live (58%/57% self-share above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
