### PR TITLE
Version 1.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.8.0 LANGUAGES CXX)
+project(serialize VERSION 1.9.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -35,9 +35,9 @@
 /** @file */
 
 #define SERIALIZE_VERSION_MAJOR 1
-#define SERIALIZE_VERSION_MINOR 8
+#define SERIALIZE_VERSION_MINOR 9
 #define SERIALIZE_VERSION_PATCH 0
-#define SERIALIZE_VERSION "1.8.0"
+#define SERIALIZE_VERSION "1.9.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
Version bump for the reader-validation release: all four version sites move together (CMakeLists project VERSION and the three serialize.h macros plus the string), which the version-consistency job checks.