### PR TITLE
wstring converts at the boundary: astral text rides as surrogate pairs

### DIFF
--- a/fuzz.cpp
+++ b/fuzz.cpp
@@ -480,7 +480,10 @@ template <typename Stream> bool FuzzRoundTrip( Stream & stream, const uint8_t * 
                 const int length = pool.NextByte() % ( sizeof( expected ) - 1 );
                 for ( int j = 0; j < length; j++ )
                 {
-                    const uint8_t c = pool.NextByte();
+                    // masked to ASCII: the string payload is well-formed UTF-8 by the
+                    // writer's contract, debug-asserted, and asserts are live in this
+                    // harness. Arbitrary bytes still reach the READ path via FuzzRead.
+                    const uint8_t c = pool.NextByte() & 0x7F;
                     expected[j] = ( c != 0 ) ? (char) c : ' ';
                 }
                 expected[length] = '\0';
@@ -502,7 +505,16 @@ template <typename Stream> bool FuzzRoundTrip( Stream & stream, const uint8_t * 
                 wchar_t expected[8];
                 const int length = pool.NextByte() % ( sizeof( expected ) / sizeof( wchar_t ) - 1 );
                 for ( int j = 0; j < length; j++ )
-                    expected[j] = (wchar_t) ( pool.NextUint32() % 0xFFFF + 1 );                 // [1,0xFFFF]: valid for 2 and 4 byte wchar_t
+                {
+                    uint32_t unit = pool.NextUint32() % 0xFFFF + 1;                             // [1,0xFFFF]: valid for 2 and 4 byte wchar_t
+                    if ( unit >= 0xD800 && unit <= 0xDFFF )
+                    {
+                        unit -= 0x0800;     // out of the surrogate block: the payload is well-formed
+                                            // UTF-16 by the writer's contract, debug-asserted, and
+                                            // asserts are live in this harness
+                    }
+                    expected[j] = (wchar_t) unit;
+                }
                 expected[length] = L'\0';
                 wchar_t value[8];
                 if ( Stream::IsWriting )

--- a/serialize.h
+++ b/serialize.h
@@ -2664,6 +2664,74 @@ namespace serialize
             }                                                                       \
         } while (0)
 
+    /*
+        The string payload is well-formed UTF-8 BY CONTRACT (STANDARD.md, adopted
+        2026-08-15): the writer's obligation, never the reader's check. Per the
+        writes-trusted doctrine the contract is a debug-only assert — an O(n) check
+        no release path should carry — so this validator is referenced only from
+        serialize_assert and compiles out under NDEBUG. The read side is untouched:
+        there is no mandatory read-path validation.
+    */
+
+    inline bool serialize_string_is_valid_utf8( const char * string, int length )
+    {
+        int i = 0;
+        while ( i < length )
+        {
+            const uint32_t lead = (uint8_t) string[i];
+            if ( lead < 0x80 )
+            {
+                i += 1;
+            }
+            else if ( ( lead & 0xE0 ) == 0xC0 )
+            {
+                if ( lead < 0xC2 )                                                              // overlong
+                    return false;
+                if ( i + 1 >= length )
+                    return false;
+                if ( ( (uint8_t) string[i+1] & 0xC0 ) != 0x80 )
+                    return false;
+                i += 2;
+            }
+            else if ( ( lead & 0xF0 ) == 0xE0 )
+            {
+                if ( i + 2 >= length )
+                    return false;
+                const uint32_t byte1 = (uint8_t) string[i+1];
+                const uint32_t byte2 = (uint8_t) string[i+2];
+                if ( ( byte1 & 0xC0 ) != 0x80 || ( byte2 & 0xC0 ) != 0x80 )
+                    return false;
+                if ( lead == 0xE0 && byte1 < 0xA0 )                                             // overlong
+                    return false;
+                if ( lead == 0xED && byte1 >= 0xA0 )                                            // surrogate code point
+                    return false;
+                i += 3;
+            }
+            else if ( ( lead & 0xF8 ) == 0xF0 )
+            {
+                if ( lead > 0xF4 )                                                              // above U+10FFFF
+                    return false;
+                if ( i + 3 >= length )
+                    return false;
+                const uint32_t byte1 = (uint8_t) string[i+1];
+                const uint32_t byte2 = (uint8_t) string[i+2];
+                const uint32_t byte3 = (uint8_t) string[i+3];
+                if ( ( byte1 & 0xC0 ) != 0x80 || ( byte2 & 0xC0 ) != 0x80 || ( byte3 & 0xC0 ) != 0x80 )
+                    return false;
+                if ( lead == 0xF0 && byte1 < 0x90 )                                             // overlong
+                    return false;
+                if ( lead == 0xF4 && byte1 >= 0x90 )                                            // above U+10FFFF
+                    return false;
+                i += 4;
+            }
+            else
+            {
+                return false;                                                                   // continuation or invalid lead byte
+            }
+        }
+        return true;
+    }
+
     template <typename Stream> bool serialize_string_internal( Stream & stream, char * string, int buffer_size )
     {
         int length = 0;
@@ -2671,6 +2739,8 @@ namespace serialize
         {
             length = (int) strlen( string );
             serialize_assert( length < buffer_size );
+            // the writer's contract, debug only. See serialize_string_is_valid_utf8.
+            serialize_assert( serialize_string_is_valid_utf8( string, length ) );
         }
         serialize_int( stream, length, 0, buffer_size - 1 );
         serialize_bytes( stream, (uint8_t*)string, length );
@@ -2681,40 +2751,164 @@ namespace serialize
         return true;
     }
 
