### PR TITLE
STANDARD: measure is a bound, readers refuse malformed strings, and two silences ratify

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -15,8 +15,10 @@ in `[0,7]` costs three.
 
 Reading and writing are expressed once, as a single templated function per
 message type, instantiated against a write stream, a read stream, or a measure
-stream. The measure stream computes the size a message would occupy without
-producing bytes. This document concerns only the bytes on the wire.
+stream. The measure stream computes a conservative bound on the size a message
+would occupy, without producing bytes — its obligations are specified in "The
+Measure Stream" below. Everything else in this document concerns the bytes on
+the wire.
 
 ## General Conventions
 
@@ -283,6 +285,19 @@ The 32 bits of the IEEE-754 single-precision representation, written as a
 The 64 bits of the IEEE-754 double-precision representation, written as one
 64-bit group.
 
+**Bit transparency — both directions** *(ratified 2026-08-15 from the #56
+re-audit; every implementation already complies)*. `float` and `double` are
+transparent in both directions. Every bit pattern is legal on the wire — NaNs
+with any payload, signaling NaNs, infinities, negative zero, denormals — and
+the reader reproduces the transmitted pattern exactly: it must not
+canonicalize, quiet, flush, or refuse any of them. There is no reader
+latitude here — a reader that rejects NaN, or canonicalizes payloads, does
+not conform; the read returns exactly the bits read. A round trip through any
+conforming writer/reader pair preserves all 32 (or 64) bits. Conformance
+vectors for these operations must compare **bit patterns, not values**: NaN
+compares unequal to itself, `-0.0 == 0.0`, and a tolerance comparison cannot
+see a quieted signaling bit, so a value-space comparison here proves nothing.
+
 ### compressed_float
 
     serialize_compressed_float( stream, value, min, max, res )
@@ -344,6 +359,15 @@ format, not an optimization — a reader that does not align will desynchronize.
 
 `count` is not written. Both sides must already agree on it.
 
+**`count` may be zero** *(ratified 2026-08-15 from the #56 re-audit; every
+implementation already complies)*. The alignment is performed regardless: a
+zero-length `serialize_bytes` pads to the byte boundary and writes nothing
+else, and the reader performs and verifies the same alignment. Skipping the
+alignment when `count` is zero — a plausible "optimization" — desynchronizes
+every field that follows, and a round-trip self-test cannot catch it, because
+both halves skip the same align. This clause is load-bearing for `string`,
+whose empty case reaches exactly this path.
+
 ### string
 
     serialize_string( stream, string, buffer_size )
@@ -362,12 +386,38 @@ string serialized against different buffer sizes produces different bytes.
 **`string` payloads are well-formed UTF-8 by contract** *(adopted 2026-08-15
 from the schema enactment, writer-trusted per the doctrine above)*. The wire
 shape is unchanged; what the `string` spelling adds is a **contract**: the
