### PR TITLE
serialize 1.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.11.0 LANGUAGES CXX)
+project(serialize VERSION 1.12.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -35,9 +35,9 @@
 /** @file */
 
 #define SERIALIZE_VERSION_MAJOR 1
-#define SERIALIZE_VERSION_MINOR 11
+#define SERIALIZE_VERSION_MINOR 12
 #define SERIALIZE_VERSION_PATCH 0
-#define SERIALIZE_VERSION "1.11.0"
+#define SERIALIZE_VERSION "1.12.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
`main` has carried the compressed float's normative integer clamp since #88 and the version still said 1.11.0, so the release check has been correctly red: nothing announced that a release was owed.

Minor rather than patch, because STANDARD.md gained a normative requirement and the encoding moves for declarations in `[2^23, 2^24)`. The witnesses the standard pins are `[0, 8388609]` and `[0, 16777215]`, both at resolution 1.

Both version sites move together, which is what the version-consistency job checks. The tag follows once this is green.
