### PR TITLE
Six rulings land as normative text, and the degenerate range reaches fixed point

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -42,6 +42,19 @@ required, rounded up to a byte.
 The stream is *aligned* when the bit index is a multiple of 8. The number of
 bits needed to reach alignment is `(8 - (bit_index % 8)) % 8`.
 
+**Writes assume trusted data — doctrine, ratified** *(adopted 2026-08-15 from
+the schema enactment; the ruling verbatim: "this is an intentional design
+choice of serialize. the write path is trusted, and it's your responsibility
+as the user of serialize library to write correctly. asserts in languages that
+support them in debug only.")*. Writer inputs are stated as **obligations, not
+defined behaviors**: this document owes a conforming writer exact bytes and
+owes a misbehaving writer nothing. Within that doctrine, misuse surfaces by
+each implementation's own convention, and costlier contracts — the UTF-8
+well-formedness contract under `string` is the type case, an O(n) check no
+release path should carry — assert in debug only, everywhere. The read side is
+untouched by the doctrine: readers face untrusted data, and every refusal rule
+this document states binds in every build mode.
+
 ## Bit-Level Primitives
 
 ### bits
@@ -192,10 +205,32 @@ convention — and with `fraction_bits = 0` the operation *is* a ranged integer.
 Readers must check that the decoded offset is at most `raw_max - raw_min` and
 fail otherwise — reject, never clamp.
 
+**A degenerate range where `min == max` is legal and costs zero bits — on
+every storage width** *(adopted 2026-08-15 from the schema enactment)*. The
+wire carries nothing and the reader recovers the value from the range alone:
+the raw value is `min << fraction_bits`, exactly the rule the ranged integers
+have always stated. The storage width must not change this: a Q112.16 field
+over a degenerate range costs zero bits, not `fraction_bits` zeros. *(Until
+2026-08-15 the implementations behaved four different ways here — zero bits,
+`fraction_bits` of zeros on the wide path only, a compile failure and a
+panic — the divergence the ruling closes.)*
+
 Because fixed point values are integers underneath, the round trip is
 **exact**: unlike `compressed_float` there is no quantization step, and the
 same raw value produces the same bytes and reads back bit-for-bit identical on
 every platform.
+
+**The one rounding rule** *(adopted 2026-08-15 from the schema enactment)*:
+the wire itself never rounds — the round trip above is exact — but wherever a
+value is quantized into a Q format or narrowed out of one, fixed point rounds
+ties **half away from zero**, everywhere it rounds: `( raw + half ) >> drop`
+for `raw >= 0`, `-( ( -raw + half ) >> drop )` for `raw < 0`, with
+`half = 1 << ( drop - 1 )`. The hazard, named: the naive arithmetic shift
+*floors*, so an implementation that applies `( raw + half ) >> drop` to a
+negative raw rounds ties toward +infinity and diverges by exactly one raw
+step, on exact ties of negative raws only. A rounding rule is not wire shape —
+no protocol identifier can see the divergence — so a conformance vector must
+pin a negative tie value that distinguishes the two rules.
 
 ### int_relative
 
@@ -223,6 +258,14 @@ width the subtraction buys nothing, and sending the absolute value lets the
 reader check `current > previous` directly. A reader must perform that check
 and fail if it does not hold, since the absolute form carries no ordering
 guarantee of its own.
+
+**The semantics are pinned: no wrapping** *(adopted 2026-08-15 from the schema
+enactment; the ruling verbatim: "no wrapping sequence numbers. meant for
+positive only and up to maximum only.")*. `serialize_int_relative` is strictly
+increasing — `current > previous`, the reader fails otherwise — and no wrap
+semantics exist: a caller with a wrapping counter unwraps it before
+serializing. Wrap-around is not an encoding this operation carries, not now
+and not by future amendment.
 
 ## Floating Point
 
@@ -316,6 +359,16 @@ The terminator is not transmitted; the reader appends it.
 Because `buffer_size` is an operand rather than a transmitted value, the same
 string serialized against different buffer sizes produces different bytes.
 
+**`string` payloads are well-formed UTF-8 by contract** *(adopted 2026-08-15
+from the schema enactment, writer-trusted per the doctrine above)*. The wire
+shape is unchanged; what the `string` spelling adds is a **contract**: the
+payload is well-formed UTF-8, the writer's obligation, never the reader's
+check. Writing malformed UTF-8 is a writer contract violation — debug-only
+asserts where the language supports them — there is no mandatory read-path
+validation and no release-path cost anywhere, and the conformance vectors
+carry only valid UTF-8. An application with genuinely arbitrary payloads uses
+`serialize_bytes`, which remains exactly that.
+
 ### wstring
 
     serialize_wstring( stream, string, buffer_size )
@@ -332,10 +385,20 @@ counterpart, which aligns via `serialize_bytes`. An implementation that mirrors
 the narrow string path here will produce the wrong bytes.
 
 Wide characters are transmitted as 32 bits regardless of the local `wchar_t`
-width, so streams are compatible between platforms with 2-byte and 4-byte
-`wchar_t`. Code points are not translated between UTF-16 and UTF-32: a reader
-whose `wchar_t` cannot hold a received value **fails the read rather than
-truncating**.
+width. A reader whose `wchar_t` cannot hold a received value **fails the read
+rather than truncating**.
+
+**Each 32-bit group carries one UTF-16 code unit — not one code point — and
+the payload is well-formed UTF-16 by contract** *(adopted 2026-08-15 from the
+schema enactment, writer-trusted per the doctrine above)*. Surrogate **pairs**
+are valid — full Unicode, an astral character is two groups; an **unpaired**
+surrogate is a writer contract violation, debug-asserted where the language
+supports it. 2-byte and 4-byte `wchar_t` platforms must produce **identical
+bytes**: the 4-byte platform converts at the boundary — splits astral code
+points into surrogate pairs on write, recombines on read — because the
+platform-compatibility claim this section used to make was false for astral
+text when each platform transmitted its own `wchar_t` units. Basic-plane text
+is unaffected on every platform.
 
 ## Worked Example
 

--- a/serialize.h
+++ b/serialize.h
@@ -123,7 +123,7 @@
     #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
       #define SERIALIZE_BIG_ENDIAN 1
     #else
-      #error Unknown machine endianess detected. User needs to define SERIALIZE_LITTLE_ENDIAN or SERIALIZE_BIG_ENDIAN.
+      #error Unknown machine endianness detected. User needs to define SERIALIZE_LITTLE_ENDIAN or SERIALIZE_BIG_ENDIAN.
     #endif // __BYTE_ORDER__
 
   // Detect with GLIBC's endian.h
@@ -134,7 +134,7 @@
     #elif (__BYTE_ORDER == __BIG_ENDIAN)
       #define SERIALIZE_BIG_ENDIAN 1
     #else
-      #error Unknown machine endianess detected. User needs to define SERIALIZE_LITTLE_ENDIAN or SERIALIZE_BIG_ENDIAN.
+      #error Unknown machine endianness detected. User needs to define SERIALIZE_LITTLE_ENDIAN or SERIALIZE_BIG_ENDIAN.
     #endif // __BYTE_ORDER
 
   // Detect with _LITTLE_ENDIAN and _BIG_ENDIAN macro
@@ -158,7 +158,7 @@
   #elif defined(_MSC_VER) && defined(_M_ARM)
     #define SERIALIZE_LITTLE_ENDIAN 1
   #else
-    #error Unknown machine endianess detected. User needs to define SERIALIZE_LITTLE_ENDIAN or SERIALIZE_BIG_ENDIAN.
+    #error Unknown machine endianness detected. User needs to define SERIALIZE_LITTLE_ENDIAN or SERIALIZE_BIG_ENDIAN.
   #endif
 #endif
 
@@ -3018,6 +3018,20 @@ namespace serialize
             const uint64_t raw_max = uint64_t( MaxUnits ) << FractionalBits;
             const uint64_t raw_range = raw_max - raw_min;
 
+            if ( MinUnits == MaxUnits )
+            {
+                // degenerate range: the value IS the range, nothing to send (STANDARD.md: min == max costs zero bits, on every storage width)
+                if ( Stream::IsWriting )
+                {
+                    serialize_assert( uint64_t( value ) == raw_min );       // all checking is performed by debug asserts on write
+                }
+                if ( Stream::IsReading )
+                {
+                    value = Storage( raw_min );
+                }
+                return true;
+            }
+
             const int bits = BitsRequired64<raw_min, raw_max>::result;
 
             uint64_t offset = 0;
@@ -3098,6 +3112,22 @@ namespace serialize
             const Unsigned raw_min = Unsigned( Storage( MinUnits ) ) << FractionalBits;
             const Unsigned raw_max = Unsigned( Storage( MaxUnits ) ) << FractionalBits;
             const Unsigned raw_range = raw_max - raw_min;
+
+            if ( MinUnits == MaxUnits )
+            {
+                // degenerate range: the value IS the range, nothing to send. the wide path must agree
+                // with the narrow path here — FractionalBits of zeros is NOT a degenerate encoding
+                // (STANDARD.md: min == max costs zero bits, on every storage width)
+                if ( Stream::IsWriting )
+                {
+                    serialize_assert( Unsigned( value ) == raw_min );       // all checking is performed by debug asserts on write
+                }
+                if ( Stream::IsReading )
+                {
+                    value = Storage( raw_min );
+                }
+                return true;
+            }
 
             // the wire cost, computed in the 64 bit compile time domain: the range in whole units
             // is exact in a uint64, and shifting it left by FractionalBits adds exactly
@@ -3205,7 +3235,7 @@ namespace serialize
         serialize_static_assert( IntegerBits >= 1, "serialize_fixed needs at least one integer bit. the sign bit counts for signed storage" );
         serialize_static_assert( FractionalBits >= 0, "serialize_fixed fractional bits can't be negative" );
         serialize_static_assert( IntegerBits + FractionalBits == 8 * (int) sizeof( Storage ), "serialize_fixed integer bits plus fractional bits must equal the number of bits in the storage type" );
-        serialize_static_assert( MinUnits < MaxUnits, "serialize_fixed min must be below max" );
+        serialize_static_assert( MinUnits <= MaxUnits, "serialize_fixed min must not exceed max" );
 
         return FixedPointSerializer< ( 8 * (int) sizeof( Storage ) > 64 ) >::template Serialize<IntegerBits, FractionalBits, MinUnits, MaxUnits>( stream, value );
     }
@@ -3215,6 +3245,7 @@ namespace serialize
         This is a helper macro to make writing unified serialize functions easier.
         The Q format and the bounds are compile time constants: integer_bits plus fraction_bits must equal the number of bits in the storage type, with the sign bit counting towards integer_bits for signed storage. For example, Q48.16 in an int64_t is ( 48, 16 ) and Q112.16 in a serialize::int128_t is ( 112, 16 ). Any integer storage type works, including 128 bit storage on every platform: native __int128 where the compiler provides it, the emulated pair where it doesn't.
         The bounds are whole units and must be constant expressions: a runtime bound fails to compile, and bounds that don't fit the Q format fail with a static assert. The value is serialized as an offset from min in the minimal number of bits for the range — a constant of the call site — and the round trip is exact: fixed point values are integers underneath, so unlike compressed floats there is no quantization error and results are identical across platforms.
+        A degenerate range where min == max is legal and costs zero bits on every storage width: nothing is written, and the reader recovers the value from the range alone — the raw value min << fraction_bits.
         For storage of 64 bits or fewer the wire format is byte identical to serialize_int64 of the raw value over the raw bounds.
         Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
         IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
@@ -5101,7 +5132,7 @@ inline void test_serialize_fixed()
     //     int32_t value = 0;
     //     serialize::serialize_fixed_internal<16, 8, 0, 100>( stream, value );                 // 16 + 8 != 32: the Q format doesn't fill the storage type
     //     serialize::serialize_fixed_internal<16, 16, -40000, +40000>( stream, value );        // bounds exceed the Q16.16 whole unit capacity [-32768,32767]
-    //     serialize::serialize_fixed_internal<16, 16, 100, 100>( stream, value );              // min must be below max
+    //     serialize::serialize_fixed_internal<16, 16, 200, 100>( stream, value );              // min must not exceed max (min == max is LEGAL: zero bits, see test_serialize_fixed_degenerate)
     //     float not_an_integer = 0.0f;
     //     serialize::serialize_fixed_internal<16, 16, 0, 100>( stream, not_an_integer );       // storage must be an integer type
     //     int runtime_bound = 100;
@@ -5384,6 +5415,146 @@ inline void test_serialize_fixed_wide_emulated()
         serialize_check( read_back == ::serialize_int128_t( raw ) );
     }
 #endif // #if defined(__SIZEOF_INT128__)
