### PR TITLE
read_int / read_int64: check the deserialized value, not the assigned one

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -3196,11 +3196,11 @@ namespace serialize
             {                                                                               \
                 return false;                                                               \
             }                                                                               \
-            value = int32_value;                                                            \
-            if ( (value) < (min) || (value) > (max) )                                       \
+            if ( int32_value < int32_t(min) || int32_value > int32_t(max) )                 \
             {                                                                               \
                 return false;                                                               \
             }                                                                               \
+            value = int32_value;                                                            \
         } while (0)
 
     #define read_int64( stream, value, min, max )                                           \
@@ -3212,11 +3212,11 @@ namespace serialize
             {                                                                               \
                 return false;                                                               \
             }                                                                               \
-            value = int64_value;                                                            \
-            if ( (value) < (min) || (value) > (max) )                                       \
+            if ( int64_value < int64_t(min) || int64_value > int64_t(max) )                 \
             {                                                                               \
                 return false;                                                               \
             }                                                                               \
+            value = int64_value;                                                            \
         } while (0)
 
     #define read_int128( stream, value, min, max )                                          \


### PR DESCRIPTION
Both macros re-check the range *after* assigning into the caller's variable:

```c
value = int64_value;
if ( (value) < (min) || (value) > (max) ) return false;
```

When the caller's variable is unsigned and `min` is 0, `(value) < (min)` is always false, and GCC `-Wtype-limits` reports it. Any consumer building with `-Werror` fails outright — this surfaced in the schema compiler's CI, whose generated code is compiled that way. Clang does not warn, so it only appears on a Linux leg.

The re-check now runs against the signed temporary that was just deserialized, **before** the assignment:

```c
if ( int64_value < int64_t(min) || int64_value > int64_t(max) ) return false;
value = int64_value;
```

Same guarantee, no mixed-sign comparison. `SerializeInteger64` has already bounded the temporary, so this is the belt-and-braces pass — and validating before assigning is the better order regardless.

Applied to both `read_int` and `read_int64`.