### PR TITLE
Pre-C++11 consumers: signed to unsigned 128 bit conversion as a C++98 constructor, digraph-proof specializations, -std=c++03 CI leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,31 @@ jobs:
       - name: Test
         run: ctest --test-dir build --output-on-failure
 
+  # the strictest language mode a real consumer compiles the vendored header in. Every other job
+  # builds at the toolchain default (>= C++14), which is how a functional-style cast routed through
+  # a C++11-only explicit conversion operator shipped: yojimbo's macOS leg builds at Apple clang's
+  # default (gnu++98) and was the first thing to compile the header pre-C++11. clang specifically,
+  # because the guarded property is "compiles in C++98/03 with the declaration-only C++11
+  # extensions accepted as warnings" — the profile of the consumer that broke (gcc hard-errors on
+  # those extensions, so it cannot check this). SERIALIZE_ENABLE_TESTS forces the emulated 128 bit
+  # pair even on native-__int128 hosts, exactly as yojimbo's test build does; the second compile
+  # drops native __int128 so the emulated pair is the real storage type on the wire.
+  cxx03-consumer:
+    name: pre-C++11 consumer (clang -std=c++03)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and run tests at -std=c++03 (emulated pair alongside native)
+        run: |
+          clang++ -std=c++03 -DSERIALIZE_ENABLE_TESTS=1 -DSERIALIZE_DEBUG -Wall -Wextra -ffast-math -fno-rtti test.cpp -o test_cxx03
+          ./test_cxx03
+
+      - name: Build and run tests at -std=c++03 (emulated pair as the serialize types)
+        run: |
+          clang++ -std=c++03 -DSERIALIZE_ENABLE_TESTS=1 -DSERIALIZE_DEBUG -U__SIZEOF_INT128__ -Wall -Wextra -ffast-math -fno-rtti test.cpp -o test_cxx03_no_int128
+          ./test_cxx03_no_int128
+
   conformance:
     name: STANDARD.md conformance
     runs-on: ubuntu-24.04

--- a/serialize.h
+++ b/serialize.h
@@ -50,6 +50,19 @@
 #define serialize_assert assert
 #endif // #ifndef serialize_assert
 
+// static_assert is C++11, and consumers vendor this header into pre-C++11 builds, so compile
+// time invariants go through this macro: real static_assert (message included) from C++11 up
+// and on MSVC (which ships static_assert in every language mode it supports), and a negative
+// size array emulation before that — the message string is dropped, and the compile error
+// points at the macro use site. the attribute silences unused-local-typedef warnings.
+#if ( defined( __cplusplus ) && __cplusplus >= 201103L ) || defined( _MSC_VER )
+#define serialize_static_assert( condition, message ) static_assert( condition, message )
+#else // #if ( defined( __cplusplus ) && __cplusplus >= 201103L ) || defined( _MSC_VER )
+#define serialize_static_assert_join2( a, b ) a##b
+#define serialize_static_assert_join( a, b ) serialize_static_assert_join2( a, b )
+#define serialize_static_assert( condition, message ) typedef char serialize_static_assert_join( serialize_static_assert_line_, __LINE__ )[ ( condition ) ? 1 : -1 ] __attribute__(( unused ))
+#endif // #if ( defined( __cplusplus ) && __cplusplus >= 201103L ) || defined( _MSC_VER )
+
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS
 #endif
@@ -2503,7 +2516,7 @@ namespace serialize
     {
         // refuse narrower types at compile time: a uint64_t here would shift by 64 — undefined
         // behavior — and silently is not the 128 bit operation the caller asked for
-        static_assert( sizeof( UInt128 ) == 16, "serialize_uint128 requires a 128 bit type (did you mean serialize_uint64?)" );
+        serialize_static_assert( sizeof( UInt128 ) == 16, "serialize_uint128 requires a 128 bit type (did you mean serialize_uint64?)" );
 
         uint64_t low_half = 0;
         uint64_t high_half = 0;
@@ -2903,8 +2916,8 @@ namespace serialize
                 int64_t( ( uint64_t(1) << ( IntegerBits - 1 ) ) - 1 ) :
                 ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( IntegerBits < 64 ? IntegerBits : 0 ) ) - 1 ) );
 
-            static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
-            static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
+            serialize_static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
+            serialize_static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
 
             // shift the whole unit bounds into raw fixed point units in the unsigned domain, so negative bounds wrap two's complement instead of invoking undefined behavior.
             // everything below is a compile time constant: the bounds, the range and the bit count all fold, so the call site carries no runtime bit width computation at all.
