### PR TITLE
Version 1.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.7.1 LANGUAGES CXX)
+project(serialize VERSION 1.8.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -37,7 +37,7 @@
 #define SERIALIZE_VERSION_MAJOR 1
 #define SERIALIZE_VERSION_MINOR 7
 #define SERIALIZE_VERSION_PATCH 1
-#define SERIALIZE_VERSION "1.7.1"
+#define SERIALIZE_VERSION "1.8.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
The six schema-enactment rulings (#62) are wire-affecting normative text plus their implementation, one commit past v1.7.1 with the version still 1.7.1 — release-check flagged exactly this. Minor bump: new normative surface (string/wstring well-formedness contracts, degenerate fixed ranges at zero bits, the one rounding rule), no break to existing well-formed streams. Both version sites bumped (CMakeLists.txt, SERIALIZE_VERSION). v1.8.0 tags on merge.