### PR TITLE
The gates build strict, the reader rounds twice, and a vector that can fail proves both

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,14 +123,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # -ffp-contract=off, not -ffast-math: this binary runs the golden and conformance
+      # vectors, and those pin exact bytes and decoded bit patterns. Same rationale as
+      # SERIALIZE_DEV_FLAGS in CMakeLists.txt — the gates build strict.
       - name: Build and run tests at -std=c++03 (emulated pair alongside native)
         run: |
-          clang++ -std=c++03 -DSERIALIZE_ENABLE_TESTS=1 -DSERIALIZE_DEBUG -Wall -Wextra -ffast-math -fno-rtti test.cpp -o test_cxx03
+          clang++ -std=c++03 -DSERIALIZE_ENABLE_TESTS=1 -DSERIALIZE_DEBUG -Wall -Wextra -ffp-contract=off -fno-rtti test.cpp -o test_cxx03
           ./test_cxx03
 
       - name: Build and run tests at -std=c++03 (emulated pair as the serialize types)
         run: |
-          clang++ -std=c++03 -DSERIALIZE_ENABLE_TESTS=1 -DSERIALIZE_DEBUG -U__SIZEOF_INT128__ -Wall -Wextra -ffast-math -fno-rtti test.cpp -o test_cxx03_no_int128
+          clang++ -std=c++03 -DSERIALIZE_ENABLE_TESTS=1 -DSERIALIZE_DEBUG -U__SIZEOF_INT128__ -Wall -Wextra -ffp-contract=off -fno-rtti test.cpp -o test_cxx03_no_int128
           ./test_cxx03_no_int128
 
   conformance:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,21 @@ if(SERIALIZE_TOP_LEVEL AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPE
 endif()
 
 if(SERIALIZE_BUILD_TESTS OR SERIALIZE_FUZZ)
-    # same flags as the historical premake build: extra warnings, fast float, no rtti
+    # STRICT floating point, deliberately. These executables are the gates that certify
+    # the wire: the golden and conformance vectors pin exact bytes and exact decoded bit
+    # patterns. The historical premake flags carried -ffast-math (MSVC /fp:fast) here,
+    # which licenses contraction, reassociation and reciprocal approximation in exactly
+    # the arithmetic those vectors exist to pin — measured on arm64, it changed both the
+    # quantized integer (writer) and the decoded float (reader) of compressed_float.
+    # A proof of byte-exactness earned under flags that permit different bytes is not a
+    # proof, so every target here builds strict:
+    #   - GCC/Clang: -ffp-contract=off. Not just "no -ffast-math" — GCC's default is
+    #     -ffp-contract=fast, and clang's default =on still fuses single expressions.
+    #   - MSVC: /fp:precise. Since VS 2022 this no longer implies contraction
+    #     (there is no /fp:contract in these flags, so contraction stays off).
+    # bench builds strict too: a benchmark of arithmetic the format forbids would be a
+    # number about some other library. Consumers are unaffected either way — the library
+    # target above is INTERFACE-only and none of these flags leak.
     if(MSVC)
         # 4127/4244 are opted back in here: the header now push/pops them, and this repo's own
         # executables use the same implicit-narrowing style as the header
@@ -57,9 +71,9 @@ if(SERIALIZE_BUILD_TESTS OR SERIALIZE_FUZZ)
         # source as the local ANSI code page — mangling non-ASCII characters and warning
         # C4819. The test data is written as explicit code points so behaviour never
         # depends on this, but the comments and the copyright line still need it.
-        set(SERIALIZE_DEV_FLAGS /W4 /utf-8 /fp:fast /GR- /wd4127 /wd4244)
+        set(SERIALIZE_DEV_FLAGS /W4 /utf-8 /fp:precise /GR- /wd4127 /wd4244)
     else()
-        set(SERIALIZE_DEV_FLAGS -Wall -Wextra -ffast-math -fno-rtti)
+        set(SERIALIZE_DEV_FLAGS -Wall -Wextra -ffp-contract=off -fno-rtti)
     endif()
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 endif()

--- a/serialize.h
+++ b/serialize.h
@@ -2479,7 +2479,19 @@ namespace serialize
                 return false;
             }
             const float normalizedValue = integerValue / float(maxIntegerValue);