@@ -2984,8 +2997,8 @@ namespace serialize
                 ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( ( IntegerBits < 64 ? IntegerBits : 1 ) - 1 ) ) - 1 ) ) :
                 ( ( IntegerBits >= 64 ) ? INT64_MAX : int64_t( ( uint64_t(1) << ( IntegerBits < 64 ? IntegerBits : 0 ) ) - 1 ) );
 
-            static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
-            static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
+            serialize_static_assert( MinUnits >= min_representable_units, "serialize_fixed min bound in whole units does not fit the Q format" );
+            serialize_static_assert( MaxUnits <= max_representable_units, "serialize_fixed max bound in whole units does not fit the Q format" );
 
             // shift the whole unit bounds into raw fixed point units in the unsigned 128 bit domain, so negative bounds wrap two's complement instead of invoking undefined behavior.
             // the storage constructor sign extends the int64 bounds for signed storage. everything below folds: the bounds, the range, the bit count and the group structure.
@@ -3095,11 +3108,11 @@ namespace serialize
     template <int IntegerBits, int FractionalBits, int64_t MinUnits, int64_t MaxUnits, typename Stream, typename Storage>
     bool serialize_fixed_internal( Stream & stream, Storage & value )
     {
-        static_assert( FixedPointInteger<Storage>::is_integer == 1, "serialize_fixed storage must be an integer type" );
-        static_assert( IntegerBits >= 1, "serialize_fixed needs at least one integer bit. the sign bit counts for signed storage" );
-        static_assert( FractionalBits >= 0, "serialize_fixed fractional bits can't be negative" );
-        static_assert( IntegerBits + FractionalBits == 8 * (int) sizeof( Storage ), "serialize_fixed integer bits plus fractional bits must equal the number of bits in the storage type" );
-        static_assert( MinUnits < MaxUnits, "serialize_fixed min must be below max" );
+        serialize_static_assert( FixedPointInteger<Storage>::is_integer == 1, "serialize_fixed storage must be an integer type" );
+        serialize_static_assert( IntegerBits >= 1, "serialize_fixed needs at least one integer bit. the sign bit counts for signed storage" );
+        serialize_static_assert( FractionalBits >= 0, "serialize_fixed fractional bits can't be negative" );
+        serialize_static_assert( IntegerBits + FractionalBits == 8 * (int) sizeof( Storage ), "serialize_fixed integer bits plus fractional bits must equal the number of bits in the storage type" );
+        serialize_static_assert( MinUnits < MaxUnits, "serialize_fixed min must be below max" );
 
         return FixedPointSerializer< ( 8 * (int) sizeof( Storage ) > 64 ) >::template Serialize<IntegerBits, FractionalBits, MinUnits, MaxUnits>( stream, value );
     }
@@ -4544,7 +4557,7 @@ inline void test_serialize_fixed()
         serialize_check( stream.GetBitsProcessed() == 16 );         // 200 << 8 raw values needs 16 bits
     }
 
-    // compile time refusals. each of the following fails with a static_assert, which is the point.
+    // compile time refusals. each of the following fails with a serialize_static_assert, which is the point.
     // kept as comments because a compile failure can't run inside the suite: uncomment one to verify.
     //
     //     int32_t value = 0;

--- a/serialize.h
+++ b/serialize.h
@@ -159,6 +159,14 @@
 // their own function wrappers in their own tree. Everything else — constructors, the full
 // operator surface, the explicit conversions — is C++ only, inside #ifdef __cplusplus.
 //
+// The C++ in this block must stay usable by pre-C++11 consumers: a vendored header does not get
+// to choose the consumer's -std, and real consumers compile it at C++98/03 (clang accepts the
+// declaration-only C++11 extensions here — `= default`, the explicit conversion operators to the
+// 64 bit lanes — with a warning in those modes, but overload resolution before C++11 never
+// SELECTS an explicit conversion operator, so every conversion the library performs routes
+// through C++98 constructs: converting constructors). CI compiles and runs the tests at
+// -std=c++03 to hold this.
+//
 // Semantics match native __int128 exactly, with documented choices where native has none:
 // shift counts outside [0,127] yield zero (all sign bits for the signed arithmetic right
 // shift; native shifts by 128 or more are undefined behavior), and signed INT128_MIN over -1
@@ -181,6 +189,10 @@
 
 #if !defined( SERIALIZE_UINT128_DEFINED ) && ( !defined( __SIZEOF_INT128__ ) || SERIALIZE_ENABLE_TESTS )
 
