### PR TITLE
Version 1.6.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.6.1 LANGUAGES CXX)
+project(serialize VERSION 1.6.2 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -36,8 +36,8 @@
 
 #define SERIALIZE_VERSION_MAJOR 1
 #define SERIALIZE_VERSION_MINOR 6
-#define SERIALIZE_VERSION_PATCH 1
-#define SERIALIZE_VERSION "1.6.1"
+#define SERIALIZE_VERSION_PATCH 2
+#define SERIALIZE_VERSION "1.6.2"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
Cuts v1.6.2 over the three fixes merged since v1.6.1:

- **STANDARD.md conformance (#37):** the `int_relative` ladder was missing its sixth tier and named the wrong final value. An independent C implementation written from the spec produced wire that did not match in two places.
- **Degenerate range (#38, #39):** `read_int` and `write_int` now accept `min == max`, the range the format already defines. A debug build had asserted on *writing* exactly the range the reader accepts — reached from schema, whose empty enum has wire range `[0,0]`. (`min > max` still fails.)

Patch bump: a conformance fix, no wire-format change for conforming data; the golden test is unaffected. The Rust port shipped the same change as serialize.rs 1.5.0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>