### PR TITLE
The C reader takes the slack contract, like C++

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -651,15 +651,18 @@ it is interpretable.
 **Past-end memory is an implementation contract, not a format concern.** The
 stream is exactly its stated length, and no operation's meaning ever depends
 on memory beyond it. An implementation may still *load* — never interpret —
-bytes past the end as an artifact of how it reads: the C++ implementation
-loads 64-bit windows at byte granularity and therefore requires its caller to
-allocate at least 8 bytes beyond the data; the C implementation prices its
-window to stay inside the buffer and imposes no such requirement. Both are
-conforming. Conformance requires that loaded-but-uninterpreted bytes can never
-influence a decoded value or an accept/reject decision, and that an
-implementation state which allocation contract its caller is under — a caller
-holding the wrong contract is reading out of bounds, and that is a property of
-the implementation's documentation, not of the wire.
+bytes past the end as an artifact of how it reads: the C++ and C
+implementations both load 64-bit windows at byte granularity and therefore
+require their caller to allocate at least 8 bytes beyond the data. That is
+the accepted best practice, and Implementation Law's buffer contract holds
+implementations to it: machinery that avoids the slack requirement at the
+cost of per-operation work in the hot path is a slower correct option, and is
+refused by the speed rule. The format turns on none of this. Conformance
+requires that loaded-but-uninterpreted bytes can never influence a decoded
+value or an accept/reject decision, and that an implementation state which
+allocation contract its caller is under — a caller holding the wrong contract
+is reading out of bounds, and that is a property of the implementation's
+documentation, not of the wire.
 
 **Trailing bits: writers must write zero; readers must not look; tools may
 judge.** *(Adopted 2026-08-15; the ruling verbatim: "Yes, I am OK with


### PR DESCRIPTION
The "Past-end memory" paragraph in Reader Obligations describes the C implementation's read path wrongly.

It says the C implementation "prices its window to stay inside the buffer and imposes no such requirement". It does not. `serialize_read_bits` in serialize.c does one unconditional window load from the current byte position:

```c
SERIALIZE_WORD_COPY( &window, stream->data + ( begin >> 3 ) );
```

There is no narrowing near the end of the buffer, so the final window of a stream reaches past the data, exactly as C++ does. serialize.c's header and README have documented the resulting caller allocation contract, at least 8 bytes past the data, all along.

The sentence also contradicted Implementation Law on this same page, which names reading whole words through the end of the buffer the accepted best practice and refuses the in-bounds alternative under the speed rule. So the paragraph described a strategy the law on the page rejects, and attributed it to a port that does not use it.

It also called both strategies conforming without qualification, which Implementation Law on this same page does not: the buffer contract there names whole-word reads through the end accepted best practice and refuses the in-bounds alternative under the speed rule. Two paragraphs, opposite verdicts. Implementation Law is the authority, so Reader Obligations now defers to it in one clause rather than ruling against it.

## Also checked

The C++ `README.md` slack lines (Limitations) already state the same contract and needed no change:

> Read buffer sizes may be any number of bytes, but the underlying allocation must extend at least 8 bytes past the end of the packet data, because the bit reader loads 64 bit windows at byte granularity. The bytes past the end are loaded but never interpreted.

## Ports

The ports vendor `STANDARD.md` verbatim and their CI diffs the copy against this repo's `main`, so they pick this up on their next sync. A sync PR per port clears it.

The matching C-side work is mas-bandwidth/serialize.c#59, which corrects that repo's `SECURITY.md`, adds `serialize_read_stream_init_padded` for callers holding an exactly sized payload, and carries this exact text into serialize.c's own vendored copy. That leaves serialize.c#59 with one deliberately red `STANDARD.md matches upstream` job, against the old text still on this repo's `main`; it clears itself when this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
