### PR TITLE
Version 1.7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.7.0 LANGUAGES CXX)
+project(serialize VERSION 1.7.1 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -36,8 +36,8 @@
 
 #define SERIALIZE_VERSION_MAJOR 1
 #define SERIALIZE_VERSION_MINOR 7
-#define SERIALIZE_VERSION_PATCH 0
-#define SERIALIZE_VERSION "1.7.0"
+#define SERIALIZE_VERSION_PATCH 1
+#define SERIALIZE_VERSION "1.7.1"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
The reader fix in #58 is wire-affecting and shipped past v1.7.0 with no release announcing it — release-check said so, correctly, on its first live firing. This bumps all three version sites en route to the v1.7.1 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)