### PR TITLE
write_int: allow the degenerate range its read twin already allows

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -3330,7 +3330,7 @@ namespace serialize
     #define write_int( stream, value, min, max )                                            \
         do                                                                                  \
         {                                                                                   \
-            serialize_assert( (int32_t) ( min ) < (int32_t) ( max ) );                      \
+            serialize_assert( (int32_t) ( min ) <= (int32_t) ( max ) );                     \
             serialize_assert( (int32_t) ( value ) >= (int32_t) ( min ) );                   \
             serialize_assert( (int32_t) ( value ) <= (int32_t) ( max ) );                   \
             int32_t int32_value = (int32_t) ( value );                                      \


### PR DESCRIPTION
`read_int` was relaxed to `min <= max` in #38; `write_int` was missed, so a debug build asserted on writing exactly the range the reader accepts and STANDARD.md defines.

An asymmetry between the two halves of one macro pair is the kind of thing that surfaces as a mystery in someone else's build.

Reached from schema, whose empty enum — no variants, wire range `[0,0]` — is precisely this case.

Release and debug suites both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)