### PR TITLE
1.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.10.0 LANGUAGES CXX)
+project(serialize VERSION 1.11.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -35,9 +35,9 @@
 /** @file */
 
 #define SERIALIZE_VERSION_MAJOR 1
-#define SERIALIZE_VERSION_MINOR 10
+#define SERIALIZE_VERSION_MINOR 11
 #define SERIALIZE_VERSION_PATCH 0
-#define SERIALIZE_VERSION "1.10.0"
+#define SERIALIZE_VERSION "1.11.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
Version bump for the release carrying #83, the additive precomputed compressed-float entry points (tracking mas-bandwidth/schema#82). No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)