### PR TITLE
compressed_float: pin the arithmetic to float32, and stop the compiler fusing it

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -256,6 +256,26 @@ The writer clamps `(value - min) / delta` to `[0,1]`, multiplies by
 `bits` bits. The reader divides by `max_integer_value`, multiplies by `delta`,
 and adds `min`.
 
+**This arithmetic is `float32`, and the two roundings are part of the format.**
+The product `normalized * max_integer_value` rounds to `float32` BEFORE `0.5`
+is added, and that sum rounds to `float32` before the floor. Two roundings, not
+one. Specifically, an implementation must not:
+
+- widen any step to `double` (or any wider type) before the floor, and
+- contract the multiply and the add into a fused multiply-add, which rounds
+  once instead of twice. Languages that permit contraction must suppress it
+  here — in C and C++ by storing the product through a `float` local (or
+  `-ffp-contract=off`), in Go by an explicit `float32()` conversion around the
+  product. Rust does not fuse unless `mul_add` is called explicitly.
+
+This is not pedantry; it changes the bytes. Over `[0, 10]` at resolution
+`0.01`, the required arithmetic quantizes `0.005` to `1`, `0.025` to `3`,
+`0.105` to `11` and `9.995` to `1000`; widening to `double` yields `0`, `2`,
+`10` and `999`. A value landing exactly on a quantum — `2.5` here — agrees
+under every variant, so a conformance vector built only from such values will
+pass while the wire is wrong. Vectors must include values that land between
+quanta.
+
 Readers must reject an integer greater than `max_integer_value`.
 
 This is lossy by construction: a round trip returns the nearest representable

--- a/serialize.h
+++ b/serialize.h
@@ -2405,7 +2405,19 @@ namespace serialize
             {
                 normalizedValue = 1.0f;
             }
-            integerValue = (uint32_t) floor( normalizedValue * maxIntegerValue + 0.5f );
+            // STANDARD.md pins this to float32 with TWO roundings: the product
+            // rounds before 0.5 is added. Storing it through this local is what
+            // forces that, and it is not optional. Written as one expression,
+            // a compiler permitted to contract (clang's default is
+            // -ffp-contract=on) emits a single FMA and rounds ONCE -- and that
+            // changes the wire. On arm64 at -O2 this quantized 0.005 over
+            // [0, 10] at resolution 0.01 to 0 where every conformant runtime
+            // writes 1; on x86-64 the same source did not contract and wrote 1,
+            // so the goldens (generated on x86) and CI stayed green while
+            // Apple Silicon emitted different bytes. Do not fold this back into
+            // one expression.
+            const float scaled = normalizedValue * maxIntegerValue;
+            integerValue = (uint32_t) floor( scaled + 0.5f );
         }
 
         if ( !stream.SerializeBits( integerValue, bits ) )


### PR DESCRIPTION
`serialize_compressed_float`'s quantization is the one operation in this format
whose **result depends on how the arithmetic is performed**, not just on what it
computes. It was written as a single expression:

```cpp
integerValue = (uint32_t) floor( normalizedValue * maxIntegerValue + 0.5f );
```

clang's default is `-ffp-contract=on`, so it is free to contract that multiply
and add into one FMA — rounding **once** where the format rounds **twice**.

On arm64 at `-O2` it does exactly that. Measured against this library:

| value (over `[0,10]`, res `0.01`) | required | this library at `-O2` on arm64 |
|---|---|---|
| 0.005 | 1 | **0** |

The same source on x86-64 emits `MULSS`+`ADDSS` and writes `1`. So the wire
output has been **architecture dependent** — and because the goldens were
generated on x86 and CI runs on x86, nothing could see it.

### Why nothing caught it

Every compressed-float value in every vector across the family lands *exactly on
a quantum* — `0.75` over `[0,1]` here. A value on a quantum agrees under float32,
under double, and under an FMA alike. The gates were structurally incapable of
detecting the difference.

### What changed

- **serialize.h** — the product is stored through a `const float` local, forcing
  the intermediate rounding. Flag- and architecture-independent now.
- **STANDARD.md** — says this normatively instead of leaving precision to the
  reader: float32, two roundings, no widening to double, no contraction. It also
  records that a conformance vector built only from on-quantum values cannot
  detect any of it, with the worked divergences.

### Verified

`0.005 / 0.025 / 0.105 / 9.995` over `[0,10]` now give `1 / 3 / 11 / 1000` at
`-O2` on arm64, matching x86 and matching C#, Rust and (once fixed) C and Go.
The existing pinned vectors are **unchanged** — no previously pinned byte moved.

Found by an adversarial verifier reading schema's new packer, then confirmed
against all four sibling implementations. Companion fixes are going to
serialize.c (was quantizing in `double`), serialize.go (fused on arm64) and
schema's data compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)