### PR TITLE
BUILDING.md: the Homebrew install line as published

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,15 +21,15 @@ Or run the binaries directly:
 
 On Windows the binaries are under `build\bin\Release`, and you can open the generated `build\serialize.sln` in Visual Studio if you prefer to work there.
 
-## Installing with Homebrew (macOS)
+## Installing with Homebrew
+
+serialize is in `homebrew/core`, so no tap is needed:
 
 ```
-brew tap mas-bandwidth/tap
-brew trust mas-bandwidth/tap      # one time, Homebrew 6 and newer
 brew install serialize
 ```
 
-This installs `serialize.h` and the CMake package config, so both `#include <serialize.h>` and `find_package(serialize CONFIG)` work out of the box.
+The published formula is at version 1.16.0. It installs `serialize.h` and the CMake package config, so both `#include <serialize.h>` and `find_package(serialize CONFIG)` work out of the box.
 
 ## Using serialize in your project
 
@@ -38,7 +38,7 @@ serialize is a single header. The simplest thing is to copy `serialize.h` into y
 If you use CMake, you can consume it as a target instead — via FetchContent:
 
     include(FetchContent)
-    FetchContent_Declare(serialize GIT_REPOSITORY https://github.com/mas-bandwidth/serialize.git GIT_TAG v1.15.0)
+    FetchContent_Declare(serialize GIT_REPOSITORY https://github.com/mas-bandwidth/serialize.git GIT_TAG v1.16.0)
     FetchContent_MakeAvailable(serialize)
     target_link_libraries(your_target PRIVATE serialize::serialize)
 


### PR DESCRIPTION
Docs only. Part of a family-wide pass making every distribution claim honest against the registries.

**The claim found.** `BUILDING.md` told readers to install with:

```
brew tap mas-bandwidth/tap
brew trust mas-bandwidth/tap      # one time, Homebrew 6 and newer
brew install serialize
```

**The registry fact.** `serialize` is in `homebrew/core` — `formulae.brew.sh/api/formula/serialize.json` returns it at stable **1.16.0**, homepage `github.com/mas-bandwidth/serialize`, bottle tag `all`. `mas-bandwidth/homebrew-tap` holds only `Formula/schema.rb`, and its `tap_migrations.json` is `{"serialize": "homebrew/core"}`. So the tap lines pointed at a repo that does not carry this formula.

**Changed.**

- The Homebrew section drops the tap and trust lines and states the published formula version: `brew install serialize`, formula at 1.16.0. The heading loses "(macOS)" — the bottle is `all`, so Homebrew on Linux gets it too.
- The `FetchContent` example pinned `GIT_TAG v1.15.0`; the current release is `v1.16.0`.

No version bumps, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)