-payload is well-formed UTF-8, the writer's obligation, never the reader's
-check. Writing malformed UTF-8 is a writer contract violation — debug-only
-asserts where the language supports them — there is no mandatory read-path
-validation and no release-path cost anywhere, and the conformance vectors
-carry only valid UTF-8. An application with genuinely arbitrary payloads uses
-`serialize_bytes`, which remains exactly that.
+payload is well-formed UTF-8, the writer's obligation. Writing malformed UTF-8
+is a writer contract violation — debug-only asserts where the language
+supports them — and the conformance vectors carry only valid UTF-8. An
+application with genuinely arbitrary payloads uses `serialize_bytes`, which
+remains exactly that. *(Until 2026-08-15 this paragraph also promised no
+mandatory read-path validation; the ruling below supersedes that half. The
+writer's obligation stands unchanged.)*
+
+**Readers must refuse malformed `string` payloads** *(adopted 2026-08-15)*.
+Two refusal rules, binding in every build mode like every other read-side rule
+in this document:
+
+* **Invalid UTF-8 fails the read.** The payload the contract above promises is
+  the payload the reader insists on: a stream carrying malformed UTF-8 was not
+  produced by a conforming writer, and the reader refuses it rather than
+  handing it to the application.
+* **An interior NUL fails the read** — a zero byte anywhere among the `length`
+  transmitted bytes. A conforming writer derives `length` from `strlen`, so no
+  zero byte can reach the wire from conformance; a stream carrying one gives
+  the payload **two lengths** — the wire length, and the `strlen` every
+  consumer downstream will compute — and everything between them rides
+  invisibly past whichever side uses the other. Refusing the byte closes the
+  smuggling primitive. (NUL is well-formed UTF-8, which is why this is its own
+  rule.)
+
+These are refusal rules, and refusal rules are format: an implementation that
+skips one accepts streams a conforming implementation refuses. *(Cost,
+recorded with the ruling: the string operations are the convenience path, not
+the hot path — strings are rare in serialized game traffic, and a design
+chasing minimal bandwidth does not send strings at all — so the O(n)
+validation prices into traffic that performance-sensitive designs do not
+carry.)*
 
 ### wstring
 
@@ -399,6 +449,21 @@ points into surrogate pairs on write, recombines on read — because the
 platform-compatibility claim this section used to make was false for astral
 text when each platform transmitted its own `wchar_t` units. Basic-plane text
 is unaffected on every platform.
+
+**Readers must refuse malformed `wstring` payloads** *(adopted 2026-08-15, the
+same ruling as `string`'s)*. The same two rules, in UTF-16 terms, binding in
+every build mode:
+
+* **An unpaired surrogate fails the read**: a high surrogate
+  (`0xD800`–`0xDBFF`) not immediately followed by a low surrogate
+  (`0xDC00`–`0xDFFF`), a low surrogate not immediately preceded by a high
+  surrogate, or a high surrogate as the final transmitted group. Well-formed
+  surrogate **pairs** remain valid — they are how astral text travels.
+* **An interior NUL fails the read** — a zero group among the `length`
+  transmitted groups — by the same two-lengths logic as `string`: a conforming
+  writer derives `length` from `wcslen`, so a zero group is impossible from
+  conformance, and a stream carrying one is carrying a payload with two
+  lengths.
 
 ## Worked Example
 
@@ -449,6 +514,69 @@ write, rather than sharing one templated function.
 exist for convenience and to avoid a branch, not to encode anything
 differently. This document therefore specifies each operation once, under its
 `serialize_` name.
+
+## The Measure Stream
+
+Until 2026-08-15 this document disclaimed the measure stream in its third
+paragraph and never mentioned it again — the same silence `compressed_float`
+once enjoyed, and the implementations had quietly split under it: one measured
+alignment exactly from a running bit index, four charged the worst case. This
+section replaces the silence with the ruling *(2026-08-15, verbatim: "measure
+must be large enough to serialize the message but doesn't need to be exact. it
+is used only for yojimbo message serialization to see if there is enough room
+in the packet to definitely serialize a message.")*.
+
+**A measure is a bound, not the packet size.** A measure must report a size
+**sufficient to serialize the message at any starting bit position**. It need
+not be exact, and cannot be: alignment cost depends on the bit position the
+message is later written at, which a measure does not know — the same message
+costs different bits at different offsets, so no single number is exact for
+all of them *(the ruling: "the exact is not possible, since align is going to
+be different in 1st and 2nd times serialize is called. it is bit position
+dependent.")*.
+
+**The expected implementation charges the worst case: 7 bits per
+alignment-performing operation** — `align`, `bytes`, `string` — and exact
+width for everything else, which is every other operation: nothing else in
+this document is position-dependent.
+
+**A measure refuses nothing at runtime.** The measure follows the write
+path's misuse model *(the writes-trusted doctrine above)*: invalid parameters
+or out-of-range values are the caller's contract violation, asserted in debug
+builds where the language supports it, and a measure never refuses at runtime
+in release. A measure sits on the trusted side of the boundary — nothing it
+sees came off a network.
+
+**Exact-from-zero accounting is non-conforming** *(the ruling: "so if some
+implementations of serialize measure in other languages are exact, they
+probably should not be. make them conservative bounds like in C++, and the
+standard should specify this is what is expected.")*. A measure that computes
+alignment from a running bit index starting at zero reports the exact cost of
+writing the message from an aligned start — and **under-counts every unaligned
+start**. The worked example: `{ bits(8); align; bits(8) }` is 16 bits — 2
+bytes — written from an aligned start, where the align is a no-op; written
+from bit offset 1, the align pads 7 bits and the message spans 23 bits — 3
+bytes of room needed. The exact-from-zero answer of 2 bytes is not sufficient
+at every starting position, which is the one thing a measure is for. The
+conservative answer — 8 + 7 + 8 = 23 bits — is sufficient everywhere.
+
+**What a measure is for, and what it is not** *(rationale, recorded)*. The
+operation exists so a packet assembler can ask "does this message definitely
+fit in the space remaining?" — the yojimbo fits-check — and a conservative
+bound answers exactly that question. Comparing a measure to a write's
+`bytes_processed` and expecting equality is a misuse: the bound is not the
+packet size. An application that needs the true bit count of a message from a
+known starting position has always had the escape hatch — write it to a
+scratch stream and read the count off the write. And the operation is probably
+vestigial — *"we won't support it with the rANS encoder for example"* — 
+specified here because five implementations ship it today and had already
+begun to disagree, not because it is expected to survive into entropy-coded
+encodings.
+
+**Testable**: for every message in the conformance corpus,
+`measure >= bits written`, at every starting bit position; and the worked
+example discriminates — a conservative measure reports 23 bits for
+`{ bits(8); align; bits(8) }` where an exact-from-zero measure reports 16.
 
 ## Compatibility Notes
 

--- a/fuzz.cpp
+++ b/fuzz.cpp
@@ -480,7 +480,12 @@ template <typename Stream> bool FuzzRoundTrip( Stream & stream, const uint8_t * 
                 const int length = pool.NextByte() % ( sizeof( expected ) - 1 );
                 for ( int j = 0; j < length; j++ )
                 {
-                    const uint8_t c = pool.NextByte();
+                    // masked to ASCII: the string payload is well-formed UTF-8 by the
+                    // writer's contract, and the reader REFUSES malformed payloads
+                    // (STANDARD.md, adopted 2026-08-15), so the differential round trip
+                    // must generate conforming content. Arbitrary bytes still reach the
+                    // READ path via FuzzRead.
+                    const uint8_t c = pool.NextByte() & 0x7F;
                     expected[j] = ( c != 0 ) ? (char) c : ' ';
                 }
                 expected[length] = '\0';
@@ -502,7 +507,16 @@ template <typename Stream> bool FuzzRoundTrip( Stream & stream, const uint8_t * 
                 wchar_t expected[8];
                 const int length = pool.NextByte() % ( sizeof( expected ) / sizeof( wchar_t ) - 1 );
                 for ( int j = 0; j < length; j++ )
-                    expected[j] = (wchar_t) ( pool.NextUint32() % 0xFFFF + 1 );                 // [1,0xFFFF]: valid for 2 and 4 byte wchar_t
+                {
+                    uint32_t unit = pool.NextUint32() % 0xFFFF + 1;                             // [1,0xFFFF]: valid for 2 and 4 byte wchar_t
+                    if ( unit >= 0xD800 && unit <= 0xDFFF )
+                    {
+                        unit -= 0x0800;     // out of the surrogate block: the payload is well-formed
+                                            // UTF-16 by the writer's contract, and the reader REFUSES
+                                            // unpaired surrogates (STANDARD.md, adopted 2026-08-15)
+                    }
+                    expected[j] = (wchar_t) unit;
+                }
                 expected[length] = L'\0';
                 wchar_t value[8];
                 if ( Stream::IsWriting )

--- a/serialize.h
+++ b/serialize.h
@@ -2664,6 +2664,76 @@ namespace serialize
             }                                                                       \
         } while (0)
 
+    /*
+        UTF-8 well-formedness. Used by the READ path's refusal rule (STANDARD.md,
+        "Readers must refuse malformed string payloads", adopted 2026-08-15) — which
+        binds in every build mode, because the read side faces untrusted data — and
+        shaped to match the writer's debug-only contract validator byte for byte, so
+        the two branches carrying them merge to one function. Rejects overlong
+        encodings, surrogate code points, values above U+10FFFF, truncated sequences
+        and stray continuation bytes. NUL bytes are VALID UTF-8: the interior-NUL
+        refusal is a separate rule with its own reason.
+    */
+
+    inline bool serialize_string_is_valid_utf8( const char * string, int length )
+    {
+        int i = 0;
+        while ( i < length )
+        {
+            const uint32_t lead = (uint8_t) string[i];
+            if ( lead < 0x80 )
+            {
+                i += 1;
+            }
+            else if ( ( lead & 0xE0 ) == 0xC0 )
+            {
+                if ( lead < 0xC2 )                                                              // overlong
+                    return false;
+                if ( i + 1 >= length )
+                    return false;
+                if ( ( (uint8_t) string[i+1] & 0xC0 ) != 0x80 )
+                    return false;
+                i += 2;
+            }
+            else if ( ( lead & 0xF0 ) == 0xE0 )
+            {
+                if ( i + 2 >= length )
+                    return false;
+                const uint32_t byte1 = (uint8_t) string[i+1];
+                const uint32_t byte2 = (uint8_t) string[i+2];
+                if ( ( byte1 & 0xC0 ) != 0x80 || ( byte2 & 0xC0 ) != 0x80 )
+                    return false;
+                if ( lead == 0xE0 && byte1 < 0xA0 )                                             // overlong
+                    return false;
+                if ( lead == 0xED && byte1 >= 0xA0 )                                            // surrogate code point
+                    return false;
+                i += 3;
+            }
+            else if ( ( lead & 0xF8 ) == 0xF0 )
+            {
+                if ( lead > 0xF4 )                                                              // above U+10FFFF
+                    return false;
+                if ( i + 3 >= length )
+                    return false;
+                const uint32_t byte1 = (uint8_t) string[i+1];
+                const uint32_t byte2 = (uint8_t) string[i+2];
+                const uint32_t byte3 = (uint8_t) string[i+3];
+                if ( ( byte1 & 0xC0 ) != 0x80 || ( byte2 & 0xC0 ) != 0x80 || ( byte3 & 0xC0 ) != 0x80 )
+                    return false;
+                if ( lead == 0xF0 && byte1 < 0x90 )                                             // overlong
+                    return false;
+                if ( lead == 0xF4 && byte1 >= 0x90 )                                            // above U+10FFFF
+                    return false;
+                i += 4;
+            }
+            else
+            {
+                return false;                                                                   // continuation or invalid lead byte
+            }
+        }
+        return true;
+    }
+
     template <typename Stream> bool serialize_string_internal( Stream & stream, char * string, int buffer_size )
     {
         int length = 0;
@@ -2676,6 +2746,24 @@ namespace serialize
         serialize_bytes( stream, (uint8_t*)string, length );
         if ( Stream::IsReading )
         {
+            // STANDARD.md, "Readers must refuse malformed string payloads" (adopted
+            // 2026-08-15). Interior NUL first: a conforming writer derives the length
+            // from strlen, so a zero byte among the transmitted bytes only arrives
+            // doctored — and it gives the payload TWO lengths, the wire length and the
+            // strlen every consumer downstream computes, with everything between them
+            // riding invisibly past whichever side uses the other. NUL is valid UTF-8,
+            // so the validator below cannot catch it.
+            for ( int i = 0; i < length; i++ )
+            {
+                if ( string[i] == '\0' )
+                {
+                    return false;
+                }
+            }
+            if ( !serialize_string_is_valid_utf8( string, length ) )
+            {
+                return false;
+            }
             string[length] = '\0';
         }
         return true;
@@ -2684,6 +2772,13 @@ namespace serialize
     // Wire format is 32 bits per character, so streams are compatible between platforms with 2 and 4 byte wchar_t.
     // Code points above 0xFFFF are not translated between UTF-16 and UTF-32 platforms: reading a value that doesn't
     // fit in the local wchar_t fails rather than truncating.
+    //
+    // On read, malformed payloads are REFUSED in every build mode (STANDARD.md, "Readers must
+    // refuse malformed wstring payloads", adopted 2026-08-15): an unpaired surrogate fails the
+    // read — a high surrogate without its low, a low with no high before it, or a dangling high
+    // as the final group — and so does an interior NUL group, because a conforming writer
+    // derives the length from wcslen, so a zero group only arrives doctored and gives the
+    // payload two lengths. Well-formed surrogate PAIRS pass: they are how astral text travels.
 
     template <typename Stream> bool serialize_wstring_internal( Stream & stream, wchar_t * string, int buffer_size )
     {
@@ -2695,6 +2790,7 @@ namespace serialize
             serialize_assert( length < buffer_size );
         }
         serialize_int( stream, length, 0, buffer_size - 1 );
+        bool expecting_low_surrogate = false;
         for ( int i = 0; i < length; i++ )
         {
             uint32_t character = 0;
@@ -2709,11 +2805,35 @@ namespace serialize
                 {
                     return false;
                 }
+                if ( character == 0 )
+                {
+                    return false;                   // interior NUL: the two-lengths smuggling primitive
+                }
+                if ( expecting_low_surrogate )
+                {
+                    if ( character < 0xDC00 || character > 0xDFFF )
+                    {
+                        return false;               // high surrogate without its low
+                    }
+                    expecting_low_surrogate = false;
+                }
+                else if ( character >= 0xDC00 && character <= 0xDFFF )
+                {
+                    return false;                   // low surrogate with no high before it
+                }
+                else if ( character >= 0xD800 && character <= 0xDBFF )
+                {
+                    expecting_low_surrogate = true;
+                }
                 string[i] = (wchar_t) character;
             }
         }
         if ( Stream::IsReading )
         {
+            if ( expecting_low_surrogate )
+            {
+                return false;                       // the final group is a dangling high surrogate
+            }
             string[length] = L'\0';
         }
         return true;
@@ -2724,6 +2844,7 @@ namespace serialize
         Serialize a string to the stream (read/write/measure).
         This is a helper macro to make writing unified serialize functions easier.
         Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
+        On read, malformed payloads are refused (STANDARD.md, adopted 2026-08-15): invalid UTF-8 fails the read, and so does an interior NUL byte among the transmitted bytes.
         IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
         @param stream The stream object. May be a read, write or measure stream.
         @param string The string to serialize write/measure. Pointer to buffer to be filled on read.
@@ -2744,6 +2865,7 @@ namespace serialize
         This is a helper macro to make writing unified serialize functions easier.
         Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
         The wire format is 32 bits per character, so streams are compatible between platforms with 2 and 4 byte wchar_t. Reading a character that doesn't fit in the local wchar_t fails rather than truncating.
+        On read, malformed payloads are refused (STANDARD.md, adopted 2026-08-15): an unpaired surrogate fails the read, and so does an interior NUL group among the transmitted groups.
         IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
         @param stream The stream object. May be a read, write or measure stream.
         @param string The wide string to serialize write/measure. Pointer to buffer to be filled on read.
@@ -4845,6 +4967,191 @@ inline void test_wstring_validation()
             serialize_check( result == false );
             serialize_check( read_back[0] != (wchar_t) ( above_bmp & 0xFFFF ) );
         }
+    }
+}
+
+inline void test_string_read_validation()
+{
+    // STANDARD.md, "Readers must refuse malformed string payloads" (adopted 2026-08-15).
+    // Every refused stream below is DOCTORED with raw bit operations — no conforming
+    // writer can produce it — and the refusal binds in every build mode. Proven
+    // red-then-green: against the pre-ruling reader, every doctored stream here was
+    // ACCEPTED (harness run recorded with the ruling batch); with the refusals in
+    // place they are REFUSED, and the valid-content controls are unchanged.
+
+    const int BufferSize = 16;
+
+    // invalid UTF-8: 0xFF can never appear anywhere in well-formed UTF-8
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        int32_t length = 3;
+        serialize_check( writeStream.SerializeInteger( length, 0, BufferSize - 1 ) );
+        const uint8_t payload[3] = { 0xFF, 0xFE, 0xFF };
+        serialize_check( writeStream.SerializeBytes( payload, 3 ) );
+        writeStream.Flush();
+
+        char read_back[BufferSize];
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize_check( serialize::serialize_string_internal( readStream, read_back, BufferSize ) == false );
+    }
+
+    // truncated UTF-8: a 3 byte lead as the final transmitted byte
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        int32_t length = 2;
+        serialize_check( writeStream.SerializeInteger( length, 0, BufferSize - 1 ) );
+        const uint8_t payload[2] = { 'a', 0xE2 };
+        serialize_check( writeStream.SerializeBytes( payload, 2 ) );
+        writeStream.Flush();
+
+        char read_back[BufferSize];
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize_check( serialize::serialize_string_internal( readStream, read_back, BufferSize ) == false );
+    }
+
+    // interior NUL: wire length 3, strlen 1 — the TWO-LENGTHS smuggling primitive. A
+    // conforming writer derives the length from strlen, so this stream is impossible
+    // from conformance; accepted, it hands the application a payload whose wire length
+    // and C length disagree, and everything between them travels invisibly.
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        int32_t length = 3;
+        serialize_check( writeStream.SerializeInteger( length, 0, BufferSize - 1 ) );
+        const uint8_t payload[3] = { 'a', 0x00, 'b' };
+        serialize_check( writeStream.SerializeBytes( payload, 3 ) );
+        writeStream.Flush();
+
+        char read_back[BufferSize];
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize_check( serialize::serialize_string_internal( readStream, read_back, BufferSize ) == false );
+    }
+
+    // control: valid multi-byte UTF-8 — 2, 3 and 4 byte sequences, built from explicit
+    // bytes so the source file encoding can never change the test — still round trips.
+    // The refusal costs no valid stream.
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        char text[BufferSize];
+        const uint8_t utf8[11] = { 'h', 0xC3, 0xA9, 0xE2, 0x82, 0xAC, 0xF0, 0x9F, 0x98, 0x80, 0 };  // h, e-acute, euro sign, U+1F600
+        memcpy( text, utf8, sizeof( utf8 ) );
+
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        serialize_check( serialize::serialize_string_internal( writeStream, text, BufferSize ) );
+        writeStream.Flush();
+
+        char read_back[BufferSize];
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize_check( serialize::serialize_string_internal( readStream, read_back, BufferSize ) );
+        serialize_check( strcmp( read_back, text ) == 0 );
+    }
+}
+
+inline void test_wstring_read_validation()
+{
+    // STANDARD.md, "Readers must refuse malformed wstring payloads" (adopted 2026-08-15).
+    // Same shape as the narrow test above: doctored streams refused in every build mode,
+    // proven red-then-green, valid content unchanged.
+
+    const int BufferSize = 8;
+
+    // high surrogate followed by a non-surrogate: unpaired, refused
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        int32_t length = 2;
+        serialize_check( writeStream.SerializeInteger( length, 0, BufferSize - 1 ) );
+        uint32_t group0 = 0xD800;
+        uint32_t group1 = 0x0041;
+        serialize_check( writeStream.SerializeBits( group0, 32 ) );
+        serialize_check( writeStream.SerializeBits( group1, 32 ) );
+        writeStream.Flush();
+
+        wchar_t read_back[BufferSize];
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize_check( serialize::serialize_wstring_internal( readStream, read_back, BufferSize ) == false );
+    }
+
+    // low surrogate with no high before it: refused
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        int32_t length = 1;
+        serialize_check( writeStream.SerializeInteger( length, 0, BufferSize - 1 ) );
+        uint32_t group0 = 0xDC00;
+        serialize_check( writeStream.SerializeBits( group0, 32 ) );
+        writeStream.Flush();
+
+        wchar_t read_back[BufferSize];
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize_check( serialize::serialize_wstring_internal( readStream, read_back, BufferSize ) == false );
+    }
+
+    // high surrogate as the final transmitted group: dangling, refused
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        int32_t length = 1;
+        serialize_check( writeStream.SerializeInteger( length, 0, BufferSize - 1 ) );
+        uint32_t group0 = 0xD83D;
+        serialize_check( writeStream.SerializeBits( group0, 32 ) );
+        writeStream.Flush();
+
+        wchar_t read_back[BufferSize];
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize_check( serialize::serialize_wstring_internal( readStream, read_back, BufferSize ) == false );
+    }
+
+    // interior NUL group: wire length 3, wcslen 1 — the same two-lengths primitive as
+    // the narrow string, refused
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        int32_t length = 3;
+        serialize_check( writeStream.SerializeInteger( length, 0, BufferSize - 1 ) );
+        uint32_t group0 = 0x0041;
+        uint32_t group1 = 0x0000;
+        uint32_t group2 = 0x0042;
+        serialize_check( writeStream.SerializeBits( group0, 32 ) );
+        serialize_check( writeStream.SerializeBits( group1, 32 ) );
+        serialize_check( writeStream.SerializeBits( group2, 32 ) );
+        writeStream.Flush();
+
+        wchar_t read_back[BufferSize];
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize_check( serialize::serialize_wstring_internal( readStream, read_back, BufferSize ) == false );
+    }
+
+    // control: a well-formed surrogate PAIR is valid UTF-16 — it is how astral text
+    // travels — and must be ACCEPTED. Against main's reader the pair is stored as its
+    // two units on every platform; recombination on 4 byte wchar_t is the surrogate
+    // boundary branch's work and composes on top of this check.
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        int32_t length = 2;
+        serialize_check( writeStream.SerializeInteger( length, 0, BufferSize - 1 ) );
+        uint32_t group0 = 0xD83D;
+        uint32_t group1 = 0xDE00;
+        serialize_check( writeStream.SerializeBits( group0, 32 ) );
+        serialize_check( writeStream.SerializeBits( group1, 32 ) );
+        writeStream.Flush();
+
+        wchar_t read_back[BufferSize];
+        memset( read_back, 0, sizeof( read_back ) );
+        serialize::ReadStream readStream( buffer, writeStream.GetBytesProcessed() );
+        serialize_check( serialize::serialize_wstring_internal( readStream, read_back, BufferSize ) == true );
     }
 }
 
