### PR TITLE
STANDARD.md: the int_relative ladder was missing a tier, and named the wrong value

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -212,9 +212,17 @@ each answering "does it fit in this tier?":
 | `0 0 1` | `serialize_int( d, 7, 23 )` — 5 bits | 7 – 23 |
 | `0 0 0 1` | `serialize_int( d, 24, 280 )` — 9 bits | 24 – 280 |
 | `0 0 0 0 1` | `serialize_int( d, 281, 4377 )` — 13 bits | 281 – 4377 |
-| `0 0 0 0 0` | 32 raw bits | anything |
+| `0 0 0 0 0 1` | `serialize_int( d, 4378, 69914 )` — 17 bits | 4378 – 69914 |
+| `0 0 0 0 0 0` | `current` as 32 raw bits | anything |
 
 A difference of 1 — the common case for sequence numbers — costs a single bit.
+
+**The final tier transmits `current`, not the difference.** Every tier above it
+encodes the difference, so this reads as an inconsistency and is not: at full
+width the subtraction buys nothing, and sending the absolute value lets the
+reader check `current > previous` directly. A reader must perform that check
+and fail if it does not hold, since the absolute form carries no ordering
+guarantee of its own.
 
 ## Floating Point
 


### PR DESCRIPTION
Writing an independent C implementation from STANDARD.md produced wire that did not match, in two places:

1. **A sixth tier is missing.** `serialize_int( d, 4378, 69914 )` at 17 bits. The table jumped from 4377 straight to the raw fallback.
2. **The final tier transmits `current`, not the difference.** Every tier above encodes the difference, so "32 raw bits" naturally reads as the difference — and that is what the C port implemented before the byte comparison caught it.

Both are **documentation bugs, not wire bugs**: all four implementations already agree with each other, and serialize.go even says so in a comment. Only the document was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)