### PR TITLE
The write spine demands inlining, and writes stop trailing every port

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -45,6 +45,44 @@
 #define serialize_restrict __restrict__
 #endif // #if defined(_MSC_VER)
 
+/*
+    SERIALIZE_ALWAYS_INLINE — how the per-field write spine is spelled.
+
+    A serialize function is a chain of fallible calls — if ( !stream.SerializeX( ... ) )
+    return false; — and LLVM's static branch heuristics treat each success/failure split as
+    roughly even odds, so block frequency decays geometrically down the chain. A few fields in,
+    every remaining callsite is judged cold and held to the cold-callsite inline threshold (45,
+    where a hot callsite in the same function gets 250+), which the write helpers do not fit:
+    measured on Apple silicon (Apple clang 21, schema bench, -O2 and -O3), WriteStream::
+    SerializeBits and SerializeInteger were refused at cost 60-105 against threshold 45,
+    stranding 2-6 calls per packet in every write path, and the write rows trailed the C and
+    Rust ports 14-23% while the branchless reads led every language. With the demand in place
+    the write spine inlines end to end and the same write rows lead instead
+    (+57-92%, both optimization levels).
+
+    The read spine does not make the demand because the measurement says it does not need it:
+    every read row was already `full` in the emitted code — the branchless reader's per-field
+    operations fit the inliner's budget even at the cold threshold. This is the split
+    serialize.c records on its read spine, mirrored: demand inlining exactly where measurement
+    says the hint is not enough.
+
+    The sibling ports' other lever — pinning the error edges cold (serialize.rs's #[cold]
+    constructor) — was tried here as __builtin_expect on the macros' error branches, measured,
+    and REJECTED: it left every cold-callsite refusal in place, and the cold blocks it created
+    invited Apple clang's machine outliner to shred the write bodies into bl-called fragments
+    (bits write -25%, packet read -21% at -O2, measured). Do not re-add it without measuring.
+
+    MSVC spells the demand __forceinline; compilers with neither spelling fall back to the
+    plain inline hint, and lose only the optimization.
+*/
+#if defined( _MSC_VER )
+#define SERIALIZE_ALWAYS_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SERIALIZE_ALWAYS_INLINE inline __attribute__(( always_inline ))
+#else // #if defined( _MSC_VER )
+#define SERIALIZE_ALWAYS_INLINE inline
+#endif // #if defined( _MSC_VER )
+
 #ifndef serialize_assert
 #include <assert.h>
 #define serialize_assert assert
@@ -1118,7 +1156,7 @@ namespace serialize
         // fully inline (the raw bitpacker loop compiles to identical code). The read path does not need this:
         // the branchless reader stores nothing through m_data, so it already keeps its state in registers.
 