@@ -7456,6 +7763,8 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_serialize_int64_validation );
         SERIALIZE_RUN_TEST( test_serialize_bytes_validation );
         SERIALIZE_RUN_TEST( test_wstring_validation );
+        SERIALIZE_RUN_TEST( test_string_read_validation );
+        SERIALIZE_RUN_TEST( test_wstring_read_validation );
         SERIALIZE_RUN_TEST( test_int_relative_validation );
         SERIALIZE_RUN_TEST( test_compressed_float_validation );
         SERIALIZE_RUN_TEST( test_serialize_fixed );

--- a/serialize.h
+++ b/serialize.h
@@ -7639,6 +7639,332 @@ inline void test_compressed_float_conformance_nonzero_min()
     }
 }
 
+// Conformance vector for float/double BIT TRANSPARENCY (STANDARD.md, "Floating Point",
+// ratified 2026-08-15 from the #56 re-audit). Additive: golden_wire_bytes is untouched.
+//
+// The golden's float is 3.1415926f and its double 1.0/3.0 — ordinary values that any
+// sanitizing implementation reproduces — and the document-side checker compares them by
+// TOLERANCE, which is structurally unable to see a canonicalized NaN payload, a quieted
+// signaling bit, or a sign-of-zero flip. These patterns are the ones a sanitizer breaks,
+// constructed by bit-cast (never by literal) and compared by bits (never by value: NaN
+// compares unequal to itself and -0.0 == 0.0, so value comparison proves nothing here).
+
+static const uint8_t golden_float_bytes[] =
+{
+    0x01, 0x00, 0xC0, 0x7F,                             // f32 0x7FC00001: quiet NaN, payload 1
+    0x01, 0x00, 0x80, 0x7F,                             // f32 0x7F800001: SIGNALING NaN
+    0x00, 0x00, 0x80, 0xFF,                             // f32 0xFF800000: -Inf
+    0x00, 0x00, 0x00, 0x80,                             // f32 0x80000000: -0.0
+    0x01, 0x00, 0x00, 0x00,                             // f32 0x00000001: smallest denormal
+    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF4, 0x7F,     // f64 0x7FF4000000000001: signaling NaN, payload 1
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80      // f64 0x8000000000000000: -0.0
+};
+
+static const uint32_t golden_float_patterns[5] = { 0x7FC00001u, 0x7F800001u, 0xFF800000u, 0x80000000u, 0x00000001u };
+static const uint64_t golden_double_patterns[2] = { 0x7FF4000000000001ULL, 0x8000000000000000ULL };
+
+template <typename Stream> bool GoldenFloatSerialize( Stream & stream, float * float_values, double * double_values )
+{
+    for ( int i = 0; i < 5; i++ )
+    {
+        serialize_float( stream, float_values[i] );
+    }
+    for ( int i = 0; i < 2; i++ )
+    {
+        serialize_double( stream, double_values[i] );
+    }
+    return true;
+}
+
+inline void test_golden_float_bit_transparency()
+{
+    // write side: the bit patterns above, bit-cast into float/double and serialized, must
+    // produce exactly the pinned little-endian bytes — no quieting, no canonicalization
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream stream( buffer, (int) sizeof( buffer ) );
+        float float_values[5];
+        double double_values[2];
+        for ( int i = 0; i < 5; i++ )
+            memcpy( &float_values[i], &golden_float_patterns[i], 4 );
+        for ( int i = 0; i < 2; i++ )
+            memcpy( &double_values[i], &golden_double_patterns[i], 8 );
+        serialize_check( GoldenFloatSerialize( stream, float_values, double_values ) == true );
+        stream.Flush();
+        serialize_check( stream.GetBytesProcessed() == (int) sizeof( golden_float_bytes ) );
+        serialize_check( memcmp( buffer, golden_float_bytes, sizeof( golden_float_bytes ) ) == 0 );
+    }
+
+    // read side: the recovered BIT PATTERNS must equal the transmitted ones exactly.
+    // a tolerance-based harness passes a sanitizing reader forever — which is the point
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        memcpy( buffer, golden_float_bytes, sizeof( golden_float_bytes ) );
+        serialize::ReadStream stream( buffer, (int) sizeof( golden_float_bytes ) );
+        float float_values[5];
+        double double_values[2];
+        memset( float_values, 0, sizeof( float_values ) );
+        memset( double_values, 0, sizeof( double_values ) );
+        serialize_check( GoldenFloatSerialize( stream, float_values, double_values ) == true );
+        for ( int i = 0; i < 5; i++ )
+        {
+            uint32_t bits = 0;
+            memcpy( &bits, &float_values[i], 4 );
+            serialize_check( bits == golden_float_patterns[i] );
+        }
+        for ( int i = 0; i < 2; i++ )
+        {
+            uint64_t bits = 0;
+            memcpy( &bits, &double_values[i], 8 );
+            serialize_check( bits == golden_double_patterns[i] );
+        }
+    }
+}
+
+// Conformance vectors for the zero-count and unaligned bytes paths (STANDARD.md, "bytes —
+// count may be zero", ratified 2026-08-15 from the #56 re-audit). Additive pins. Each one
+// discriminates: the wrong-but-plausible implementation produces DIFFERENT bytes, spelled
+// out per vector, so a port carrying the divergence fails the pin instead of agreeing with
+// itself forever — round-trip self-tests cannot catch a skipped align, because both halves
+// skip the same one.
+
+template <typename Stream> bool ZeroLengthBytesSerialize( Stream & stream, uint32_t & head, uint8_t * data, uint32_t & tail )
+{
+    serialize_bits( stream, head, 3 );
+    serialize_bytes( stream, data, 0 );
+    serialize_bits( stream, tail, 8 );
+    return true;
+}
+
+inline void test_golden_zero_length_bytes()
+{
+    // { bits(5,3); bytes(count=0); bits(0xA5,8) }. The zero-length bytes still ALIGNS:
+    // the pad lands in bits [3,8) and 0xA5 occupies byte 1. A port that early-returns on
+    // count == 0 writes { 0x2D, 0x05 } — every later field shifted by five bits.
+    static const uint8_t pinned_bytes[2] = { 0x05, 0xA5 };
+
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream stream( buffer, (int) sizeof( buffer ) );
+        uint32_t head = 5;
+        uint32_t tail = 0xA5;
+        uint8_t data[1] = { 0 };
+        serialize_check( ZeroLengthBytesSerialize( stream, head, data, tail ) == true );
+        stream.Flush();
+        serialize_check( stream.GetBytesProcessed() == (int) sizeof( pinned_bytes ) );
+        serialize_check( memcmp( buffer, pinned_bytes, sizeof( pinned_bytes ) ) == 0 );
+    }
+
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        memcpy( buffer, pinned_bytes, sizeof( pinned_bytes ) );
+        serialize::ReadStream stream( buffer, (int) sizeof( pinned_bytes ) );
+        uint32_t head = 0;
+        uint32_t tail = 0;
+        uint8_t data[1] = { 0 };
+        serialize_check( ZeroLengthBytesSerialize( stream, head, data, tail ) == true );
+        serialize_check( head == 5 );
+        serialize_check( tail == 0xA5 );
+        serialize_check( stream.GetBytesProcessed() == (int) sizeof( pinned_bytes ) );
+    }
+}
+
+template <typename Stream> bool ZeroLengthStringSerialize( Stream & stream, uint32_t & head, char * string, uint32_t & tail )
+{
+    serialize_bits( stream, head, 3 );
+    serialize_string( stream, string, 8 );
+    serialize_bits( stream, tail, 8 );
+    return true;
+}
+
+inline void test_golden_zero_length_string()
+{
+    // { bits(5,3); string("", buffer_size 8); bits(0xA5,8) }. The empty string is a 3-bit
+    // length of 0, then the zero-length payload's align pads bits [6,8). A port whose
+    // STRING path skips the empty-payload align writes { 0x45, 0x29 } — the exact hazard
+    // the C port's comment names, and a separate code path from bytes in three ports.
+    static const uint8_t pinned_bytes[2] = { 0x05, 0xA5 };
+
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream stream( buffer, (int) sizeof( buffer ) );
+        uint32_t head = 5;
+        uint32_t tail = 0xA5;
+        char string[8] = { 0 };
+        serialize_check( ZeroLengthStringSerialize( stream, head, string, tail ) == true );
+        stream.Flush();
+        serialize_check( stream.GetBytesProcessed() == (int) sizeof( pinned_bytes ) );
+        serialize_check( memcmp( buffer, pinned_bytes, sizeof( pinned_bytes ) ) == 0 );
+    }
+
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        memcpy( buffer, pinned_bytes, sizeof( pinned_bytes ) );
+        serialize::ReadStream stream( buffer, (int) sizeof( pinned_bytes ) );
+        uint32_t head = 0;
+        uint32_t tail = 0;
+        char string[8];
+        memset( string, 0xFF, sizeof( string ) );
+        serialize_check( ZeroLengthStringSerialize( stream, head, string, tail ) == true );
+        serialize_check( head == 5 );
+        serialize_check( string[0] == '\0' );
+        serialize_check( tail == 0xA5 );
+        serialize_check( stream.GetBytesProcessed() == (int) sizeof( pinned_bytes ) );
+    }
+}
+
+template <typename Stream> bool UnalignedBytesSerialize( Stream & stream, uint32_t & head, uint8_t * data, uint32_t & tail )
+{
+    serialize_bits( stream, head, 1 );
+    serialize_bytes( stream, data, 2 );
+    serialize_bits( stream, tail, 4 );
+    return true;
+}
+
+inline void test_golden_unaligned_bytes()
+{
+    // { bits(1,1); bytes({0xEF,0xBE}, 2); bits(0x0F,4) }. Exercises serialize_bytes' OWN
+    // align from bit index 1 — the case the golden vector structurally shadows, because an
+    // explicit serialize_align immediately precedes its bytes field, making the operation's
+    // internal align a no-op there.
+    static const uint8_t pinned_bytes[4] = { 0x01, 0xEF, 0xBE, 0x0F };
+
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream stream( buffer, (int) sizeof( buffer ) );
+        uint32_t head = 1;
+        uint32_t tail = 0x0F;
+        uint8_t data[2] = { 0xEF, 0xBE };
+        serialize_check( UnalignedBytesSerialize( stream, head, data, tail ) == true );
+        stream.Flush();
+        serialize_check( stream.GetBytesProcessed() == (int) sizeof( pinned_bytes ) );
+        serialize_check( memcmp( buffer, pinned_bytes, sizeof( pinned_bytes ) ) == 0 );
+    }
+
+    {
+        uint8_t buffer[64];
+        memset( buffer, 0, sizeof( buffer ) );
+        memcpy( buffer, pinned_bytes, sizeof( pinned_bytes ) );
+        serialize::ReadStream stream( buffer, (int) sizeof( pinned_bytes ) );
+        uint32_t head = 0;
+        uint32_t tail = 0;
+        uint8_t data[2] = { 0, 0 };
+        serialize_check( UnalignedBytesSerialize( stream, head, data, tail ) == true );
+        serialize_check( head == 1 );
+        serialize_check( data[0] == 0xEF );
+        serialize_check( data[1] == 0xBE );
+        serialize_check( tail == 0x0F );
+        serialize_check( stream.GetBytesProcessed() == (int) sizeof( pinned_bytes ) );
+    }
+}
+
+inline void test_measure_bound()
+{
+    // STANDARD.md, "The Measure Stream" (adopted 2026-08-15): a measure reports a size
+    // sufficient at ANY starting bit position — a bound, not the packet size — and the
+    // expected implementation charges worst-case 7 bits per alignment-performing
+    // operation. Exact-from-zero accounting is non-conforming: it under-counts every
+    // unaligned start.
+
+    // the ruling's worked example: { bits(8); align; bits(8) }
+    {
+        serialize::MeasureStream measureStream;
+        uint32_t byte_value = 0xAB;
+        serialize_check( measureStream.SerializeBits( byte_value, 8 ) == true );
+        serialize_check( measureStream.SerializeAlign() == true );
+        serialize_check( measureStream.SerializeBits( byte_value, 8 ) == true );
+        serialize_check( measureStream.GetBitsProcessed() == 23 );      // 8 + 7 + 8: the conservative charge.
+                                                                        // an exact-from-zero measure reports 16 —
+                                                                        // 2 bytes — which is NOT enough room when
+                                                                        // the message lands at bit offset 1
+
+        // written at every starting offset, the message's actual span never exceeds the
+        // measure — the property the bound exists to guarantee
+        for ( int offset = 0; offset < 8; offset++ )
+        {
+            uint8_t buffer[64];
+            memset( buffer, 0, sizeof( buffer ) );
+            serialize::WriteStream writeStream( buffer, (int) sizeof( buffer ) );
+            for ( int i = 0; i < offset; i++ )
+            {
+                uint32_t one_bit = 1;
+                serialize_check( writeStream.SerializeBits( one_bit, 1 ) == true );
+            }
+            const int64_t start = writeStream.GetBitsProcessed();
+            serialize_check( writeStream.SerializeBits( byte_value, 8 ) == true );
+            serialize_check( writeStream.SerializeAlign() == true );
+            serialize_check( writeStream.SerializeBits( byte_value, 8 ) == true );
+            const int64_t span = writeStream.GetBitsProcessed() - start;
+            serialize_check( span <= measureStream.GetBitsProcessed() );
+            if ( offset == 0 )
+                serialize_check( span == 16 );                          // 2 bytes from an aligned start...
+            if ( offset == 1 )
+                serialize_check( span == 23 );                          // ...3 bytes of room needed from offset 1
+        }
+    }
+
+    // measure >= written, across every message this suite pins. (The fuzz harness holds
+    // the same inequality over arbitrary op programs on every run.)
+    {
+        GoldenWireData data;
+        GoldenWireInit( data );
+        serialize::MeasureStream measureStream;
+        serialize_check( GoldenWireSerialize( measureStream, data ) == true );
+        uint8_t buffer[256];
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream writeStream( buffer, (int) sizeof( buffer ) );
+        serialize_check( GoldenWireSerialize( writeStream, data ) == true );
+        writeStream.Flush();
+        serialize_check( measureStream.GetBitsProcessed() >= writeStream.GetBitsProcessed() );
+    }
+
+    {
+        float float_values[5];
+        double double_values[2];
+        for ( int i = 0; i < 5; i++ )
+            memcpy( &float_values[i], &golden_float_patterns[i], 4 );
+        for ( int i = 0; i < 2; i++ )
+            memcpy( &double_values[i], &golden_double_patterns[i], 8 );
+        serialize::MeasureStream measureStream;
+        serialize_check( GoldenFloatSerialize( measureStream, float_values, double_values ) == true );
+        serialize_check( measureStream.GetBitsProcessed() >= 5 * 32 + 2 * 64 );     // no aligns: exact, and still a bound
+    }
+
+    {
+        uint32_t head = 5;
+        uint32_t tail = 0xA5;
+        uint8_t data[1] = { 0 };
+        serialize::MeasureStream measureStream;
+        serialize_check( ZeroLengthBytesSerialize( measureStream, head, data, tail ) == true );
+        serialize_check( measureStream.GetBitsProcessed() >= 16 );                  // 3 + pad + 8 written; measure charges 3 + 7 + 8
+    }
+
+    {
+        uint32_t head = 5;
+        uint32_t tail = 0xA5;
+        char string[8] = { 0 };
+        serialize::MeasureStream measureStream;
+        serialize_check( ZeroLengthStringSerialize( measureStream, head, string, tail ) == true );
+        serialize_check( measureStream.GetBitsProcessed() >= 16 );
+    }
+
+    {
+        uint32_t head = 1;
+        uint32_t tail = 0x0F;
+        uint8_t data[2] = { 0xEF, 0xBE };
+        serialize::MeasureStream measureStream;
+        serialize_check( UnalignedBytesSerialize( measureStream, head, data, tail ) == true );
+        serialize_check( measureStream.GetBitsProcessed() >= 28 );                  // 28 bits written; measure charges 1 + 7 + 16 + 4
+    }
+}
+
 inline void test_unaligned_writer()
 {
     // the bit writer stores each dword with memcpy, so the write buffer does not need 4 byte alignment.
@@ -7793,6 +8119,11 @@ inline void serialize_test()
 #endif // #if defined( SERIALIZE_HAS_COMPILE_TIME_SURFACE )
         SERIALIZE_RUN_TEST( test_golden_wire_format );
         SERIALIZE_RUN_TEST( test_compressed_float_conformance_nonzero_min );
+        SERIALIZE_RUN_TEST( test_golden_float_bit_transparency );
+        SERIALIZE_RUN_TEST( test_golden_zero_length_bytes );
+        SERIALIZE_RUN_TEST( test_golden_zero_length_string );
+        SERIALIZE_RUN_TEST( test_golden_unaligned_bytes );
+        SERIALIZE_RUN_TEST( test_measure_bound );
         SERIALIZE_RUN_TEST( test_unaligned_writer );
         SERIALIZE_RUN_TEST( test_large_buffer );
     }


### PR DESCRIPTION
Enacts four of tonight's rulings as normative text plus the C++ implementation and five vectors that can fail:

- **measure is a conservative bound, never exact** (align is bit-position dependent; exactness is impossible by design — ruling verbatim in the commits)
- **readers refuse malformed string content**: invalid UTF-8, unpaired surrogates, interior NULs (ruling #8)
- **float/double bit-transparency and zero-length bytes** ratified from verified-unanimous behavior (F3, F2)
- five new test vectors, each proven able to fail: doctored streams accepted by main then refused here; measure bound pinned at all 8 bit offsets

Composes with #60: expect a positional STANDARD.md conflict (both insert after the read-only/write-only forms) — both sections are kept. No wire bytes move.