+}
+
+inline void test_serialize_fixed_degenerate()
+{
+    // STANDARD.md: a degenerate range where min == max is LEGAL and costs ZERO
+    // BITS on every storage width -- nothing is written, and the reader
+    // recovers the value from the range alone: the raw value min << fraction_bits.
+    //
+    // The wide path is why this test exists (serialize#54): ports computed the
+    // wide bit count as bits_required( min, max ) + fraction_bits, which
+    // degenerates to fraction_bits ZEROS when min == max while their narrow
+    // paths wrote nothing -- the same library disagreeing with itself across
+    // the 64/128 storage boundary. This library refused to compile the case
+    // outright (static assert min < max), stricter than the format. Both
+    // paths must write zero bits, and this test pins each of them.
+
+    // narrow storage: Q16.16
+    {
+        uint8_t buffer[16] = { 0 };
+
+        serialize::WriteStream writeStream( buffer, 16 );
+        int32_t degenerate = 5 * 65536;                              // 5.0 in Q16.16: the raw value IS min << 16
+        int32_t after = 3;
+        serialize_check( ( serialize::serialize_fixed_internal<16, 16, 5, 5>( writeStream, degenerate ) ) == true );
+        serialize_check( writeStream.GetBitsProcessed() == 0 );      // nothing written
+        serialize_check( writeStream.SerializeInteger( after, 0, 7 ) );
+        serialize_check( writeStream.GetBitsProcessed() == 3 );      // the NEXT field starts at bit 0
+        writeStream.Flush();
+
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        int32_t read_degenerate = 0;
+        int32_t read_after = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<16, 16, 5, 5>( readStream, read_degenerate ) ) == true );
+        serialize_check( read_degenerate == 5 * 65536 );             // recovered from the range
+        serialize_check( readStream.GetBitsProcessed() == 0 );
+        serialize_check( readStream.SerializeInteger( read_after, 0, 7 ) );
+        serialize_check( read_after == 3 );
+
+        serialize::MeasureStream measureStream;
+        int32_t measured = 5 * 65536;
+        serialize_check( ( serialize::serialize_fixed_internal<16, 16, 5, 5>( measureStream, measured ) ) == true );
+        serialize_check( measureStream.GetBitsProcessed() == 0 );
+    }
+
+    // narrow storage, negative degenerate bound: Q48.16 at -7.0 -- the raw min
+    // is negative, and the reader must still recover it exactly
+    {
+        uint8_t buffer[16] = { 0 };
+
+        serialize::WriteStream writeStream( buffer, 16 );
+        int64_t degenerate = int64_t( -7 ) * 65536;
+        int32_t after = 3;
+        serialize_check( ( serialize::serialize_fixed_internal<48, 16, -7, -7>( writeStream, degenerate ) ) == true );
+        serialize_check( writeStream.GetBitsProcessed() == 0 );
+        serialize_check( writeStream.SerializeInteger( after, 0, 7 ) );
+        writeStream.Flush();
+
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        int64_t read_degenerate = 0;
+        int32_t read_after = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<48, 16, -7, -7>( readStream, read_degenerate ) ) == true );
+        serialize_check( read_degenerate == int64_t( -7 ) * 65536 );
+        serialize_check( readStream.SerializeInteger( read_after, 0, 7 ) );
+        serialize_check( read_after == 3 );
+    }
+
+    // wide storage: Q112.16 -- the path that used to cost fraction_bits zeros
+    // in the ports. zero bits here, exactly like the narrow path
+    {
+        uint8_t buffer[16] = { 0 };
+
+        serialize::WriteStream writeStream( buffer, 16 );
+        serialize::int128_t degenerate = serialize::int128_t( 9 * 65536 );  // 9.0 in Q112.16
+        int32_t after = 3;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, 9, 9>( writeStream, degenerate ) ) == true );
+        serialize_check( writeStream.GetBitsProcessed() == 0 );      // zero bits, NOT fraction_bits
+        serialize_check( writeStream.SerializeInteger( after, 0, 7 ) );
+        serialize_check( writeStream.GetBitsProcessed() == 3 );
+        writeStream.Flush();
+
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize::int128_t read_degenerate( 0 );
+        int32_t read_after = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, 9, 9>( readStream, read_degenerate ) ) == true );
+        serialize_check( read_degenerate == serialize::int128_t( 9 * 65536 ) );
+        serialize_check( readStream.GetBitsProcessed() == 0 );
+        serialize_check( readStream.SerializeInteger( read_after, 0, 7 ) );
+        serialize_check( read_after == 3 );
+
+        serialize::MeasureStream measureStream;
+        serialize::int128_t measured = serialize::int128_t( 9 * 65536 );
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, 9, 9>( measureStream, measured ) ) == true );
+        serialize_check( measureStream.GetBitsProcessed() == 0 );
+    }
+
+    // wide storage, negative degenerate bound: Q112.16 at -9.0
+    {
+        uint8_t buffer[16] = { 0 };
+
+        serialize::WriteStream writeStream( buffer, 16 );
+        serialize::int128_t degenerate = serialize::int128_t( -9 * 65536 );
+        int32_t after = 3;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -9, -9>( writeStream, degenerate ) ) == true );
+        serialize_check( writeStream.GetBitsProcessed() == 0 );
+        serialize_check( writeStream.SerializeInteger( after, 0, 7 ) );
+        writeStream.Flush();
+
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize::int128_t read_degenerate( 0 );
+        int32_t read_after = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<112, 16, -9, -9>( readStream, read_degenerate ) ) == true );
+        serialize_check( read_degenerate == serialize::int128_t( -9 * 65536 ) );
+        serialize_check( readStream.SerializeInteger( read_after, 0, 7 ) );
+        serialize_check( read_after == 3 );
+    }
+
+    // wide storage, emulated representation: Q64.64 over min == max == 0. the
+    // old wide formula would have made this 64 bits of zeros -- the fraction
+    // alone spans the full 64 bit fractional field. explicitly the emulated
+    // pair, so the degenerate path is proven in both representations on every
+    // platform
+    {
+        uint8_t buffer[16] = { 0 };
+
+        serialize::WriteStream writeStream( buffer, 16 );
+        ::serialize_int128_t degenerate( 0 );
+        int32_t after = 3;
+        serialize_check( ( serialize::serialize_fixed_internal<64, 64, 0, 0>( writeStream, degenerate ) ) == true );
+        serialize_check( writeStream.GetBitsProcessed() == 0 );      // zero bits, not the 64 bit fractional field
+        serialize_check( writeStream.SerializeInteger( after, 0, 7 ) );
+        writeStream.Flush();
+
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        ::serialize_int128_t read_degenerate( 1 );                   // a wrong value, so recovery is observable
+        int32_t read_after = 0;
+        serialize_check( ( serialize::serialize_fixed_internal<64, 64, 0, 0>( readStream, read_degenerate ) ) == true );
+        serialize_check( read_degenerate == ::serialize_int128_t( 0 ) );
+        serialize_check( readStream.SerializeInteger( read_after, 0, 7 ) );
+        serialize_check( read_after == 3 );
+    }
 }
 
 inline void test_serialize_uint128()