-            value = normalizedValue * delta + min;
+            // The reader rounds twice for the same reason the writer above does:
+            // the product must round to float32 BEFORE min is added, and storing
+            // it through this local is what forces that. Written as one
+            // expression, a compiler permitted to contract (clang's default
+            // -ffp-contract=on is enough — no -ffast-math required) fuses the
+            // multiply and add into a single FMA on arm64 and rounds ONCE. That
+            // decodes a float one ulp away from every conformant runtime whenever
+            // min is non-zero, so a value read on arm64 and re-encoded produces
+            // different wire. The conformance vector with min = -100 pins the
+            // decoded bit pattern exactly and goes red if this is ever folded
+            // back into one expression.
+            const float scaledValue = normalizedValue * delta;
+            value = scaledValue + min;
         }
 
         return true;
@@ -7078,6 +7090,77 @@ inline void test_golden_wire_format()
     }
 }
 
+// Conformance vector for compressed_float over a range with a NON-ZERO min. Additive: the
+// golden wire test above is untouched and its bytes are pinned forever.
+//
+// The golden's compressed_float is 5.0 over [0,10]: min is 0, so the reader's final add
+// contributes nothing and a reader whose multiply and add are fused into one FMA decodes
+// the identical float — that vector is structurally blind to reader contraction. This one
+// pins the decoded BIT PATTERNS, not just the wire bytes, over [-100,100] at resolution
+// 0.01 (max_integer_value = 20000, 15 bits per value), where the add is load-bearing:
+//
+//   written value   quantized   pinned decode   what a wrong reading produces
+//   0.0             10000       0x00000000      nothing — on-quantum sanity row, agrees everywhere
+//   -99.875         13          0xC2C7BD71      a writer widened to double quantizes 12, not 13:
+//                                               the scaled product is exactly 12.5, a boundary
+//                                               value landing between quanta, and double resolves
+//                                               it to 12.499999... — different wire bytes
+//   -33.34          6666        0xC2055C2A      a reader contracted to an FMA decodes 0xC2055C29
+//
+// The last row is why this test exists: at plain -O2 on arm64 (clang's default
+// -ffp-contract=on), the pre-fix single-expression reader decoded 0xC2055C29 — one ulp off
+// every conformant runtime, so an arm64 re-encode produced different wire — and no vector
+// in the family could see it. Under -ffast-math (the gate binaries' former flags) the 0.0
+// row also breaks: reciprocal approximation of the division decodes 0xB6298800.
+
+template <typename Stream> bool CompressedFloatNonZeroMinSerialize( Stream & stream, float & a, float & b, float & c )
+{
+    serialize_compressed_float( stream, a, -100.0f, 100.0f, 0.01f );
+    serialize_compressed_float( stream, b, -100.0f, 100.0f, 0.01f );
+    serialize_compressed_float( stream, c, -100.0f, 100.0f, 0.01f );
+    serialize_align( stream );
+    return true;
+}
+
+inline void test_compressed_float_conformance_nonzero_min()
+{
+    static const uint8_t pinned_bytes[6] = { 0x10, 0xA7, 0x06, 0x80, 0x82, 0x06 };
+
+    // write side: the strict two-rounding quantization must produce exactly these bytes
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream stream( buffer, (int) sizeof( buffer ) );
+        float a = 0.0f;
+        float b = -99.875f;
+        float c = -33.34f;
+        serialize_check( CompressedFloatNonZeroMinSerialize( stream, a, b, c ) == true );
+        stream.Flush();
+        serialize_check( stream.GetBytesProcessed() == (int) sizeof( pinned_bytes ) );
+        serialize_check( memcmp( buffer, pinned_bytes, sizeof( pinned_bytes ) ) == 0 );
+    }
+
+    // read side: the decoded floats are pinned bit-exactly. tolerance comparison would
+    // defeat the purpose — the divergence this detects is a single ulp.
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        memcpy( buffer, pinned_bytes, sizeof( pinned_bytes ) );
+        serialize::ReadStream stream( buffer, (int) sizeof( pinned_bytes ) );
+        float a = -1.0f;
+        float b = -1.0f;
+        float c = -1.0f;
+        serialize_check( CompressedFloatNonZeroMinSerialize( stream, a, b, c ) == true );
+        uint32_t bits_a, bits_b, bits_c;
+        memcpy( &bits_a, &a, 4 );
+        memcpy( &bits_b, &b, 4 );
+        memcpy( &bits_c, &c, 4 );
+        serialize_check( bits_a == 0x00000000u );
+        serialize_check( bits_b == 0xC2C7BD71u );
+        serialize_check( bits_c == 0xC2055C2Au );
+    }
+}
+
 inline void test_unaligned_writer()
 {
     // the bit writer stores each dword with memcpy, so the write buffer does not need 4 byte alignment.
@@ -7228,6 +7311,7 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_compile_time_packet );
 #endif // #if defined( SERIALIZE_HAS_COMPILE_TIME_SURFACE )
         SERIALIZE_RUN_TEST( test_golden_wire_format );