-    // Wire format is 32 bits per character, so streams are compatible between platforms with 2 and 4 byte wchar_t.
-    // Code points above 0xFFFF are not translated between UTF-16 and UTF-32 platforms: reading a value that doesn't
-    // fit in the local wchar_t fails rather than truncating.
+    // Counts the UTF-16 code units a wide string transmits — which on a 4 byte wchar_t
+    // platform is more than its character count when astral text is present, and is the
+    // count the wstring length field carries (STANDARD.md: each 32 bit group is one UTF-16
+    // code unit). Shared by write and measure, so both agree on cost.
+
+    inline int serialize_wstring_unit_count( const wchar_t * string )
+    {
+        int units = 0;
+        for ( int i = 0; string[i] != L'\0'; i++ )
+        {
+            const uint32_t character = (uint32_t) string[i];
+            units += ( character >= 0x10000 && character <= 0x10FFFF ) ? 2 : 1;
+        }
+        return units;
+    }
+
+    /*
+        The wstring payload is well-formed UTF-16 BY CONTRACT (STANDARD.md, adopted
+        2026-08-15): an unpaired surrogate is a writer contract violation, debug-asserted
+        per the writes-trusted doctrine. On a 4 byte wchar_t platform the string is UTF-32,
+        where a surrogate CODE POINT or a value above U+10FFFF is the malformation; on a
+        2 byte platform it is UTF-16, where the pairing itself is checked. Referenced only
+        from serialize_assert; compiles out under NDEBUG.
+    */
+
+    inline bool serialize_wstring_is_valid_utf16( const wchar_t * string )
+    {
+        // through a local rather than tested inline, so MSVC /W4 does not flag the constant conditional
+        const bool wide_wchar = sizeof( wchar_t ) >= 4;
+        int i = 0;
+        while ( string[i] != L'\0' )
+        {
+            const uint32_t character = (uint32_t) string[i];
+            if ( wide_wchar )
+            {
+                if ( character >= 0xD800 && character <= 0xDFFF )       // a surrogate is not a code point
+                    return false;
+                if ( character > 0x10FFFF )                             // above Unicode
+                    return false;
+                i += 1;
+            }
+            else
+            {
+                if ( character >= 0xD800 && character <= 0xDBFF )
+                {
+                    const uint32_t next = (uint32_t) string[i+1];
+                    if ( next < 0xDC00 || next > 0xDFFF )               // high surrogate without its pair
+                        return false;
+                    i += 2;
+                }
+                else if ( character >= 0xDC00 && character <= 0xDFFF )
+                {
+                    return false;                                       // low surrogate with no high before it
+                }
+                else
+                {
+                    i += 1;
+                }
+            }
+        }
+        return true;
+    }
+
+    // Wire format is 32 bits per group, EACH GROUP ONE UTF-16 CODE UNIT (STANDARD.md, adopted
+    // 2026-08-15), so streams are byte-identical between platforms with 2 and 4 byte wchar_t:
+    // the 4 byte platform converts at the boundary — an astral code point splits into its
+    // surrogate pair on write, and the pair recombines on read. The length field counts the
+    // units transmitted. Reading a value that doesn't fit in the local wchar_t fails rather
+    // than truncating.
 
     template <typename Stream> bool serialize_wstring_internal( Stream & stream, wchar_t * string, int buffer_size )
     {
-        const uint32_t max_wchar_value = ( sizeof( wchar_t ) >= 4 ) ? 0xFFFFFFFFU : 0xFFFFU;
         int length = 0;
         if ( Stream::IsWriting )
         {
-            length = (int) wcslen( string );
+            // the writer's contract, debug only. See serialize_wstring_is_valid_utf16.
+            serialize_assert( serialize_wstring_is_valid_utf16( string ) );
+            length = serialize_wstring_unit_count( string );
             serialize_assert( length < buffer_size );
         }
         serialize_int( stream, length, 0, buffer_size - 1 );
-        for ( int i = 0; i < length; i++ )
+        if ( Stream::IsWriting )
         {
-            uint32_t character = 0;
-            if ( Stream::IsWriting )
+            for ( int i = 0; string[i] != L'\0'; i++ )
             {
-                character = (uint32_t) string[i];
-            }
-            serialize_bits( stream, character, 32 );
-            if ( Stream::IsReading )
-            {
-                if ( character > max_wchar_value )
+                const uint32_t character = (uint32_t) string[i];
+                if ( character >= 0x10000 && character <= 0x10FFFF )
                 {
-                    return false;
+                    // an astral code point in a 4 byte wchar_t: split into its surrogate
+                    // pair at the boundary, so the bytes are the ones a 2 byte wchar_t
+                    // platform produces
+                    uint32_t high_surrogate = 0xD800 + ( ( character - 0x10000 ) >> 10 );
+                    uint32_t low_surrogate = 0xDC00 + ( ( character - 0x10000 ) & 0x3FF );
+                    serialize_bits( stream, high_surrogate, 32 );
+                    serialize_bits( stream, low_surrogate, 32 );
                 }
-                string[i] = (wchar_t) character;
+                else
+                {
+                    uint32_t unit = character;
+                    serialize_bits( stream, unit, 32 );
+                }
             }
         }
-        if ( Stream::IsReading )
+        else
         {
-            string[length] = L'\0';
+            // through a local rather than tested inline, so MSVC /W4 does not flag the constant conditional
+            const bool wide_wchar = sizeof( wchar_t ) >= 4;
+            uint32_t pending = 0;                   // a high surrogate awaiting its pair
+            bool have_pending = false;
+            int output_index = 0;
+            for ( int i = 0; i < length; i++ )
+            {
+                uint32_t character = 0;
+                serialize_bits( stream, character, 32 );
+                if ( wide_wchar )
+                {
+                    // recombine at the boundary: a surrogate pair becomes one code point,
+                    // the inverse of the split the writer performed. The payload is
+                    // well-formed by the WRITER's contract, so an unpaired surrogate is
+                    // not a mandated refusal here: it is stored as it arrived, which a
+                    // 4 byte wchar_t can always hold.
+                    if ( have_pending )
+                    {
+                        if ( character >= 0xDC00 && character <= 0xDFFF )
+                        {
+                            string[output_index++] = (wchar_t) ( 0x10000 + ( ( pending - 0xD800 ) << 10 ) + ( character - 0xDC00 ) );
+                            have_pending = false;
+                            continue;
+                        }
+                        string[output_index++] = (wchar_t) pending;
+                        have_pending = false;
+                    }
+                    if ( character >= 0xD800 && character <= 0xDBFF )
+                    {
+                        pending = character;
+                        have_pending = true;
+                        continue;
+                    }
+                    string[output_index++] = (wchar_t) character;
+                }
+                else
+                {
+                    // a 2 byte wchar_t IS a UTF-16 code unit, so units are stored as they
+                    // arrive — surrogate pairs included. Where wchar_t cannot hold what
+                    // arrived, FAIL rather than truncate: a silently mangled code point
+                    // is worse than a refused packet.
+                    if ( character > 0xFFFF )
+                    {
+                        return false;
+                    }
+                    string[output_index++] = (wchar_t) character;
+                }
+            }
+            if ( have_pending )
+            {
+                string[output_index++] = (wchar_t) pending;
+            }
+            string[output_index] = L'\0';
         }
         return true;
     }
