### PR TITLE
1.6.0: fixed point, 128-bit integers, and the C++03 floor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.5.0 LANGUAGES CXX)
+project(serialize VERSION 1.6.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -35,9 +35,9 @@
 /** @file */
 
 #define SERIALIZE_VERSION_MAJOR 1
-#define SERIALIZE_VERSION_MINOR 5
+#define SERIALIZE_VERSION_MINOR 6
 #define SERIALIZE_VERSION_PATCH 0
-#define SERIALIZE_VERSION "1.5.0"
+#define SERIALIZE_VERSION "1.6.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
Version bump only: serialize.h (1.5.0 -> 1.6.0, both macro and string sites) and CMakeLists.txt. Precedes the v1.6.0 release. The direct push to main is structurally blocked by org ruleset 19155174 (required check 'caa' fires only on PRs), so the bump takes the PR route the ruleset requires.