### PR TITLE
The read spine can demand inlining — SERIALIZE_READ_SPINE_DEMAND, default off

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -60,11 +60,20 @@
     the write spine inlines end to end and the same write rows lead instead
     (+57-92%, both optimization levels).
 
-    The read spine does not make the demand because the measurement says it does not need it:
-    every read row was already `full` in the emitted code — the branchless reader's per-field
-    operations fit the inliner's budget even at the cold threshold. This is the split
-    serialize.c records on its read spine, mirrored: demand inlining exactly where measurement
-    says the hint is not enough.
+    The read spine does not make the demand BY DEFAULT, because the original measurement said
+    the simple rows did not need it: the per-message read rows were `full` in the emitted code.
+    That claim has a named exception the remarks prove (Apple clang 21, -O3, schema bench):
+    inside a large generated reader the chain decays far enough that the read helpers strand —
+    ReadStream::SerializeInteger64 refused at cost=70 against the cold-callsite threshold 45,
+    SerializeBytes at 115 and 130, SerializeAlign at 80 — five per-op calls left in that
+    bench's read path while every write row inlines end to end. SERIALIZE_READ_SPINE_DEMAND
+    (below) arms the same demand on the read spine — BitReader::ReadBits/ReadAlign and
+    ReadStream's six per-field methods, the exact mirror of the write set — as a compile-time
+    switch, OFF by default: undefined, the spelling expands to nothing and the header is
+    token-identical to the undemanded form. It stays off until a bench-standard timing pass
+    validates it; arm it with -DSERIALIZE_READ_SPINE_DEMAND to build the candidate. This is
+    the split serialize.c records on its read spine, mirrored as a switch: demand inlining
+    exactly where measurement says the hint is not enough, and measure before defaulting.
 
     The sibling ports' other lever — pinning the error edges cold (serialize.rs's #[cold]
     constructor) — was tried here as __builtin_expect on the macros' error branches, measured,
@@ -82,6 +91,25 @@
 #else // #if defined( _MSC_VER )
 #define SERIALIZE_ALWAYS_INLINE inline
 #endif // #if defined( _MSC_VER )
+
+/*
+    SERIALIZE_READ_SPINE_DEMAND — the read-spine inlining demand, OFF by default.
+
+    Undefined (the default), SERIALIZE_READ_INLINE expands to nothing and the read spine is
+    spelled exactly as it always was. Defined, the read spine — BitReader::ReadBits and
+    ReadAlign, plus ReadStream's SerializeInteger/Integer64/Integer128/Bits/Bytes/Align, the
+    mirror of the demanded write set — demands inlining the same way the write spine does.
+    See the rationale above for the remark evidence this switch answers to. The compressed
+    float and string bodies stay undemanded either way, deliberately: their cost is the work,
+    not the call (the same boundary serialize.c draws). No branch-weight hints ride with the
+    demand — cold hints are measured in this library to activate the machine outliner
+    (bits write -25%); the demand is a demand.
+*/
+#if defined( SERIALIZE_READ_SPINE_DEMAND )
+#define SERIALIZE_READ_INLINE SERIALIZE_ALWAYS_INLINE
+#else // #if defined( SERIALIZE_READ_SPINE_DEMAND )
+#define SERIALIZE_READ_INLINE
+#endif // #if defined( SERIALIZE_READ_SPINE_DEMAND )
 
 #ifndef serialize_assert
 #include <assert.h>
@@ -1402,7 +1430,7 @@ namespace serialize
             @see BitWriter::WriteBits
          */
 