@@ -2743,7 +2937,7 @@ namespace serialize
         Serialize a wide string to the stream (read/write/measure).
         This is a helper macro to make writing unified serialize functions easier.
         Serialize macros returns false on error so we don't need to use exceptions for error handling on read. This is an important safety measure because packet data comes from the network and may be malicious.
-        The wire format is 32 bits per character, so streams are compatible between platforms with 2 and 4 byte wchar_t. Reading a character that doesn't fit in the local wchar_t fails rather than truncating.
+        The wire format is 32 bits per group, each group one UTF-16 code unit, so streams are byte-identical between platforms with 2 and 4 byte wchar_t: on a 4 byte wchar_t platform an astral code point splits into its surrogate pair on write and recombines on read. The payload is well-formed UTF-16 by the writer's contract (debug-asserted). Reading a character that doesn't fit in the local wchar_t fails rather than truncating.
         IMPORTANT: This macro must be called inside a templated serialize function with template \<typename Stream\>. The serialize method must have a bool return value.
         @param stream The stream object. May be a read, write or measure stream.
         @param string The wide string to serialize write/measure. Pointer to buffer to be filled on read.
@@ -3508,21 +3702,36 @@ namespace serialize
         {                                                                                   \
             int length = (int) strlen( string );                                            \
             serialize_assert( length < (buffer_size) );                                     \
+            /* the writer's contract, debug only. See serialize_string_is_valid_utf8 */     \
+            serialize_assert( serialize::serialize_string_is_valid_utf8( string, length ) );\
             write_int( stream, length, 0, (buffer_size) - 1 );                              \
             write_bytes( stream, (uint8_t*) ( string ), length );                           \
         } while (0)
 