+#ifdef __cplusplus
+struct serialize_int128_t;      // forward declaration for the bit preserving converting constructor below
+#endif
+
 typedef struct serialize_uint128_t
 {
     uint64_t lo;            ///< the low 64 bits. first, matching the little endian layout and the wire order
@@ -202,6 +214,14 @@ typedef struct serialize_uint128_t
     serialize_uint128_t( unsigned int value )       : lo( value ), hi( 0 ) {}
     serialize_uint128_t( unsigned long value )      : lo( value ), hi( 0 ) {}
     serialize_uint128_t( unsigned long long value ) : lo( value ), hi( 0 ) {}
+
+    // bit preserving conversion from the signed type, defined inline after serialize_int128_t below.
+    // this is a converting CONSTRUCTOR, not a conversion operator on serialize_int128_t, on purpose:
+    // explicit conversion operators are C++11, and consumers vendor this header into pre-C++11
+    // builds where a functional-style cast through one does not compile (overload resolution never
+    // considers explicit conversion functions before C++11). an explicit converting constructor is
+    // C++98 and behaves identically at every cast site.
+    explicit serialize_uint128_t( serialize_int128_t value );
 
     explicit operator uint64_t () const
     {
@@ -496,13 +516,10 @@ typedef struct serialize_int128_t
 
     explicit serialize_int128_t( serialize_uint128_t value ) : lo( value.lo ), hi( value.hi ) {}        // bit preserving
 
-    explicit operator serialize_uint128_t () const                                                // bit preserving
-    {
-        serialize_uint128_t result( 0 );
-        result.lo = lo;
-        result.hi = hi;
-        return result;
-    }
+    // the bit preserving conversion in the other direction is the explicit
+    // serialize_uint128_t( serialize_int128_t ) constructor, declared on the unsigned type and
+    // defined after this struct — a constructor rather than a C++11 explicit conversion operator
+    // so serialize_uint128_t( signed_value ) compiles in pre-C++11 consumers too
 
     explicit operator int64_t () const
     {
@@ -668,6 +685,14 @@ typedef struct serialize_int128_t
 #endif // #ifdef __cplusplus
 
 } serialize_int128_t;
+
+#ifdef __cplusplus
+
+// the bit preserving signed to unsigned conversion declared inside serialize_uint128_t above,
+// defined here where serialize_int128_t is complete
+inline serialize_uint128_t::serialize_uint128_t( serialize_int128_t value ) : lo( value.lo ), hi( value.hi ) {}
+
+#endif // #ifdef __cplusplus
 
 #define SERIALIZE_UINT128_DEFINED 1
 
@@ -2833,8 +2858,8 @@ namespace serialize
     // the emulated pair works as storage too. without native __int128 these ARE the serialize
     // typedefs; with it they are a distinct set of types (present when tests are enabled, or
     // when a sibling header defined the block first), so the specializations never collide
-    template <> struct FixedPointInteger<::serialize_int128_t>            { enum { is_integer = 1, is_signed = 1 }; };
-    template <> struct FixedPointInteger<::serialize_uint128_t>           { enum { is_integer = 1, is_signed = 0 }; };
+    template <> struct FixedPointInteger< ::serialize_int128_t >            { enum { is_integer = 1, is_signed = 1 }; };
+    template <> struct FixedPointInteger< ::serialize_uint128_t >           { enum { is_integer = 1, is_signed = 0 }; };
 #endif // #if defined(SERIALIZE_UINT128_DEFINED)
 
     /**
@@ -2852,8 +2877,8 @@ namespace serialize
     template <> struct FixedPointUnsigned<uint128_t>                { typedef uint128_t type; };
 #endif // #if defined(__SIZEOF_INT128__)
 #if defined(SERIALIZE_UINT128_DEFINED)
-    template <> struct FixedPointUnsigned<::serialize_int128_t>           { typedef ::serialize_uint128_t type; };
-    template <> struct FixedPointUnsigned<::serialize_uint128_t>          { typedef ::serialize_uint128_t type; };
+    template <> struct FixedPointUnsigned< ::serialize_int128_t >           { typedef ::serialize_uint128_t type; };
+    template <> struct FixedPointUnsigned< ::serialize_uint128_t >          { typedef ::serialize_uint128_t type; };
 #endif // #if defined(SERIALIZE_UINT128_DEFINED)
 
     /**


### PR DESCRIPTION
## What

Backwards-compat defect caught by the yojimbo vendor trial (mas-bandwidth/yojimbo#326, job 92728237341): yojimbo's macOS arm64 debug make leg compiles at Apple clang's **default language mode (gnu++98)**, and in that mode the newly vendored serialize.h fails to compile:

```
error: no matching conversion for functional-style cast from 'const serialize_int128_t' to 'serialize_uint128_t'
```

at serialize.h:556-563, 569, 581, 596, 606-607 (and, past clang's default error limit, at the fixed point codec's generic `Unsigned( Storage )` casts and one test site). serialize's own CI is all-green because every leg builds at the toolchain default (>= C++14) — this was a strictness gap only a real consumer could expose, which is exactly what the vendor trial exists to do.

## Why it failed

The signed-to-unsigned bit preserving conversion was an **explicit conversion operator** on `serialize_int128_t` — a C++11 feature. clang accepts the *declaration* in C++98/03 mode as an extension (warning only), but overload resolution before C++11 **never selects** an explicit conversion function, so every `serialize_uint128_t( signed_value )` functional-style cast has no viable path.

A second, independent pre-C++11 break hid behind the same error limit: `FixedPointInteger<::serialize_int128_t>` — before C++11, `<:` is the digraph for `[`.

## The fix

- The conversion becomes an **explicit converting constructor** `serialize_uint128_t( serialize_int128_t )` — C++98, identical behavior at every cast site (explicit both before and after; direct-init picks it as an exact match), same member-wise `lo`/`hi` init. Declared in-class against a forward declaration, defined inline after `serialize_int128_t` is complete. The C++11-only operator is removed; both directions are now constructors, symmetric with the existing `serialize_int128_t( serialize_uint128_t )`.
- The four fixed point template specializations get digraph-proof spacing: `< ::serialize_int128_t >`.
- The 128 bit block comment now states the pre-C++11 consumer property explicitly: a vendored header does not get to choose the consumer's `-std`.

## Standard floor reasoning

The repo configures no `-std`, so the floor is defined by what consumers actually compile the header with. The consumer profile that broke is *clang at gnu++98 tolerating declaration-only C++11 extensions as warnings* (yojimbo's own headers emit "variadic templates are a C++11 extension" warnings on that leg). The fix makes every conversion the library itself performs route through C++98 constructs; the remaining C++11 extensions in the block (`= default`, the explicit conversions to the 64 bit lanes) are declaration-only and compile as warnings in that profile.

## No wire change — proven, not assumed

Pure conversion-path change; the constructor performs the same bit preserving member init the operator did.

- Golden wire pins + full suite: Debug, Release, ASan+UBSan — all pass
- Emulated-vs-native differential tests pass at gnu++14 **and** `-std=c++03`, both with the pair forced alongside native (`SERIALIZE_ENABLE_TESTS=1`, as yojimbo's test build does) and with `-U__SIZEOF_INT128__` (emulated pair as the real storage type)
- Fuzz smoke: 60 s native (5.08 M iters) + 60 s emulated-as-real (4.12 M iters) under ASan+UBSan, no findings
- Conformance: 29/29 checks against STANDARD.md

## Regression guard

New CI leg `pre-C++11 consumer (clang -std=c++03)`: compiles and **runs** the full test suite at `-std=c++03`, in both emulated-pair configurations. clang specifically, because the guarded property is "compiles in C++98/03 with C++11 extensions accepted as warnings" — gcc hard-errors on the extensions and cannot check this profile.

## Second finding: the guard leg earned its keep on its first run

The new `-std=c++03` leg failed its first CI revolution on a break local Apple clang could not see: **`static_assert` is a C++11 keyword**, and mainstream clang at strict `-std=c++03` parses it as an undeclared identifier (Apple clang accepts it in every mode, which is why the yojimbo trial leg — Apple clang — never hit it and local verification passed). Ten uses across `serialize_uint128` and the fixed point internals.

Second commit: compile time invariants route through `serialize_static_assert` — real `static_assert` (message included) from C++11 up and on MSVC (which ships it in every language mode), a negative size array typedef emulation before that (`__attribute__((unused))` keeps `-Wall -Wextra` clean). No semantic change in any mode >= C++11: the macro expands to the same `static_assert` text. Full suite re-verified after the change: Debug, Release, ASan+UBSan, conformance 29/29, both `-std=c++03` configurations.

Also pre-tested the real consumer: the full yojimbo build (vendor-trial worktree, this header dropped in) compiles and passes **ALL TESTS** at `-std=gnu++98` — the exact profile of the leg that caught the original defect.
