### PR TITLE
serialize 1.13.0: expected skips are silent — test names and failures only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.12.0 LANGUAGES CXX)
+project(serialize VERSION 1.13.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -35,9 +35,9 @@
 /** @file */
 
 #define SERIALIZE_VERSION_MAJOR 1
-#define SERIALIZE_VERSION_MINOR 12
+#define SERIALIZE_VERSION_MINOR 13
 #define SERIALIZE_VERSION_PATCH 0
-#define SERIALIZE_VERSION "1.12.0"
+#define SERIALIZE_VERSION "1.13.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict
@@ -5704,7 +5704,8 @@ inline void test_compressed_float_non_finite_asserts()
     serialize_check( serialize_test_assert_fires( serialize_test_write_non_finite_declaration ) == true );
     serialize_check( serialize_test_assert_fires( serialize_test_write_non_finite_value ) == true );
 #else
-    printf( "(skipped test_compressed_float_non_finite_asserts: needs an assert-enabled build and fork)\n" );
+    // silently skipped: needs an assert-enabled build and fork. An expected
+    // skip is not information — the suite prints test names and failures only.
 #endif // #if !defined( NDEBUG ) && !defined( _WIN32 )
 }
 
@@ -5719,7 +5720,8 @@ inline void test_compressed_float_precomputed_asserts()
     serialize_check( serialize_test_assert_fires( serialize_test_write_non_finite_value_precomputed ) == true );
     serialize_check( serialize_test_assert_fires( serialize_test_precomputed_inconsistent_bits ) == true );
 #else
-    printf( "(skipped test_compressed_float_precomputed_asserts: needs an assert-enabled build and fork)\n" );
+    // silently skipped: needs an assert-enabled build and fork. An expected
+    // skip is not information — the suite prints test names and failures only.
 #endif // #if !defined( NDEBUG ) && !defined( _WIN32 )
 }
 


### PR DESCRIPTION
The two assert-contract tests (`test_compressed_float_non_finite_asserts`, `test_compressed_float_precomputed_asserts`) printed a `(skipped ...)` parenthetical in builds without assert-and-fork support (NDEBUG, Windows). An expected skip is not information: the branch is now a comment, and the suite prints test names and failures only. `test_large_buffer`'s allocation-failure note stays — a failed allocation is something going wrong, not an expected skip.

Both version sites carry 1.13.0 (serialize.h macros, CMake project version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)