+        SERIALIZE_RUN_TEST( test_compressed_float_conformance_nonzero_min );
         SERIALIZE_RUN_TEST( test_unaligned_writer );
         SERIALIZE_RUN_TEST( test_large_buffer );
     }


### PR DESCRIPTION
The binaries that certify this wire format could not have caught the wire being wrong. This closes that, in three connected moves.

**The reader now rounds twice.** `serialize_compressed_float`'s read side was one contractible expression, `value = normalizedValue * delta + min`. At plain `-O2` on arm64 — clang's default `-ffp-contract=on`, no exotic flags — it fused into a single FMA and decoded a float one ulp away from every conformant runtime whenever `min` is non-zero. Bytes on write were unaffected, but a value read on arm64 and re-encoded produced different wire, which breaks the round-trip claim the format rests on. The product now stores through a `float` local, exactly mirroring the writer's fix from #42.

**The gate binaries build strict.** Every binary that proves byte-exactness — the golden test, the fuzz harness, bench, and both cxx03 CI legs — built with `-ffast-math` (`/fp:fast` on MSVC), which licenses contraction, reassociation and reciprocal approximation in precisely the arithmetic the vectors pin. Measured on this branch: `-ffast-math`'s reciprocal division decodes 0.0 as -2.5e-06. The flags are dropped entirely rather than split per target: `SERIALIZE_DEV_FLAGS` is now `-ffp-contract=off` (`/fp:precise` on MSVC, which since VS 2022 no longer implies contraction), bench included — a benchmark of arithmetic the format forbids would be a number about some other library. Consumers never saw these flags either way; the library target is INTERFACE-only. The rationale is recorded in CMakeLists.txt where the flags live.

**A vector that can fail.** The golden's compressed_float is 5.0 over [0,10]: min = 0, the reader's add contributes nothing, and fused, widened and strict arithmetic all agree — structurally blind, as STANDARD.md's own conformance-vector rule predicts. The new pinned vector runs [-100,100] at resolution 0.01 and pins decoded **bit patterns**, not just bytes:

| written | quantized | pinned decode | discriminates |
|---|---|---|---|
| 0.0 | 10000 | `0x00000000` | sanity row — and red under `-ffast-math` (reciprocal division) |
| -99.875 | 13 | `0xC2C7BD71` | scaled product exactly 12.5, between quanta: a double-widened writer quantizes 12 |
| -33.34 | 6666 | `0xC2055C2A` | a fused reader decodes `0xC2055C29` |

Proven able to fail, both halves, on arm64 (Apple Silicon):

- pre-fix single-expression reader, plain `-O2`: **red** — `check failed: ( bits_c == 0xC2055C2Au )`
- fixed reader, old `-ffast-math` flags: **red** — `check failed: ( bits_a == 0x00000000u )`
- fixed reader, strict flags: full suite green, Debug and Release. No previously pinned byte moved.

Closes #57. This is the serialize.h/flags half of #47 — the normative reader paragraph for STANDARD.md is drafted in a separate PR awaiting Glenn, and the serialize.c and serialize.go readers land in their own repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)