-    #define write_wstring( stream, string, buffer_size )                                    \
-        do                                                                                  \
-        {                                                                                   \
-            const wchar_t * wstring_ptr = (const wchar_t*) ( string );                      \
-            int length = (int) wcslen( wstring_ptr );                                       \
-            serialize_assert( length < (buffer_size) );                                     \
-            write_int( stream, length, 0, (buffer_size) - 1 );                              \
-            for ( int i = 0; i < length; i++ )                                              \
-            {                                                                               \
-                write_bits( stream, (uint32_t) wstring_ptr[i], 32 );                        \
-            }                                                                               \
+    #define write_wstring( stream, string, buffer_size )                                            \
+        do                                                                                          \
+        {                                                                                           \
+            const wchar_t * wstring_ptr = (const wchar_t*) ( string );                              \
+            /* the writer's contract, debug only. See serialize_wstring_is_valid_utf16 */           \
+            serialize_assert( serialize::serialize_wstring_is_valid_utf16( wstring_ptr ) );         \
+            int wstring_units = serialize::serialize_wstring_unit_count( wstring_ptr );             \
+            serialize_assert( wstring_units < (buffer_size) );                                      \
+            write_int( stream, wstring_units, 0, (buffer_size) - 1 );                               \
+            for ( int i = 0; wstring_ptr[i] != L'\0'; i++ )                                         \
+            {                                                                                       \
+                const uint32_t wstring_character = (uint32_t) wstring_ptr[i];                       \
+                if ( wstring_character >= 0x10000 && wstring_character <= 0x10FFFF )                \
+                {                                                                                   \
+                    /* astral: split into the surrogate pair at the boundary, matching */           \
+                    /* serialize_wstring_internal byte for byte */                                  \
+                    write_bits( stream, 0xD800 + ( ( wstring_character - 0x10000 ) >> 10 ), 32 );   \
+                    write_bits( stream, 0xDC00 + ( ( wstring_character - 0x10000 ) & 0x3FF ), 32 ); \
+                }                                                                                   \
+                else                                                                                \
+                {                                                                                   \
+                    write_bits( stream, wstring_character, 32 );                                    \
+                }                                                                                   \
+            }                                                                                       \
         } while (0)
 
 
@@ -4845,6 +5054,96 @@ inline void test_wstring_validation()
             serialize_check( result == false );
             serialize_check( read_back[0] != (wchar_t) ( above_bmp & 0xFFFF ) );
         }
