### PR TITLE
A no-op build prints nothing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,16 @@
 cmake_minimum_required(VERSION 3.16)
 
+# A no-op build prints nothing (rowan-new#110). The per-target "Built target" lines are
+# the only output a rebuild with nothing to do produces, and they carry no information; a
+# real build still prints its [ x%] progress lines, and errors are untouched. This sits
+# above project() because CMAKE_TARGET_MESSAGES initializes the TARGET_MESSAGES global
+# property there and has no effect if set after it, and under the same top-level test as
+# SERIALIZE_TOP_LEVEL below, so a consumer that pulls this library in through FetchContent
+# keeps its own messages.
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(CMAKE_TARGET_MESSAGES OFF)
+endif()
+
 project(serialize VERSION 1.15.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
One line does it:

    set(CMAKE_TARGET_MESSAGES OFF)

It sits above project(), under the same top-level test that SERIALIZE_TOP_LEVEL
uses below, so it applies only when this repo is the top level project and a
consumer that pulls the library in through FetchContent or add_subdirectory keeps
its own "Built target" messages. Above project() because CMAKE_TARGET_MESSAGES
initializes the TARGET_MESSAGES global property there and has no effect if set
after it.

Before / after, on a tree with nothing to do:

    $ cmake --build build | wc -l
    4   # before
    0   # after

A real build is unchanged: touching test.cpp still prints its [ x%] progress
lines. Errors are untouched: a deliberate syntax error in test.cpp still fails
with rc=2 and the compiler diagnostic (verified, then reverted).

Tests: ctest --test-dir build -> 100% tests passed out of 3

Same change as netcode#182, yojimbo#338 and reliable#57. Refs mas-bandwidth/rowan-new#110.
