### PR TITLE
serialize 1.15.0: both version sites carry the new number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(serialize VERSION 1.14.0 LANGUAGES CXX)
+project(serialize VERSION 1.15.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/serialize.h
+++ b/serialize.h
@@ -35,9 +35,9 @@
 /** @file */
 
 #define SERIALIZE_VERSION_MAJOR 1
-#define SERIALIZE_VERSION_MINOR 14
+#define SERIALIZE_VERSION_MINOR 15
 #define SERIALIZE_VERSION_PATCH 0
-#define SERIALIZE_VERSION "1.14.0"
+#define SERIALIZE_VERSION "1.15.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
The wire-affecting change aboard main past v1.14.0 is #99: the compressed_float roundings pinned in-source by SERIALIZE_FLOAT_FORCE_ROUND, wire bits identical under every -ffp-contract setting (#92/#95). Bytes unchanged on every conformant build (the cross-mode sweep in #99 is the proof), but the library section changed and the unreleased-wire gate is announcing the owed release — this bump is the announcement's other half, turning the gate's error into its tag-pending warning. Tagging v1.15.0 stays a deliberate release action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)