### PR TITLE
serialize 1.10.0: both version sites carry the new number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.9.0 LANGUAGES CXX)
+project(serialize VERSION 1.10.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -35,9 +35,9 @@
 /** @file */
 
 #define SERIALIZE_VERSION_MAJOR 1
-#define SERIALIZE_VERSION_MINOR 9
+#define SERIALIZE_VERSION_MINOR 10
 #define SERIALIZE_VERSION_PATCH 0
-#define SERIALIZE_VERSION "1.9.0"
+#define SERIALIZE_VERSION "1.10.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
Version bump for the 1.10.0 release: serialize.h (SERIALIZE_VERSION and its parts) and CMakeLists.txt move from 1.9.0 to 1.10.0. No behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)