+    }
+}
+
+inline void test_wstring_utf16_code_units()
+{
+    // wstring transmits UTF-16 CODE UNITS: an astral code point is a surrogate pair on the
+    // wire, and 2 and 4 byte wchar_t platforms produce IDENTICAL bytes — the 4 byte platform
+    // converts at the boundary, splitting on write and recombining on read (STANDARD.md,
+    // adopted 2026-08-15). The input is built per the local width, the expected bytes are the
+    // code unit stream spelled out directly with raw bit operations, and the two must agree
+    // everywhere. Mirrors the vector serialize.c pins in test/roundtrip.c.
+
+    const int BufferSize = 8;
+
+    // U+1F600 is the surrogate pair 0xD83D 0xDE00: one character but two units on a 4 byte
+    // wchar_t platform. On a 2 byte platform the string already holds the pair.
+    wchar_t ws_in[8];
+    if ( sizeof( wchar_t ) >= 4 )
+    {
+        ws_in[0] = (wchar_t) 0x0001F600;
+        ws_in[1] = (wchar_t) 0x0041;
+        ws_in[2] = L'\0';
+    }
+    else
+    {
+        ws_in[0] = (wchar_t) 0xD83DU;
+        ws_in[1] = (wchar_t) 0xDE00U;
+        ws_in[2] = (wchar_t) 0x0041;
+        ws_in[3] = L'\0';
+    }
+
+    // the wire, spelled out with raw bit operations: three units in a [0,7] length field,
+    // then each unit as a 32 bit group
+    uint8_t expected_bytes[64];
+    memset( expected_bytes, 0, sizeof( expected_bytes ) );
+    int expected_bytes_processed = 0;
+    {
+        serialize::WriteStream expectedStream( expected_bytes, sizeof( expected_bytes ) );
+        serialize_check( expectedStream.SerializeInteger( 3, 0, BufferSize - 1 ) );
+        uint32_t high_surrogate = 0xD83D;
+        uint32_t low_surrogate = 0xDE00;
+        uint32_t letter_a = 0x0041;
+        serialize_check( expectedStream.SerializeBits( high_surrogate, 32 ) );
+        serialize_check( expectedStream.SerializeBits( low_surrogate, 32 ) );
+        serialize_check( expectedStream.SerializeBits( letter_a, 32 ) );
+        expectedStream.Flush();
+        expected_bytes_processed = expectedStream.GetBytesProcessed();
+    }
+
+    // write side: the unified serialize path must produce exactly those bytes
+    int bits_written = 0;
+    uint8_t buffer[64];
+    {
+        memset( buffer, 0, sizeof( buffer ) );
+        serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+        serialize_check( serialize::serialize_wstring_internal( writeStream, ws_in, BufferSize ) );
+        writeStream.Flush();
+        serialize_check( writeStream.GetBytesProcessed() == expected_bytes_processed );
+        serialize_check( memcmp( buffer, expected_bytes, expected_bytes_processed ) == 0 );
+        bits_written = writeStream.GetBitsProcessed();
+    }
+
+    // the measure counts the units transmitted, not the characters held
+    {
+        serialize::MeasureStream measureStream;
+        serialize_check( serialize::serialize_wstring_internal( measureStream, ws_in, BufferSize ) );
+        serialize_check( measureStream.GetBitsProcessed() == bits_written );
+    }
+
+    // the write-only macro form must stay byte-identical to the unified path
+    // (STANDARD.md, "Read-only and write-only forms")
+    {
+        uint8_t macro_buffer[64];
+        memset( macro_buffer, 0, sizeof( macro_buffer ) );
+        serialize::WriteStream writeStream( macro_buffer, sizeof( macro_buffer ) );
+        const wchar_t * wstring = ws_in;
+        write_wstring( writeStream, wstring, BufferSize );
+        writeStream.Flush();
+        serialize_check( writeStream.GetBytesProcessed() == expected_bytes_processed );
+        serialize_check( memcmp( macro_buffer, expected_bytes, expected_bytes_processed ) == 0 );
+    }
+
+    // read side: the code unit stream decodes to the platform's own representation —
+    // recombined on 4 byte wchar_t, the pair itself on 2 byte
+    {
+        wchar_t read_back[BufferSize];
+        memset( read_back, 0xFF, sizeof( read_back ) );
+        serialize::ReadStream readStream( expected_bytes, expected_bytes_processed );
+        serialize_check( serialize::serialize_wstring_internal( readStream, read_back, BufferSize ) );
+        serialize_check( wcscmp( read_back, ws_in ) == 0 );
     }
 }
 
@@ -7456,6 +7755,7 @@ inline void serialize_test()
         SERIALIZE_RUN_TEST( test_serialize_int64_validation );
         SERIALIZE_RUN_TEST( test_serialize_bytes_validation );
         SERIALIZE_RUN_TEST( test_wstring_validation );
+        SERIALIZE_RUN_TEST( test_wstring_utf16_code_units );
         SERIALIZE_RUN_TEST( test_int_relative_validation );
         SERIALIZE_RUN_TEST( test_compressed_float_validation );
         SERIALIZE_RUN_TEST( test_serialize_fixed );


### PR DESCRIPTION
Closes #65. The wstring write path converts astral code points to surrogate pairs at the boundary (split/recombine ported from the C implementation), with the writer contracts landing as debug asserts. BMP wire proven unchanged via the pinned 112-byte golden.

Compose note: this branch's read loop adopts spec-batch-2's refusals — the 'unpaired surrogate stored as-arrived' leniency is superseded by ruling #8. The UTF-8 validator and fuzz-generator bodies are byte-identical across the two branches; merge resolves to one copy.