@@ -7292,6 +7463,7 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_serialize_fixed_matches_int64 );
         SERIALIZE_RUN_TEST( test_serialize_fixed_wide );
         SERIALIZE_RUN_TEST( test_serialize_fixed_wide_emulated );
+        SERIALIZE_RUN_TEST( test_serialize_fixed_degenerate );
         SERIALIZE_RUN_TEST( test_serialize_uint128 );
         SERIALIZE_RUN_TEST( test_serialize_int128 );
         SERIALIZE_RUN_TEST( test_uint128_emulation );


### PR DESCRIPTION
STANDARD.md adopts the six decisions' normative texts from the schema enactment, each marked *adopted 2026-08-15 from the schema enactment* and placed in its matching section — the surviving forks issue #56 records:

- **Writes assume trusted data** (General Conventions) — doctrine ratified, the ruling verbatim. Obligations, not defined behaviors; costly contracts assert in debug only; the read side untouched.
- **`string` payloads are well-formed UTF-8 by contract** (string) — the writer's obligation, never the reader's check; no mandatory read-path validation, no release-path cost anywhere.
- **Each `wstring` group carries one UTF-16 code unit, well-formed UTF-16 by contract** (wstring) — surrogate pairs valid, an unpaired surrogate a writer contract violation; 2-byte and 4-byte `wchar_t` platforms must produce identical bytes, the 4-byte platform converting at the boundary.
- **A degenerate `fixed` range `min == max` is legal and costs zero bits, on every storage width** (fixed) — the reader recovers `min << fraction_bits` from the range alone.
- **The one rounding rule** (fixed) — fixed point rounds ties half away from zero, everywhere it rounds; the naive shift floors on negative ties, so a discriminating vector must pin a negative tie.
- **`int_relative` semantics pinned** (int_relative) — no wrapping sequence numbers, the ruling verbatim; strictly increasing, the reader fails otherwise.

**serialize.h conforms to the degenerate ruling.** `serialize_fixed` refused `min == max` outright (`static assert min < max`, stricter than the format), and its wide path would have computed `fraction_bits` of zeros where the narrow path writes nothing — the same 64/128 self-disagreement serialize#54 pins on the Go and C# ports. Both `FixedPointSerializer` specializations now take a degenerate early-out: zero bits, write-side debug assert, read recovers the value from the range. `test_serialize_fixed_degenerate` pins narrow, wide-native and wide-emulated storage, negative bounds included, plus MeasureStream agreement.

Also: the three `#error` strings now spell "endianness".

**Deliberately not touched:** the compressed_float reader-arithmetic paragraph and the Reader Obligations section that PR #60 drafts — no overlap, #60 stays as drafted.

**Residual, recorded:** `serialize_wstring_internal` still transmits raw `wchar_t` units with no surrogate-pair boundary conversion, so the implementation does not yet meet the adopted astral-text obligation on 4-byte `wchar_t` platforms. Basic-plane text — the only text any caller sends; `wstring` has zero usage in the tree — is byte-identical either way. Under the Provenance rule that gap is an implementation bug, held open deliberately rather than papered over here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)