### PR TITLE
Version 1.6.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.6.0 LANGUAGES CXX)
+project(serialize VERSION 1.6.1 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -36,8 +36,8 @@
 
 #define SERIALIZE_VERSION_MAJOR 1
 #define SERIALIZE_VERSION_MINOR 6
-#define SERIALIZE_VERSION_PATCH 0
-#define SERIALIZE_VERSION "1.6.0"
+#define SERIALIZE_VERSION_PATCH 1
+#define SERIALIZE_VERSION "1.6.1"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
Cuts 1.6.1 for the `read_int`/`read_int64` fix — the bounds check tested the value after assignment rather than the value deserialized.

Bumps `CMakeLists.txt` and the three `SERIALIZE_VERSION*` macros together, which the version-consistency check requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)