-        uint32_t ReadBits( int bits )
+        SERIALIZE_READ_INLINE uint32_t ReadBits( int bits )
         {
             serialize_assert( m_data );                 // if this fires, the reader was used before Initialize
             serialize_assert( bits > 0 );
@@ -1430,7 +1458,7 @@ namespace serialize
             @see BitWriter::WriteAlign
          */
 
-        bool ReadAlign()
+        SERIALIZE_READ_INLINE bool ReadAlign()
         {
             const int remainderBits = m_bitsRead % 8;
             if ( remainderBits != 0 )
@@ -1837,7 +1865,7 @@ namespace serialize
             @returns Returns true if the serialize succeeded and the value is in the correct range. False otherwise.
          */
 
-        bool SerializeInteger( int32_t & value, int32_t min, int32_t max )
+        SERIALIZE_READ_INLINE bool SerializeInteger( int32_t & value, int32_t min, int32_t max )
         {
             serialize_assert( min <= max );
             const int bits = bits_required( min, max );
@@ -1864,7 +1892,7 @@ namespace serialize
             @returns Returns true if the serialize succeeded and the value is in the correct range. False otherwise.
          */
 
-        bool SerializeInteger64( int64_t & value, int64_t min, int64_t max )
+        SERIALIZE_READ_INLINE bool SerializeInteger64( int64_t & value, int64_t min, int64_t max )
         {
             serialize_assert( min <= max );
             const int bits = bits_required64( uint64_t(min), uint64_t(max) );
@@ -1902,7 +1930,7 @@ namespace serialize
             @returns Returns true if the serialize succeeded and the value is in the correct range. False otherwise.
          */
 
-        bool SerializeInteger128( int128_t & value, int128_t min, int128_t max )
+        SERIALIZE_READ_INLINE bool SerializeInteger128( int128_t & value, int128_t min, int128_t max )
         {
             serialize_assert( min <= max );
             const int bits = bits_required128( uint128_t(min), uint128_t(max) );
@@ -1950,7 +1978,7 @@ namespace serialize
             @returns Returns true if the serialize read succeeded, false otherwise.
          */
 
-        bool SerializeBits( uint32_t & value, int bits )
+        SERIALIZE_READ_INLINE bool SerializeBits( uint32_t & value, int bits )
         {
             serialize_assert( bits > 0 );
             serialize_assert( bits <= 32 );
@@ -1968,7 +1996,7 @@ namespace serialize
             @returns Returns true if the serialize read succeeded. False otherwise.
          */
 
-        bool SerializeBytes( uint8_t * data, int64_t bytes )
+        SERIALIZE_READ_INLINE bool SerializeBytes( uint8_t * data, int64_t bytes )
         {
             if ( bytes < 0 )
                 return false;
@@ -1986,7 +2014,7 @@ namespace serialize
             @returns Returns true if the serialize read succeeded. False otherwise.
          */
 
-        bool SerializeAlign()
+        SERIALIZE_READ_INLINE bool SerializeAlign()
         {
             const int alignBits = m_reader.GetAlignBits();
             if ( m_reader.WouldReadPastEnd( alignBits ) )


### PR DESCRIPTION
## What

A compile-time switch, **OFF by default**, arming the write spine's inlining demand on the read spine: `SERIALIZE_READ_INLINE` expands to nothing unless the consumer defines `SERIALIZE_READ_SPINE_DEMAND`, in which case `BitReader::ReadBits`/`ReadAlign` and `ReadStream::SerializeInteger / SerializeInteger64 / SerializeInteger128 / SerializeBits / SerializeBytes / SerializeAlign` — the exact mirror of the demanded write set — are spelled `SERIALIZE_ALWAYS_INLINE`. The compressed-float and string bodies stay undemanded either way, deliberately: their cost is the work, not the call (the same boundary serialize.c draws). `__restrict` qualifiers untouched; no branch-weight hints (cold hints are measured in this library to activate the machine outliner — bits write −25%).

## Why (remark evidence, compile-only — NO timing claims in this PR)

The write-spine rationale in this header says the read spine does not need the demand because "every read row was already `full`". The remarks name the exception (Apple clang 21, `-O3`, schema bench, recorded flags): inside a large generated reader the fallible chain decays far enough that the read helpers strand at the cold-callsite threshold —

```
ReadStream::SerializeInteger64  not inlined (cost=70,  threshold=45)
ReadStream::SerializeBytes      not inlined (cost=115, threshold=45)
ReadStream::SerializeBytes      not inlined (cost=130, threshold=45)
ReadStream::SerializeAlign      not inlined (cost=80,  threshold=45)
```

— five per-op calls left in that bench's read path (its `.inline` row publishes `partial:5`) while every write row inlines end to end, plus the same `SerializeBytes` strand in the rt `bench_packet` read body. Same disease the write spine already treats, landing later in the chain. The header comment is amended to name this falsifying exception instead of the outdated blanket claim.

## Verification

- **OFF (default): byte-identical.** The schema bench C++ leg built against this branch disassembles identically (`otool -tv`) to one built against main.
- **ON:** all four demandable strands report `inlined (cost=always)`; the rt `bench_packet` read strand clears; the one remaining read-side refusal in the whole leg is `serialize_compressed_float_internal<ReadStream>` — the recorded doctrine residual.
- **ON:** zero `OUTLINED_FUNCTION_*` symbols — the machine outliner did not activate.
- Test suite (`test.cpp` with `SERIALIZE_ENABLE_TESTS`): ALL TESTS PASS, armed and unarmed.

## What this PR is NOT

Not a performance claim — nothing here was timed, deliberately. The switch stays OFF until a quiet-window A/B pass under schema's `bench/BENCH-STANDARD.md` validates it; the staged timing protocol lives with the Phase-4 analysis. Draft until then; do not merge before the pass runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
