### PR TITLE
The rounding rule is tested now: two shapes where ceil and round disagree

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -4322,6 +4322,7 @@ inline void SerializeCheckHandler( const char * condition,
                                    int line )
 {
     printf( "check failed: ( %s ), function %s, file %s, line %d\n", condition, function, file, line );
+    fflush( stdout );       // the trap below skips atexit, so a buffered stdout (any pipe: CI) would lose the line above
 #ifndef NDEBUG
     #if defined( __GNUC__ )
         __builtin_trap();
@@ -8544,6 +8545,11 @@ static const CompressedFloatShape compressed_float_shapes[] =
     { 0.0f,       15.0f,          1.0f,       15,          4  },       // step count exactly fills the wire width: no headroom to refuse
     { 0.0f,       1000000.0f,     1.0f,       1000000,     20 },       // a million steps
     { 0.0f,       10000000000.0f, 1.0f,       4294967040u, 32 },       // values clamps down to the largest float below 2^32
+    // shapes that discriminate the rounding rule itself: a fractional step count BELOW the half step,
+    // where ceil and round disagree. Every row above lands on an integer or within half a step of one,
+    // so all of them derive the same constants under either rule -- the corpus could not see a swap.
+    { 0.0f,       10.0f,          0.3f,       34,          6  },       // 33.333332 steps: ceil 34, round 33 -- same width, different step count
+    { 0.0f,       63.3f,          1.0f,       64,          7  },       // 63.3 steps: ceil 64 (7 bits), round 63 (6 bits) -- straddles a power of two, so the WIRE WIDTH moves
 };
 
 inline void test_compressed_float_precomputed_differential()


### PR DESCRIPTION
`max_integer_value = ceil( (max - min) / res )` was untested in this repo. Swapping `ceil` for `round` in **both** derivations — the live one at serialize.h:2497 and the frozen pre-split copy at 8352 — leaves the entire suite green.

The differential is not at fault; the declaration corpus is. Every shape in `compressed_float_shapes` has a step count landing exactly on an integer, with one exception — `(-1, 1)` at `0.001`, 1999.9999 steps — and that one is within half a step, so the two rules agree on it too. With no shape where they disagree, the frozen reference and the split composition derive the same constants under either rule, and the pinned table matches both.

It matters more than a tidiness point: `max_integer_value` feeds `bits_required`, so a wrong rounding rule changes the **wire width** of every value of a field, not merely shifts it by one quantum.

## The fix

Two rows in the derivation-edges section. Only fractional counts *below* the half step can discriminate, since above it the two rules agree again:

| shape | steps | `ceil` | `round` |
| --- | --- | --- | --- |
| `(0.0, 10.0, 0.3)` | 33.333332 | **34** (6 bits) | 33 (6 bits) |
| `(0.0, 63.3, 1.0)` | 63.3 | **64** (7 bits) | 63 (**6 bits**) |

The second straddles a power of two, so it pins the wire width as well as the step count.

3,758,427 checks (debug) / 3,760,127 (release) over 20 declarations, up from 18. The `round()` perturbation now fails on shape 19 where before it passed.

## And one separable fix, because it is what made the falsification unreadable

`SerializeCheckHandler` prints and then calls `__builtin_trap()`, which skips `atexit` — so with a fully buffered stdout, which is every CI run and every redirect, a failing check prints **nothing**. The trap's exit code is all you get. One `fflush( stdout )` before the trap. Measured on the perturbation above: silent before, and after it prints

```
check failed: ( max_integer_value == compressed_float_shapes[s].expected_max_integer_value ), function test_compressed_float_precomputed_differential, file serialize.h, line 8577
```

Drop that hunk if you would rather it went on its own.

## Green

Debug, Release, asan+ubsan, `ctest`, `tools/conformance` (89 checks against STANDARD.md), and `example`, on arm64.

**The other four legs have the same gap** — C, C#, Go and Rust mirror this shape list. Rust closed it in serialize.rs#49; C, C# and Go have not, and it is two rows each with no library change.

Refs #82 (mas-bandwidth/schema).