-        void WriteBits( uint32_t value, int bits ) serialize_restrict
+        SERIALIZE_ALWAYS_INLINE void WriteBits( uint32_t value, int bits ) serialize_restrict
         {
             serialize_assert( m_data );                 // if this fires, the writer was used before Initialize
             serialize_assert( bits > 0 );
@@ -1154,7 +1192,7 @@ namespace serialize
             @see BitReader::ReadAlign
          */
 
-        void WriteAlign()
+        SERIALIZE_ALWAYS_INLINE void WriteAlign()
         {
             const int remainderBits = m_bitsWritten % 8;
 
@@ -1563,7 +1601,7 @@ namespace serialize
             @returns Always returns true. All checking is performed by debug asserts only on write.
          */
 
-        bool SerializeInteger( int32_t value, int32_t min, int32_t max )
+        SERIALIZE_ALWAYS_INLINE bool SerializeInteger( int32_t value, int32_t min, int32_t max )
         {
             serialize_assert( min <= max );
             serialize_assert( value >= min );
@@ -1587,7 +1625,7 @@ namespace serialize
             @returns Always returns true. All checking is performed by debug asserts only on write.
          */
 
-        bool SerializeInteger64( int64_t value, int64_t min, int64_t max )
+        SERIALIZE_ALWAYS_INLINE bool SerializeInteger64( int64_t value, int64_t min, int64_t max )
         {
             serialize_assert( min <= max );
             serialize_assert( value >= min );
@@ -1616,7 +1654,7 @@ namespace serialize
             @returns Always returns true. All checking is performed by debug asserts only on write.
          */
 
-        bool SerializeInteger128( int128_t value, int128_t min, int128_t max )
+        SERIALIZE_ALWAYS_INLINE bool SerializeInteger128( int128_t value, int128_t min, int128_t max )
         {
             serialize_assert( min <= max );
             serialize_assert( value >= min );
@@ -1661,7 +1699,7 @@ namespace serialize
             @returns Always returns true. All checking is performed by debug asserts on write.
          */
 
-        bool SerializeBits( uint32_t value, int bits )
+        SERIALIZE_ALWAYS_INLINE bool SerializeBits( uint32_t value, int bits )
         {
             serialize_assert( bits > 0 );
             serialize_assert( bits <= 32 );
@@ -1676,7 +1714,7 @@ namespace serialize
             @returns Always returns true. All checking is performed by debug asserts on write.
          */
 
-        bool SerializeBytes( const uint8_t * data, int64_t bytes )
+        SERIALIZE_ALWAYS_INLINE bool SerializeBytes( const uint8_t * data, int64_t bytes )
         {
             serialize_assert( data );
             serialize_assert( bytes >= 0 );
@@ -1690,7 +1728,7 @@ namespace serialize
             @returns Always returns true. All checking is performed by debug asserts on write.
          */
 
-        bool SerializeAlign()
+        SERIALIZE_ALWAYS_INLINE bool SerializeAlign()
         {
             m_writer.WriteAlign();
             return true;
@@ -2336,7 +2374,7 @@ namespace serialize
             }                                                           \
         } while (0)
 
-    template <typename Stream> bool serialize_float_internal( Stream & stream, float & value )
+    template <typename Stream> SERIALIZE_ALWAYS_INLINE bool serialize_float_internal( Stream & stream, float & value )
     {
         uint32_t int_value = 0;
         if ( Stream::IsWriting )
@@ -2444,7 +2482,7 @@ namespace serialize
         }                                                                                           \
     } while (0)
 
-    template <typename Stream> bool serialize_double_internal( Stream & stream, double & value )
+    template <typename Stream> SERIALIZE_ALWAYS_INLINE bool serialize_double_internal( Stream & stream, double & value )
     {
         union DoubleInt
         {
@@ -2482,7 +2520,7 @@ namespace serialize
             }                                                                       \
         } while (0)
 
-    template <typename Stream> bool serialize_bytes_internal( Stream & stream, uint8_t * data, int64_t bytes )
+    template <typename Stream> SERIALIZE_ALWAYS_INLINE bool serialize_bytes_internal( Stream & stream, uint8_t * data, int64_t bytes )
     {
         return stream.SerializeBytes( data, bytes );
     }


### PR DESCRIPTION
## What

`SERIALIZE_ALWAYS_INLINE` on the per-field write spine — `BitWriter::WriteBits`/`WriteAlign`, `WriteStream::SerializeInteger`/`SerializeInteger64`/`SerializeInteger128`/`SerializeBits`/`SerializeBytes`/`SerializeAlign`, and the thin `serialize_float_internal`/`serialize_double_internal`/`serialize_bytes_internal` templates. Bulk and branchy bodies (`BitWriter::WriteBytes`, strings, `int_relative`, compressed float) deliberately stay under the cost model: their cost is the work, not the call.

Attributes only — wire bytes are byte-identical (the schema bench §1.5 oracle gate byte-compares the wire against the goldens on every measured run, both levels), NDEBUG assert semantics unchanged, nothing asked of consumers' build flags.

## Why

The C++ write rows were the last place this library trailed its ports: `bench_packet` write 51.9M vs C 59.0M (+14%) and Rust 63.9M (+23%), `bench_mixed` write 77.9M vs C 90.7M (+16%), while C++ reads led every language. The inline ledger said why: the four rt write benches published `partial:6/3/2/5` — 2–6 calls into the runtime stranded per packet on the write path, `full` on every read.

The mechanism, from `-Rpass-missed=inline` and the emitted arm64 code (Apple clang 21, M2): a serialize function is a chain of fallible calls, LLVM's static branch heuristics price each success/failure split at roughly even odds, block frequency decays geometrically down the chain, and a few fields in the inliner holds every remaining callsite to the **cold-callsite threshold (45)** — which the write helpers do not fit:

```
WriteStream::SerializeBits      not inlined: cost=65,    threshold=45   (x11 across the rt shapes)
WriteStream::SerializeInteger   not inlined: cost=60-65, threshold=45   (x5)
serialize_float_internal<Write> not inlined: cost=75,    threshold=45   (x3)
serialize_bytes_internal<Write> not inlined: cost=105,   threshold=45   (x1)
```

The same root mechanism was found and fixed in serialize.c (#1, read spine) and serialize.rs (#31, cold error edges). Here it bites the write side: the branchless reader's per-field ops fit the inliner's budget even at the cold threshold, the writer's do not.

## Measured

schema bench, BENCH-STANDARD §2.4 interleaved pass-driver, 3 rounds + two 7-run control legs, oracle-gated, Apple M2, Apple clang 21, windows OK (control delta 0.0–2.3%), C leg as same-window reference (C moved ≤0.5% in every window):

| bench | path | O3 before | O3 after | Δ | O2 before | O2 after | Δ | C same-window O3 |
|---|---|---|---|---|---|---|---|---|
| bench_packet | write | 51.9M | 83.6M | **+61%** | 51.8M | 82.5M | **+59%** | 59.2M |
| bench_ints | write | 115.4M | 185.1M | **+60%** | 115.8M | 188.9M | **+63%** | 119.5M |
| bench_bits | write | 122.4M | 187.0M | **+53%** | 122.3M | 186.2M | **+52%** | 117.5M |
| bench_mixed | write | 78.3M | 153.6M | **+96%** | 78.6M | 152.8M | **+94%** | 90.8M |

(best across rounds; medians agree within the recorded spreads, writes ≤3.2%)

Every C++ write row moves from 14–23% behind C and Rust to ahead of both, at both published optimization levels, and the O2/O3 ranking does not invert. Reads and the raw bitpacker are unchanged (reads were already `full`; the bitpacker fully inlines with or without the attribute). Gen-family rows: writes within ±1%, reads within their documented noise band; `testdata` read picks up one inlined call (`partial:6` → `partial:5`) via the stream-generic `serialize_bytes_internal`.

Inline verdicts (regenerated §4.1 ledger, both levels): cpp rt writes `partial:6/3/2/5` → `partial:1/full/full/full` — the one remaining call is `BitWriter::WriteBytes` for bench_packet's 17-byte blob, the deliberate bulk-copy boundary.

## The lever that was tried and rejected

The sibling ports' other lever — pinning error edges cold — was tried here as `__builtin_expect` on the serialize macros' error branches, measured separately at both levels, and **rejected**: it fixed none of the cold-callsite refusals (identical remarks and identical stranded calls with the machine outliner disabled), and the cold blocks it created invited Apple clang's machine outliner to shred the write bodies into `bl`-called fragments — bench_bits write −25%, bench_mixed −13%, bench_packet −11%, and bench_packet read −21% at −O2. The header comment records the rejection so it is not re-tried unmeasured.

## Gates

- cmake Release build + ctest: pass (includes the golden wire-format test)
- C++03 consumer leg (CI's exact flags, tests on, `*** ALL TESTS PASS ***`): pass
- STANDARD.md conformance checker: 29 checks, 0 failures
- schema bench §1.5 oracle gate: byte-identical wire on every measured run, both levels

Results CSVs + inline ledgers: `schema/bench/results/2026-08-15-cpp-write-spine-{before,after}-{O3,O2}-arm64-macbook-pass.{csv,inline}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
