### PR TITLE
Version bump: the degenerate range, and the corrected wire standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.6.1 LANGUAGES CXX)
+project(serialize VERSION 1.7.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -35,9 +35,9 @@
 /** @file */
 
 #define SERIALIZE_VERSION_MAJOR 1
-#define SERIALIZE_VERSION_MINOR 6
-#define SERIALIZE_VERSION_PATCH 1
-#define SERIALIZE_VERSION "1.6.1"
+#define SERIALIZE_VERSION_MINOR 7
+#define SERIALIZE_VERSION_PATCH 0
+#define SERIALIZE_VERSION "1.7.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
Two changes since the last tag:

- **A degenerate range (`min == max`) is now supported**, as STANDARD.md always defined it — zero bits, the value recovered from the range alone. Every port had independently grown a guard stricter than the format, so the same sequence worked against one runtime and failed against another.
- **STANDARD.md was corrected**: the `int_relative` ladder was missing its sixth tier (4378–69914), and its final tier transmits `current`, not the difference. Both were documentation bugs — every implementation already agreed with the others.

No wire change. `min > max` still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)