### PR TITLE
Version 1.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.6.2 LANGUAGES CXX)
+project(serialize VERSION 1.7.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -35,9 +35,9 @@
 /** @file */
 
 #define SERIALIZE_VERSION_MAJOR 1
-#define SERIALIZE_VERSION_MINOR 6
-#define SERIALIZE_VERSION_PATCH 2
-#define SERIALIZE_VERSION "1.6.2"
+#define SERIALIZE_VERSION_MINOR 7
+#define SERIALIZE_VERSION_PATCH 0
+#define SERIALIZE_VERSION "1.7.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
The release commit for the night's work: #42 (compressed_float pinned to float32, no contraction), #43 (the spec is the format), #44 (degenerate range for int64), #45 (the write spine inlines). Bumps serialize.h and the CMake project version together, as Release Check demands.

Minor rather than patch because this release changes written bytes on arm64 — that is the #42 fix restoring cross-platform and cross-language agreement, and the release notes will say so plainly rather than bury it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)