### PR TITLE
Ignore tending/, so bench-local scratch cannot be committed by accident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ corpus/
 
 # editors and os
 .DS_Store
+
+# Bench-local scratch: working notes, logs and generated corpora.
+# Never repo content — this ignore is what keeps it that way.
+tending/


### PR DESCRIPTION
`tending/` is working scratch — notes, logs, generated corpora. It was untracked but **not ignored**, which is exactly how a directory like this ends up in a repository's history one careless `git add -A` later.

This closes that path. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)