### PR TITLE
serialize 1.16.1: the write side assertions see the caller's value, and the family matrix becomes a gate

### DIFF
--- a/.github/workflows/family-matrix.yml
+++ b/.github/workflows/family-matrix.yml
@@ -1,0 +1,217 @@
+name: Family Matrix
+
+# The compatibility matrix is a gate, not a page. COMPATIBILITY.txt claims that nine
+# releases carry format version 1.1 and vendor one pinned commit of this repository's
+# standard and corpus. This job proves every row of that claim against the actual
+# repositories, rather than against the claim itself.
+#
+# Nightly as well as on push, because a row can go wrong with nothing landing here: a port
+# can move a release tag, retag, or amend a vendored file after the fact. A gate that runs
+# only when this repository changes cannot see any of that.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  schedule:
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  family-matrix:
+    name: family matrix
+    runs-on: ubuntu-24.04
+    steps:
+      # pinned by commit, not by tag: this job's whole subject is the difference between a
+      # pin and a moving target, and a workflow that pins its own actions by tag is not in
+      # a position to make that argument
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7
+        with:
+          fetch-depth: 0        # the pinned commit is read out of this repository's history
+
+      - name: Prove every row
+        run: |
+          set -u
+
+          fail=0
+          rows=0
+          : > /tmp/summary.md
+
+          note() {
+            echo "$1"
+            printf '%s\n' "$1" >> /tmp/summary.md
+          }
+
+          bad() {
+            echo "::error::$1"
+            printf 'FAILED: %s\n' "$1" >> /tmp/summary.md
+            fail=1
+          }
+
+          # the value of key $2 in the COMPATIBILITY.txt record that starts at line $1
+          field() {
+            awk -v start="$1" -v key="$2" '
+              NR < start { next }
+              /^[[:space:]]*$/ { if ( seen ) exit; next }
+              /^#/ { next }
+              {
+                seen = 1
+                if ( $1 == key )
+                {
+                  line = $0
+                  sub( /^[^[:space:]]+[[:space:]]+/, "", line )
+                  print line
+                  exit
+                }
+              }
+            ' COMPATIBILITY.txt
+          }
+
+          # ---------------------------------------------------------------------------
+          # the pins
+          # ---------------------------------------------------------------------------
+
+          format_version=$(sed -nE 's/^format_version[[:space:]]+(.+)$/\1/p' COMPATIBILITY.txt)
+          standard_commit=$(sed -nE 's/^standard_commit[[:space:]]+([0-9a-f]{40})$/\1/p' COMPATIBILITY.txt)
+          corpus_commit=$(sed -nE 's/^corpus_commit[[:space:]]+([0-9a-f]{40})$/\1/p' COMPATIBILITY.txt)
+
+          if [ -z "$format_version" ] || [ -z "$standard_commit" ] || [ -z "$corpus_commit" ]; then
+            echo "::error::COMPATIBILITY.txt is missing format_version, standard_commit or corpus_commit. Both pins must be a full 40 character sha: an abbreviation is not a pin."
+            exit 1
+          fi
+          note "format version $format_version"
+          note "standard pinned at $standard_commit"
+          note "corpus pinned at $corpus_commit"
+
+          if ! grep -Fq "**The format version is ${format_version}.**" STANDARD.md; then
+            bad "STANDARD.md does not state format version ${format_version}, which COMPATIBILITY.txt claims"
+          fi
+          if ! grep -Fq "Format version ${format_version}" COMPATIBILITY.md; then
+            bad "COMPATIBILITY.md does not state format version ${format_version}"
+          fi
+          for pin in "$standard_commit" "$corpus_commit"; do
+            if ! grep -Fq "$pin" COMPATIBILITY.md; then
+              bad "COMPATIBILITY.md does not carry the pinned commit $pin"
+            fi
+          done
+
+          rm -rf /tmp/pinned && mkdir -p /tmp/pinned
+          git cat-file -e "${standard_commit}^{commit}" 2>/dev/null || git fetch --quiet origin "$standard_commit" 2>/dev/null || true
+          git cat-file -e "${corpus_commit}^{commit}" 2>/dev/null || git fetch --quiet origin "$corpus_commit" 2>/dev/null || true
+          if ! git show "${standard_commit}:STANDARD.md" > /tmp/pinned/STANDARD.md 2>/dev/null; then
+            echo "::error::the pinned standard commit $standard_commit is not in this repository"
+            exit 1
+          fi
+          if ! git archive "$corpus_commit" conformance > /tmp/corpus.tar 2>/dev/null; then
+            echo "::error::the pinned corpus commit $corpus_commit is not in this repository"
+            exit 1
+          fi
+          tar -x -C /tmp/pinned -f /tmp/corpus.tar
+          note "pinned corpus: $(ls /tmp/pinned/conformance | tr '\n' ' ')"
+
+          # ---------------------------------------------------------------------------
+          # the rows
+          # ---------------------------------------------------------------------------
+
+          for start in $(grep -n '^runtime ' COMPATIBILITY.txt | cut -d: -f1); do
+            rows=$(( rows + 1 ))
+            runtime=$(field "$start" runtime)
+            language=$(field "$start" language)
+            repository=$(field "$start" repository)
+            release=$(field "$start" release)
+            version_file=$(field "$start" version_file)
+            version_pattern=$(field "$start" version_pattern)
+
+            note ""
+            note "### $runtime ($language) $release"
+
+            if [ -z "$runtime" ] || [ -z "$language" ] || [ -z "$repository" ] || [ -z "$release" ] || [ -z "$version_file" ] || [ -z "$version_pattern" ]; then
+              bad "$runtime: the row is missing a field. runtime, language, repository, release, version_file and version_pattern are all required, and the two version fields are - where the release carries no version file."
+              continue
+            fi
+
+            version="${release#v}"
+
+            # the page must carry the same row, or the page and the gate are two matrices
+            needle=$(printf '`%s`' "$release")
+            if ! grep -F "$runtime" COMPATIBILITY.md | grep -Fq "$needle"; then
+              bad "$runtime: COMPATIBILITY.md does not list $runtime at $release"
+            fi
+
+            # the pattern that proves the version must itself contain the release's version,
+            # or a row could pin a pattern that matches whatever the file happens to say
+            if [ "$version_file" = "-" ]; then
+              note "no version file: the release tag is the version"
+            elif ! printf '%s' "$version_pattern" | grep -Fq "$version"; then
+              bad "$runtime: version_pattern does not contain $version, so it cannot prove the release's version"
+              continue
+            fi
+
+            if [ "$repository" = "$GITHUB_REPOSITORY" ]; then
+              # this repository: checked against the working checkout rather than against the
+              # tag, because the release this row names is cut FROM the checkout, so a tag
+              # check would fail for every commit between the version bump and the release
+              checkout="."
+              note "checked against this checkout, which is where the release is cut from"
+            else
+              checkout="/tmp/family/$runtime"
+              rm -rf "$checkout"
+              if ! git clone --quiet --depth 1 --branch "$release" "https://github.com/${repository}.git" "$checkout"; then
+                bad "$runtime: could not clone $repository at $release"
+                continue
+              fi
+            fi
+
+            if [ "$version_file" != "-" ]; then
+              if [ ! -f "$checkout/$version_file" ]; then
+                bad "$runtime: $version_file does not exist at $release"
+              elif ! grep -Fq "$version_pattern" "$checkout/$version_file"; then
+                bad "$runtime: $version_file at $release does not carry '$version_pattern'. The release and its version file disagree."
+              else
+                note "$version_file carries $version"
+              fi
+            fi
+
+            # the standard and the corpus live in this repository, so this repository has
+            # nothing vendored to diff against the pin
+            if [ "$repository" = "$GITHUB_REPOSITORY" ]; then
+              continue
+            fi
+
+            if diff -u /tmp/pinned/STANDARD.md "$checkout/STANDARD.md" > /tmp/std.diff 2>&1; then
+              note "vendored STANDARD.md matches the pin"
+            else
+              bad "$runtime: the STANDARD.md vendored at $release differs from the pinned commit"
+              head -40 /tmp/std.diff
+            fi
+
+            if diff -ru /tmp/pinned/conformance "$checkout/conformance" > /tmp/corpus.diff 2>&1; then
+              note "vendored conformance/ matches the pin ($(ls "$checkout/conformance" | wc -l | tr -d ' ') files)"
+            else
+              bad "$runtime: the conformance corpus vendored at $release differs from the pinned commit"
+              head -40 /tmp/corpus.diff
+            fi
+          done
+
+          if [ "$rows" -eq 0 ]; then
+            echo "::error::COMPATIBILITY.txt holds no runtime rows. An empty matrix is a broken file, not a pass."
+            exit 1
+          fi
+
+          {
+            echo "## Family matrix"
+            echo ""
+            echo "$rows row(s) checked against format version $format_version."
+            echo ""
+            cat /tmp/summary.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::the compatibility matrix does not hold. Every failing row is annotated above."
+            exit 1
+          fi
+
+          echo "every row holds."

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -44,7 +44,7 @@ If you use CMake, you can consume it as a target instead — via FetchContent:
 
 or via `add_subdirectory`, or install it (`cmake --install build`) and use `find_package(serialize CONFIG REQUIRED)`. In all cases the `serialize::serialize` target carries only the include path: none of this repo's warning or fast-math flags leak into your build, and the test and example targets are only built when serialize is the top level project.
 
-Pin a release tag, as in the FetchContent lines above. Both endpoints of a connection must run releases carrying the same format version, which is stated at the head of [STANDARD.md](STANDARD.md) and is not the library version. A floating branch moves one endpoint on its own schedule, which is how two endpoints end up on different format versions.
+`GIT_TAG` names a release, never a branch. A release carries a stated format version, and both endpoints of a connection must run releases carrying the same format version or they do not interoperate. The format version is stated at the head of [STANDARD.md](STANDARD.md) and is not the library version; [COMPATIBILITY.md](COMPATIBILITY.md) lists the release of every implementation in the family that carries the current one. A floating branch moves one endpoint on its own schedule, which is how two endpoints end up on different format versions.
 
 The library version is available as `SERIALIZE_VERSION` (and `SERIALIZE_VERSION_MAJOR/MINOR/PATCH`) after including the header.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,12 +146,18 @@ performance work here must not relearn:
 - The version lives in two files and a CI job compares them: `project(serialize VERSION ...)`
   in CMakeLists.txt and `SERIALIZE_VERSION` plus its MAJOR/MINOR/PATCH triple in serialize.h.
   Bump both together.
-- The shared conformance corpus is `conformance/`, one file per operation, and
+- The shared conformance corpus is `conformance/`, one file per covered operation, and
   [conformance.cpp](conformance.cpp) runs every vector in it through this library's reader as the
-  ctest target `conformance` (the vector files are globbed at cmake configure time and passed on
-  the command line — a directory walk is not portable across the matrix). It is deliberately not
-  generated from this code: a suite that regenerates its own expectations proves only that the
-  library agrees with itself.
+  ctest target `conformance`. The runner discovers the directory rather than naming files, which
+  STANDARD.md requires of every runner in the family: here the glob is at cmake configure time,
+  with CONFIGURE_DEPENDS so an added or removed file re-runs it, and an empty directory is a
+  configure error. It is deliberately not generated from this code: a suite that regenerates its
+  own expectations proves only that the library agrees with itself.
+- The write side debug assertions are tested by [asserts.cpp](asserts.cpp), the ctest target
+  `asserts`. It defines `serialize_assert` itself, so an assertion firing is an observable result
+  rather than a process death and the target runs in Release too. A macro that narrows the
+  caller's value must assert on the caller's original expression first: an assertion after a
+  narrowing sees a value the narrowing already made legal.
 
 ### What's genuinely good
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(CMAKE_TARGET_MESSAGES OFF)
 endif()
 
-project(serialize VERSION 1.16.0 LANGUAGES CXX)
+project(serialize VERSION 1.16.1 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
@@ -116,7 +116,13 @@ if(SERIALIZE_BUILD_TESTS)
     add_executable(serialize_conformance conformance.cpp serialize.h)
     set_target_properties(serialize_conformance PROPERTIES OUTPUT_NAME conformance)
 
-    foreach(target serialize_test example serialize_conformance)
+    # The write side debug assertions, observed rather than aborted on: asserts.cpp defines
+    # serialize_assert itself, so the assertions are live in Release too and this target is
+    # registered unconditionally.
+    add_executable(serialize_asserts asserts.cpp serialize.h)
+    set_target_properties(serialize_asserts PROPERTIES OUTPUT_NAME asserts)
+
+    foreach(target serialize_test example serialize_conformance serialize_asserts)
         target_link_libraries(${target} PRIVATE serialize)
         target_compile_options(${target} PRIVATE ${SERIALIZE_DEV_FLAGS})
         target_compile_definitions(${target} PRIVATE
@@ -128,6 +134,7 @@ if(SERIALIZE_BUILD_TESTS)
     enable_testing()
     add_test(NAME test COMMAND serialize_test)
     add_test(NAME conformance COMMAND serialize_conformance ${SERIALIZE_CONFORMANCE_VECTORS})
+    add_test(NAME asserts COMMAND serialize_asserts)
 
     # THE SAME SUITE A SECOND TIME AT -ffp-contract=on, AND A THIRD TIME AT
     # -ffp-contract=fast. This is not belt and braces; these are the only builds in which the

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,60 @@
+# Family compatibility
+
+**Format version 1.1.** Two endpoints interoperate when they run releases
+carrying the same format version. The format version names the wire, not a
+library release, and it is stated at the head of
+[STANDARD.md](STANDARD.md).
+
+These are the releases that carry format version 1.1:
+
+| runtime | language | release |
+|---|---|---|
+| [serialize](https://github.com/mas-bandwidth/serialize) | C++ | `v1.16.1` |
+| [serialize.c](https://github.com/mas-bandwidth/serialize.c) | C | `v1.9.1` |
+| [serialize.cs](https://github.com/mas-bandwidth/serialize.cs) | C# | `v1.9.0` |
+| [serialize.go](https://github.com/mas-bandwidth/serialize.go) | Go | `v1.15.0` |
+| [serialize.rs](https://github.com/mas-bandwidth/serialize.rs) | Rust | `v2.3.0` |
+| [serialize.js](https://github.com/mas-bandwidth/serialize.js) | JavaScript | `v1.4.0` |
+| [serialize.dart](https://github.com/mas-bandwidth/serialize.dart) | Dart | `v1.1.0` |
+| [serialize.java](https://github.com/mas-bandwidth/serialize.java) | Java | `v1.1.0` |
+| [serialize.elixir](https://github.com/mas-bandwidth/serialize.elixir) | Elixir | `v1.1.0` |
+
+The library versions differ across the family and always will: they count each
+implementation's own releases. The format version is the only number that says
+whether two endpoints can talk to each other.
+
+## What the pin is
+
+Every release above vendors the standard and the corpus from one commit of this
+repository:
+
+    standard_commit  7e42c0fda9c734a323af5c5f79efab82191ca294
+    corpus_commit    7e42c0fda9c734a323af5c5f79efab82191ca294
+
+The pin names a commit and never a branch. `main` moves, so a claim proved
+against `main` is a claim about whatever `main` happened to be that morning. The
+pin moves when the family re-syncs, which is a deliberate act with a release
+behind it.
+
+## What 1.1 changed, and why the number moved
+
+The bytes are unchanged for every value that is legal under 1.1. A writer that
+stays inside the format produces the same stream it produced before, and a
+reader decodes it to the same value.
+
+What changed is refusal behavior, and refusal behavior is part of the format.
+A reader that accepts a stream the standard says must be refused is not
+compatible with one that refuses it: the two disagree about which streams exist,
+which is a disagreement about the wire even when every legal stream round trips
+identically. That is why the version moved rather than staying at 1.0 with a
+note. [STANDARD.md](STANDARD.md) lists the rulings.
+
+## How this page is proved
+
+[COMPATIBILITY.txt](COMPATIBILITY.txt) holds these rows machine readably, and
+the `family matrix` job checks every one of them: it checks out each repository
+at the row's release, diffs the `STANDARD.md` and `conformance/` that release
+vendors against the pinned commit, and checks that the release's version file
+carries the release's version. It runs on every push to `main` and nightly, so a
+port that drifts after release is caught rather than assumed. A row that cannot
+be proved makes the job red.

--- a/COMPATIBILITY.txt
+++ b/COMPATIBILITY.txt
@@ -1,0 +1,93 @@
+# The serialize family compatibility matrix, machine readable.
+#
+# This file is the matrix. COMPATIBILITY.md renders the same rows for people, and the
+# `family matrix` job in .github/workflows/family-matrix.yml proves both: for every runtime
+# row it checks out that repository at the row's release, diffs the STANDARD.md and
+# conformance/ that release vendors against the pinned commit of this repository, and checks
+# that the release's version file carries the release's version. Any row that fails makes
+# the job red, on every push to main and nightly, so a port that drifts after release is
+# caught rather than assumed.
+#
+# The pins name a commit, never a branch: main moves, and a proof against a moving target
+# proves nothing. standard_commit and corpus_commit are the commit of this repository whose
+# STANDARD.md and conformance/ every listed release vendors. They move when the family
+# re-syncs, which is a deliberate act with a release behind it, not a side effect of a
+# commit landing here.
+#
+# The format is the conformance corpus's, deliberately: `#` begins a comment, blank lines
+# separate records, and each line is a key and its value.
+
+format_version 1.1
+standard_commit 7e42c0fda9c734a323af5c5f79efab82191ca294
+corpus_commit 7e42c0fda9c734a323af5c5f79efab82191ca294
+
+# The C++ implementation is this repository, so it vendors nothing: it is where STANDARD.md
+# and conformance/ live. Its row is checked against the working checkout rather than against
+# a tag, which is also what lets a release's own version bump be checked before it is tagged.
+
+runtime serialize
+language C++
+repository mas-bandwidth/serialize
+release v1.16.1
+version_file CMakeLists.txt
+version_pattern project(serialize VERSION 1.16.1 LANGUAGES CXX)
+
+runtime serialize.c
+language C
+repository mas-bandwidth/serialize.c
+release v1.9.1
+version_file serialize.h
+version_pattern #define SERIALIZE_VERSION "1.9.1"
+
+runtime serialize.cs
+language C#
+repository mas-bandwidth/serialize.cs
+release v1.9.0
+version_file src/Serialize.csproj
+version_pattern <Version>1.9.0</Version>
+
+# serialize.go carries no version string: a Go module's version is its tag, and duplicating
+# it in a file would only create a second place for it to be wrong. The row's release is
+# still checked out and its vendored copies still diffed.
+
+runtime serialize.go
+language Go
+repository mas-bandwidth/serialize.go
+release v1.15.0
+version_file -
+version_pattern -
+
+runtime serialize.rs
+language Rust
+repository mas-bandwidth/serialize.rs
+release v2.3.0
+version_file Cargo.toml
+version_pattern version = "2.3.0"
+
+runtime serialize.js
+language JavaScript
+repository mas-bandwidth/serialize.js
+release v1.4.0
+version_file package.json
+version_pattern "version": "1.4.0"
+
+runtime serialize.dart
+language Dart
+repository mas-bandwidth/serialize.dart
+release v1.1.0
+version_file pubspec.yaml
+version_pattern version: 1.1.0
+
+runtime serialize.java
+language Java
+repository mas-bandwidth/serialize.java
+release v1.1.0
+version_file src/serialize/SerializeUtil.java
+version_pattern public static final String VERSION = "1.1.0";
+
+runtime serialize.elixir
+language Elixir
+repository mas-bandwidth/serialize.elixir
+release v1.1.0
+version_file mix.exs
+version_pattern version: "1.1.0"

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Packets come off the network, so the read path validates in release builds and d
 
 The wire format itself is specified in [STANDARD.md](STANDARD.md), and the vectors every implementation in the family must agree on live in [conformance/](conformance). The test suite runs all of them.
 
+serialize is one of nine implementations of that format, in C, C++, C#, Dart, Elixir, Go, Java, JavaScript and Rust. Two endpoints interoperate when they run releases carrying the same format version, and [COMPATIBILITY.md](COMPATIBILITY.md) lists the release of each implementation that carries the current one.
+
 # Limitations
 
 * Write buffer sizes must be a multiple of 8 bytes, because the bit writer flushes qwords to memory. Bytes past the end of the written data are only ever written as zeros. Buffers do not need any particular alignment: all memory access goes through memcpy.

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -12,6 +12,9 @@ structure your code.
 **The format version is 1.1.** It names the wire, not a library release. Two
 endpoints interoperate when they run releases carrying the same format version,
 and a release states which format version it implements.
+[COMPATIBILITY.md](COMPATIBILITY.md) lists the release of every implementation
+in the family that carries it, pinned to the commit of this document and of the
+corpus that those releases vendor.
 
 The rulings that moved the format off 1.0, which was this document as first
 written:
@@ -448,8 +451,9 @@ one. Specifically, an implementation must not:
 The rule is a property of the arithmetic rather than a list of languages: no
 fused multiply-add across the expressions named here, in any language, and
 every runtime documents the barrier it uses to hold that. The witness value
-`8388608.0` and the two witness ranges named below are corpus vectors, carried
-in `conformance/` like every other pinned vector.
+`8388608.0` and the two witness ranges named below are owed as corpus vectors,
+and stand among the remaining silences under Provenance until the corpus carries
+them.
 
 **The integer clamp is normative — added 2026-08-23 (schema#109; ruling:
 Glenn, live).** Once `max_integer_value >= 2^23` the `float32` ulp at the top
@@ -994,13 +998,36 @@ explicit refusal test. An implementation conforms when it reproduces every
 vector byte for byte and refuses everything this document says must be refused.
 
 **The shared corpus is the conformance instrument.** It is the `conformance/`
-directory of this repository, one file per operation, holding the accepted and
-refused vectors this document's rules require. Every implementation vendors and
-syncs that directory the way it vendors this document, and its test suite must
-run every vector in it. No checker reimplements the codec and then checks that
-reimplementation against itself. A suite that regenerates its own expectations
-proves only that a port agrees with itself, which is how one wrong reading of
-this document travels to nine implementations under green results.
+directory of this repository, one file per covered operation, holding the
+accepted and refused vectors this document's rules require. The covered
+operations are:
+
+| file | operation | what it pins |
+|---|---|---|
+| `int_relative.txt` | `int_relative` | the domain, and the refusal of a reconstruction outside it in every tier |
+| `int128.txt` | `int128` | the ranged 128 bit codec, including ranges wider than `2^127` |
+
+Those are the covered operations today. The operations the corpus does not yet
+reach are the remaining silences below, each owed a vector; adding a file here
+is how one of them becomes a family obligation, and the table above moves with
+the directory.
+
+Every implementation vendors and syncs that directory the way it vendors this
+document, and its test suite must run every vector in it. No checker
+reimplements the codec and then checks that reimplementation against itself. A
+suite that regenerates its own expectations proves only that a port agrees with
+itself, which is how one wrong reading of this document travels to nine
+implementations under green results.
+
+**A runner discovers the directory. It does not name the files.** A runner
+holding a list of filenames in its source runs the vectors someone remembered to
+add to that list, so a newly vendored file goes untested in every implementation
+whose list was not edited, silently and under green results. Enumerate the
+directory instead: at run time, or at build time from a glob that re-runs when
+the directory changes. An empty directory fails the run, because an empty corpus
+is a broken checkout and not a pass, and so does a vector whose operation the
+runner has no code for, because an operation nobody implemented must be red
+rather than skipped.
 
 **The remaining silences.** These are the rules a reader can get today only by
 reading an implementation, each named by the section that owes it and by what a
@@ -1061,6 +1088,21 @@ is how `float` and `double` vectors are stated.
 bytes of a vector are the stream, and a harness running it against an
 implementation under the eight-byte slack contract allocates that slack behind
 them, including for the empty stream of a zero-bit read.
+
+**What a runner checks.** These are obligations. A runner that checks less than
+this is not running the instrument.
+
+* For an **accepted** vector: the decoded value equals the value the record
+  states, compared as a number, or as a bit pattern where the record states
+  `expect bits = 0x`; and the bits consumed equal `consumed`.
+* For a vector carrying `writer = canonical`: additionally, the bytes a writer
+  emits for that value, byte for byte.
+* For a **refused** vector: the read is refused, the caller's scalar destination
+  holds exactly what it held before the call, and the stream is left terminal.
+  Terminality is checked by behavior rather than by an accessor, so the check
+  ports to every implementation: issue a further read on the same stream and
+  require that it also fails, consumes no bits, and writes nothing to its own
+  destination.
 
 **Conformance vectors must discriminate.** A value taken from the middle of a
 range, or one that lands where every plausible reading agrees, proves nothing —

--- a/asserts.cpp
+++ b/asserts.cpp
@@ -1,0 +1,199 @@
+/*
+    serialize
+
+    Copyright © 2016 - 2026, Más Bandwidth LLC.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+        1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+        2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
+           in the documentation and/or other materials provided with the distribution.
+
+        3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived
+           from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+    WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+    USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+/*
+    The write side debug assertions, tested by observing them fire.
+
+    A serialize macro that narrows the caller's value before asserting on it cannot report
+    the input the assertion exists to diagnose: the assertion sees a value already truncated
+    to the narrower width, and 2^32 + 5 truncates to 5, which is in range by construction.
+    Every macro that narrows now validates the caller's original expression first, and this
+    file is where that ordering is proved.
+
+    serialize_assert is defined here, before serialize.h, which the header honors. A
+    recording definition makes "the assertion fired" an ordinary observable result rather
+    than a process death: it runs identically on all three platforms in the matrix and in
+    both build configurations, where an aborting assertion would need a death test whose
+    shape differs on each of them, and it also names WHICH assertion fired.
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+
+static int assert_fires = 0;
+static const char * assert_condition = "";
+
+#define serialize_assert( condition )                                                       \
+    do                                                                                      \
+    {                                                                                       \
+        if ( !( condition ) )                                                               \
+        {                                                                                   \
+            assert_fires++;                                                                 \
+            assert_condition = #condition;                                                  \
+        }                                                                                   \
+    }                                                                                       \
+    while ( 0 )
+
+#include "serialize.h"
+
+static int failures = 0;
+
+static void check( bool condition, const char * what )
+{
+    printf( "    %-62s %s\n", what, condition ? "pass" : "FAILED" );
+    if ( !condition )
+    {
+        failures++;
+    }
+}
+
+// the assertion counter is global to the translation unit, so each case starts from zero
+static void reset()
+{
+    assert_fires = 0;
+    assert_condition = "";
+}
+
+static void test_value_in_int_relative_domain()
+{
+    printf( "  serialize::value_in_int_relative_domain\n" );
+
+    check( serialize::value_in_int_relative_domain( 0 ), "zero is in the domain" );
+    check( serialize::value_in_int_relative_domain( 2147483647 ), "the top of the domain is in it" );
+    check( !serialize::value_in_int_relative_domain( -1 ), "a negative value is out of the domain" );
+    check( !serialize::value_in_int_relative_domain( int64_t( 2147483648LL ) ), "2^31 is out of the domain" );
+
+    // the point of the helper: a wide value whose low 32 bits are in the domain
+    check( !serialize::value_in_int_relative_domain( int64_t( 4294967301LL ) ), "2^32 + 5 is out of the domain, not 5" );
+    check( !serialize::value_in_int_relative_domain( uint64_t( 1 ) << 63 ), "2^63 is out of the domain" );
+    check( !serialize::value_in_int_relative_domain( uint32_t( 4294967295u ) ), "an unsigned value above the domain is out of it" );
+}
+
+static void test_write_int_relative_asserts_on_the_callers_value()
+{
+    printf( "  write_int_relative\n" );
+
+    uint8_t buffer[64];
+
+    // a wide current whose low 32 bits are in the domain and above previous. Narrowed to int
+    // first, this is 5, which is a legal current for a previous of 4 -- and that is what the
+    // helper's assertion used to be handed.
+    {
+        reset();
+        serialize::WriteStream stream( buffer, (int64_t) sizeof( buffer ) );
+        const int64_t current = 4294967301LL;                   // 2^32 + 5
+        const int previous = 4;
+        write_int_relative( stream, previous, current );
+        check( assert_fires > 0, "a wide out of domain current trips the assertion" );
+        printf( "      assertion: %s\n", assert_condition );
+    }
+
+    // the negative control: the same call one step inside the domain must not assert
+    {
+        reset();
+        serialize::WriteStream stream( buffer, (int64_t) sizeof( buffer ) );
+        const int64_t current = 5;
+        const int previous = 4;
+        write_int_relative( stream, previous, current );
+        check( assert_fires == 0, "an in domain current does not trip it" );
+    }
+
+    // a current at the top of the domain is legal, and 2^31 is one step outside it
+    {
+        reset();
+        serialize::WriteStream stream( buffer, (int64_t) sizeof( buffer ) );
+        const int64_t current = 2147483647LL;
+        const int previous = 2147483646;
+        write_int_relative( stream, previous, current );
+        check( assert_fires == 0, "a current at the top of the domain does not trip it" );
+    }
+
+    {
+        reset();
+        serialize::WriteStream stream( buffer, (int64_t) sizeof( buffer ) );
+        const int64_t current = 2147483648LL;
+        const int previous = 2147483646;
+        write_int_relative( stream, previous, current );
+        check( assert_fires > 0, "a current one step above the domain trips it" );
+        printf( "      assertion: %s\n", assert_condition );
+    }
+}
+
+#if defined( SERIALIZE_HAS_COMPILE_TIME_SURFACE )
+
+template <typename Stream> bool serialize_compile_time_bounded( Stream & stream, int64_t & value )
+{
+    serialize_int_compile_time( stream, value, 0, 1000 );
+    return true;
+}
+
+static void test_serialize_int_compile_time_asserts_on_the_callers_value()
+{
+    printf( "  serialize_int_compile_time\n" );
+
+    uint8_t buffer[64];
+
+    // 2^32 narrows to 0, which is in [0,1000]: the assertion inside SerializeIntConst is
+    // handed a value the narrowing already made legal
+    {
+        reset();
+        serialize::WriteStream stream( buffer, (int64_t) sizeof( buffer ) );
+        int64_t value = 4294967296LL;
+        serialize_compile_time_bounded( stream, value );
+        check( assert_fires > 0, "a wide out of range value trips the assertion" );
+        printf( "      assertion: %s\n", assert_condition );
+    }
+
+    {
+        reset();
+        serialize::WriteStream stream( buffer, (int64_t) sizeof( buffer ) );
+        int64_t value = 500;
+        serialize_compile_time_bounded( stream, value );
+        check( assert_fires == 0, "an in range value does not trip it" );
+    }
+}
+
+#endif // #if defined( SERIALIZE_HAS_COMPILE_TIME_SURFACE )
+
+int main()
+{
+    printf( "\nwrite side assertions\n\n" );
+
+    test_value_in_int_relative_domain();
+    test_write_int_relative_asserts_on_the_callers_value();
+#if defined( SERIALIZE_HAS_COMPILE_TIME_SURFACE )
+    test_serialize_int_compile_time_asserts_on_the_callers_value();
+#endif
+
+    if ( failures > 0 )
+    {
+        printf( "\n*** %d ASSERTION TESTS FAILED ***\n\n", failures );
+        return 1;
+    }
+
+    printf( "\n*** ALL ASSERTION TESTS PASS ***\n\n" );
+
+    return 0;
+}

--- a/asserts.cpp
+++ b/asserts.cpp
@@ -50,8 +50,13 @@ static const char * assert_condition = "";
     {                                                                                       \
         if ( !( condition ) )                                                               \
         {                                                                                   \
+            /* the FIRST assertion to fire is the diagnostic one: a case that gets past  */ \
+            /* it goes on to trip the downstream assertions the narrowing used to hide   */ \
+            if ( assert_fires == 0 )                                                        \
+            {                                                                               \
+                assert_condition = #condition;                                              \
+            }                                                                               \
             assert_fires++;                                                                 \
-            assert_condition = #condition;                                                  \
         }                                                                                   \
     }                                                                                       \
     while ( 0 )

--- a/conformance.cpp
+++ b/conformance.cpp
@@ -25,7 +25,7 @@
 /*
     Runs the shared conformance corpus through this library's reader.
 
-    The corpus is the conformance/ directory: one file per operation, holding the accepted and
+    The corpus is the conformance/ directory: one file per covered operation, holding the accepted and
     refused vectors STANDARD.md's rules require. It is the conformance instrument every
     implementation in the family runs, and it is deliberately not generated from this code — a
     suite that regenerates its own expectations proves only that a port agrees with itself.

--- a/conformance.cpp
+++ b/conformance.cpp
@@ -33,11 +33,15 @@
     Each vector states an operation, its parameters, the stream bytes, and either the value a
     conforming reader decodes together with the bits it consumes, or the word `refused`. An
     accepted vector must yield exactly that value and consume exactly that many bits; a refused
-    vector must be refused, and must leave the caller's scalar destination unwritten, which is the
-    obligation Reader Obligations states for every refusal.
+    vector must be refused, must leave the caller's scalar destination unwritten, and must leave
+    the stream terminal, which are the obligations Reader Obligations states for every refusal.
+    Terminality is checked by behavior rather than by an accessor, so the check ports to every
+    implementation in the family: a further read on the same stream must also fail, consume no
+    bits and write nothing.
 
-    The vector files are named on the command line. STANDARD.md, "The vector format", specifies
-    the syntax.
+    The vector files are named on the command line, and CMake discovers them: the glob is in
+    CMakeLists.txt, with CONFIGURE_DEPENDS so a vendored file that no one named still runs.
+    STANDARD.md, "The vector format", specifies the syntax.
 */
 
 #include "serialize.h"
@@ -199,6 +203,30 @@ static void fail( const Vector & vector, const char * detail )
     failures++;
 }
 
+// Failure is terminal (STANDARD.md, Reader Obligations), and a refused vector is where that
+// rule is testable: the stream is checked by behavior rather than by an accessor, so the same
+// check ports to every implementation in the family. A further read must fail, consume no bits
+// and leave its destination alone.
+static void fail_unless_stream_is_terminal( const Vector & vector, serialize::ReadStream & stream )
+{
+    uint32_t after = 0xFFFFFFFF;
+    const int64_t bitsBefore = stream.GetBitsProcessed();
+    if ( stream.SerializeBits( after, 8 ) )
+    {
+        fail( vector, "the stream accepted a read after the refusal: failure is not terminal" );
+        return;
+    }
+    if ( after != 0xFFFFFFFF )
+    {
+        fail( vector, "the read after the refusal wrote to its destination" );
+        return;
+    }
+    if ( stream.GetBitsProcessed() != bitsBefore )
+    {
+        fail( vector, "the read after the refusal consumed bits" );
+    }
+}
+
 // consumed is stated on accepted reads only: after a refusal the stream position is not part of
 // the contract, so no vector states it and no implementation is judged on it
 
@@ -246,6 +274,10 @@ static void run_int_relative( const Vector & vector )
         else if ( current != sentinel )
         {
             fail( vector, "the refused read wrote to the destination" );
+        }
+        else
+        {
+            fail_unless_stream_is_terminal( vector, stream );
         }
         return;
     }
@@ -296,6 +328,10 @@ static void run_int128( const Vector & vector )
         else if ( !( value == sentinel ) )
         {
             fail( vector, "the refused read wrote to the destination" );
+        }
+        else
+        {
+            fail_unless_stream_is_terminal( vector, stream );
         }
         return;
     }

--- a/serialize.h
+++ b/serialize.h
@@ -36,8 +36,8 @@
 
 #define SERIALIZE_VERSION_MAJOR 1
 #define SERIALIZE_VERSION_MINOR 16
-#define SERIALIZE_VERSION_PATCH 0
-#define SERIALIZE_VERSION "1.16.0"
+#define SERIALIZE_VERSION_PATCH 1
+#define SERIALIZE_VERSION "1.16.1"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict
@@ -3027,8 +3027,13 @@ namespace serialize
         int length = 0;
         if ( Stream::IsWriting )
         {
-            length = (int) strlen( string );
-            serialize_assert( length < buffer_size );
+            // the length assertion runs on the size_t strlen returns, before it narrows to int:
+            // an assertion placed after the narrowing sees a length already truncated, and a
+            // string of 2^32 + 5 bytes truncates to 5, which fits any buffer
+            const size_t string_length = strlen( string );
+            serialize_assert( buffer_size > 0 );
+            serialize_assert( string_length < (size_t) buffer_size );
+            length = (int) string_length;
             // the writer's contract, debug only. See serialize_string_is_valid_utf8.
             serialize_assert( serialize_string_is_valid_utf8( string, length ) );
         }
@@ -3320,6 +3325,20 @@ namespace serialize
      */
 
     const int64_t serialize_int_relative_max = 2147483647;
+
+    /**
+        Is a value inside the int_relative domain?
+        This is the write side domain check for serialize_int_relative and write_int_relative, and it runs on the caller's value before the macro narrows it to int. An assertion placed after the narrowing sees a value already truncated to int, so it cannot report the out of domain input it exists to diagnose: writing 2^32 + 5 arrives at serialize::serialize_int_relative_internal as 5, in the domain by construction.
+        The value is widened rather than narrowed, so an input above the top of the domain fails wherever it came from. An unsigned 64 bit value above 2^63 - 1 widens to a negative int64_t and fails too, which is the right answer: it is above the domain, not below it.
+        @param value The caller's value.
+        @returns True if the value is in [0,2^31-1].
+     */
+
+    template <typename T> inline bool value_in_int_relative_domain( T value )
+    {
+        const int64_t widened = int64_t( value );
+        return widened >= 0 && widened <= serialize_int_relative_max;
+    }
 
     /**
         Accept a reconstructed int_relative value, or refuse the read.
@@ -4077,8 +4096,12 @@ namespace serialize
     #define write_string( stream, string, buffer_size )                                     \
         do                                                                                  \
         {                                                                                   \
-            int length = (int) strlen( string );                                            \
-            serialize_assert( length < (buffer_size) );                                     \
+            /* the length assertion runs on the size_t strlen returns, before it narrows */ \
+            /* to int. See serialize::serialize_string_internal */                          \
+            const size_t string_length = strlen( string );                                  \
+            serialize_assert( (buffer_size) > 0 );                                          \
+            serialize_assert( string_length < (size_t) (buffer_size) );                     \
+            int length = (int) string_length;                                               \
             /* the writer's contract, debug only. See serialize_string_is_valid_utf8 */     \
             serialize_assert( serialize::serialize_string_is_valid_utf8( string, length ) );\
             write_int( stream, length, 0, (buffer_size) - 1 );                              \
@@ -4125,9 +4148,18 @@ namespace serialize
         }                                                                                   \
         while(0)
 
+    /**
+        Write an integer relative to a previous one, the write-only companion to serialize_int_relative.
+        Carries the same debug assertion on the domain, checked on the caller's value before it is narrowed to int: an assertion inside the helper sees a value already truncated, and 2^32 + 5 truncates to 5, which is in the domain.
+        @param stream The stream object. Must be a write stream.
+        @param previous The previous integer value, in [0,2^31-1].
+        @param current The current integer value, in [0,2^31-1] and strictly greater than previous.
+     */
+
     #define write_int_relative( stream, previous, current )                                 \
         do                                                                                  \
         {                                                                                   \
+            serialize_assert( serialize::value_in_int_relative_domain( current ) );         \
             int current_value = (int) ( current );                                          \
             serialize::serialize_int_relative_internal( stream, previous, current_value );  \
         } while (0)
@@ -4371,6 +4403,8 @@ namespace serialize
             int32_t int32_value = 0;                                                        \
             if ( Stream::IsWriting )                                                        \
             {                                                                               \
+                serialize_assert( int64_t( value ) >= int64_t( min ) );                     \
+                serialize_assert( int64_t( value ) <= int64_t( max ) );                     \
                 int32_value = (int32_t) ( value );                                          \
             }                                                                               \
             if ( !serialize::SerializeIntConst<(min), (max)>( stream, int32_value ) )       \


### PR DESCRIPTION
An outside re-audit of the serialize family at today's tags. Rebased onto main after #113 and #114, with the conformance section reconciled so it reads once.

## The finding: an assertion behind a narrowing cannot see what it exists to diagnose

`write_int_relative` narrowed the caller's `current` to `int` before the helper's assertions inspected it:

```c
#define write_int_relative( stream, previous, current )   \
    do                                                    \
    {                                                     \
        int current_value = (int) ( current );            \
        serialize::serialize_int_relative_internal( stream, previous, current_value );  \
    } while (0)
```

A `current` of `2^32 + 5` arrives at `serialize_int_relative_internal` as `5`, which is in the domain by construction, so `serialize_assert( int64_t( current ) <= serialize_int_relative_max )` passes on an input it exists to reject. That is the defect class 1.16.0 fixed in the bit macros with `serialize::value_fits_in_bits`.

## Grepping the pattern rather than fixing the one named

Three sites narrow a caller's value before an assertion looks at it. All three now validate the caller's original expression first:

| site | what narrowed | what sees the caller's value now |
|---|---|---|
| `write_int_relative` | `current` to `int` | `serialize::value_in_int_relative_domain`, the int_relative twin of `value_fits_in_bits` |
| `serialize_int_compile_time` | `value` to `int32_t`, with the bounds assertions inside `SerializeIntConst` behind it | the bounds assertions, moved to the macro, in `serialize_int`'s shape |
| `serialize_string_internal`, `write_string` | `strlen`'s `size_t` to `int` before the length was compared against the buffer | the comparison, on the `size_t` |

`serialize_int64_compile_time` narrows to `int64_t`, the widest signed width, so there is no wider value for an assertion to see: the assert would be the same expression as the narrowing. Nothing to fix there, and adding one would be scaffolding.

Every other `serialize_*`, `read_*` and `write_*` macro already asserts before it narrows.

## The test

`asserts.cpp` defines `serialize_assert` itself, which the header honors, so an assertion firing is an ordinary observable result rather than a process death. That matters: it runs identically on all three platforms and in **both** build configurations, where an aborting death test needs a different shape on each of the three and disappears entirely under `NDEBUG`. It also reports which assertion fired.

Each case carries its negative control:

* a wide out of domain `current` trips the assertion; the same call one step inside the domain does not
* a `current` one step above the top of the domain trips it; a `current` at the top does not
* a wide out of range value trips `serialize_int_compile_time`; an in range value does not

Registered as the `asserts` ctest.

## The conformance runner keeps the obligation it now states

`conformance.cpp` checked that a refused vector left the destination unwritten, but not that it left the stream terminal. It does now, by behavior rather than by an accessor, so the check is the one every port can make: a further read on the same stream must fail, consume no bits and write nothing.

## STANDARD.md

The conformance section said "one file per operation", which reads as a claim the corpus covers every operation. It now names the covered operations (`int_relative`, `int128` today) and points at #114's remaining silences for the rest.

Three additions, and one reordering:

* **A runner discovers the directory. It does not name the files.** A hand written file list runs the vectors someone remembered to add to it, so a newly vendored file goes untested in every implementation whose list was not edited. Enumerate the directory, at run time or from a build time glob that re-runs when it changes; an empty directory fails, and so does a vector whose operation the runner cannot dispatch.
* **What a runner checks**, as an obligation rather than a description: for a refused vector, the destination unwritten and the stream terminal; for an accepted vector, the value and the bits consumed.
* Reconciled with #114: the accepted bullet covers `expect bits = 0x`, and a bullet covers `writer = canonical`.
* The section is reordered so it reads once: corpus, discovery, remaining silences, the vector format and its rules, the runner contract that cites those keys, then discrimination.

One correction to #114: it says the `compressed_float` witnesses "are corpus vectors, carried in `conformance/` like every other pinned vector", while its own silences table lists them as still owed. The sentence now says they are owed.

## The family compatibility matrix, and its gate

`COMPATIBILITY.md` is the page. `COMPATIBILITY.txt` is the same matrix machine readably, in the corpus's own record format.

Format version **1.1**, standard and corpus pinned at `7e42c0fda9c734a323af5c5f79efab82191ca294`, and the nine releases that carry it: serialize `v1.16.1`, serialize.c `v1.9.1`, serialize.cs `v1.9.0`, serialize.go `v1.15.0`, serialize.rs `v2.3.0`, serialize.js `v1.4.0`, serialize.dart `v1.1.0`, serialize.java `v1.1.0`, serialize.elixir `v1.1.0`.

The page says plainly what 1.1 means: the bytes are unchanged for every value legal under 1.1, and what changed is refusal behavior. Refusal behavior is part of the format, because a reader that accepts a stream the standard says must be refused disagrees with one that refuses it about which streams exist. That is why the version moved rather than staying at 1.0 with a note.

The pin names a commit and never `main`. `main` moves, so a claim proved against `main` is a claim about whatever `main` was that morning.

### The gate

A matrix nobody checks is a page that goes quietly wrong. The new `family matrix` job proves every row:

* checks out each repository at the row's release
* diffs the `STANDARD.md` and `conformance/` that release vendors against the pinned commit
* checks the release's version file carries the release's version, and that the pattern proving it contains the release's own version
* checks `COMPATIBILITY.md` lists the same row, so the page and the gate cannot become two matrices

On push to `main`, on pull requests, and **nightly**, because a row can go wrong with nothing landing here: a port can move a tag, retag, or amend a vendored file after the fact.

`actions/checkout` is pinned by commit sha in this workflow. The other workflows here pin by tag; a follow-on can bring them across.

### The negative control

A gate nobody has seen fail is a gate nobody has tested. I planted a wrong row on this branch, watched the job go red, and reverted it. Both runs are linked in a comment below.

## Version

1.16.1 in `CMakeLists.txt` and `serialize.h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
