### PR TITLE
The conformance corpus covers every operation, and two controls prove it can go red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,3 +151,17 @@ jobs:
         working-directory: tools/conformance
         run: go run .
 
+      # The negative control the C++ gate runs as a ctest target, run against the Go
+      # checker too: the contract that a vector whose operation has no runner must FAIL
+      # rather than be skipped binds every gate, and a gate nobody has seen go red is a
+      # claim rather than a measurement. This step passes exactly when the checker
+      # rejects the control.
+      - name: Negative control - an operation with no runner must fail the checker
+        working-directory: tools/conformance
+        run: |
+          if go run . ../../conformance-controls/unknown-operation.txt; then
+            echo "the checker accepted a vector whose operation it cannot drive"
+            exit 1
+          fi
+          echo "the checker rejected the control, as the corpus contract requires"
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,85 @@ if(SERIALIZE_BUILD_TESTS)
     enable_testing()
     add_test(NAME test COMMAND serialize_test)
     add_test(NAME conformance COMMAND serialize_conformance ${SERIALIZE_CONFORMANCE_VECTORS})
+
+    # NEGATIVE CONTROLS. The corpus is the conformance instrument, and an instrument nobody has
+    # seen go red is a claim rather than a measurement. Each control below is a deliberately
+    # broken input the gate MUST reject; ctest's WILL_FAIL inverts the verdict, so a control test
+    # passes exactly when the gate it guards goes red. If one of these ever starts failing, the
+    # gate has stopped discriminating and every green result it has produced is worth
+    # re-examining.
+
+    # Control 1: a corpus file whose operation has no runner. STANDARD.md requires a suite to run
+    # every vector in the corpus, so a runner that quietly skips what it does not understand
+    # reports green over a rule nobody checked. The vector lives in conformance-controls/, which
+    # the corpus glob above deliberately does not reach. The Go checker is run against the same
+    # file in CI, because the contract binds both gates and not only this one.
+    add_test(NAME conformance-control-unknown-operation
+             COMMAND serialize_conformance ${CMAKE_CURRENT_SOURCE_DIR}/conformance-controls/unknown-operation.txt)
+    set_tests_properties(conformance-control-unknown-operation PROPERTIES WILL_FAIL TRUE)
+
+    # Control 2: a reader with ONE LINE of a refusal rule deleted, built from a scratch copy of
+    # the header and run against the real corpus, which must go red. This is the control that
+    # answers "would the corpus notice if the implementation were wrong?" — and it answers it per
+    # rule, because each sabotage names the rule it deletes and the vectors that pin it.
+    #
+    # The scratch copy is generated at configure time and the sabotage is a string replacement, so
+    # a needle that stops matching is a FATAL_ERROR rather than a silent no-op: a control that has
+    # quietly stopped sabotaging anything is worse than no control at all. conformance.cpp is
+    # copied alongside the sabotaged header because it includes "serialize.h" with quotes, which
+    # resolves against the including file's own directory first.
+    set(SERIALIZE_CONTROL_NAMES align-padding ranged-reconstruction)
+    set(SERIALIZE_CONTROL_NEEDLE_align-padding
+        "                if ( value != 0 )")
+    set(SERIALIZE_CONTROL_RULE_align-padding
+        "readers must verify that the alignment padding bits are zero")
+    # Deliberately the RECONSTRUCTION and not the range check beside it. The ranged int's range
+    # rule is guarded twice — once in ReadStream::SerializeInteger against the offset, and again
+    # in the serialize_int macro against the decoded value — so deleting either guard alone
+    # changes no verdict and no vector can see it. A control aimed there would report green while
+    # proving nothing, which is the failure these controls exist to prevent. Dropping min from the
+    # reconstruction is a single line with no second guard behind it.
+    set(SERIALIZE_CONTROL_NEEDLE_ranged-reconstruction
+        "            value = int32_t( unsigned_value + uint32_t(min) );")
+    set(SERIALIZE_CONTROL_RULE_ranged-reconstruction
+        "a ranged int decodes to its offset plus min")
+    # each replacement keeps the sabotaged line compiling warning-free: the padding is at most
+    # seven bits, so comparing it against 0xFFFFFFFF is a condition that never holds while still
+    # reading the variable the deleted rule read
+    set(SERIALIZE_CONTROL_PATCH_align-padding
+        "                if ( value == 0xFFFFFFFF ) // NEGATIVE CONTROL: this rule is deleted on purpose")
+    set(SERIALIZE_CONTROL_PATCH_ranged-reconstruction
+        "            value = int32_t( unsigned_value ); // NEGATIVE CONTROL: min is dropped on purpose")
+
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/serialize.h SERIALIZE_HEADER_TEXT)
+    foreach(control ${SERIALIZE_CONTROL_NAMES})
+        set(needle "${SERIALIZE_CONTROL_NEEDLE_${control}}")
+        string(REPLACE "${needle}" "${SERIALIZE_CONTROL_PATCH_${control}}"
+               SERIALIZE_SABOTAGED_TEXT "${SERIALIZE_HEADER_TEXT}")
+        if(SERIALIZE_SABOTAGED_TEXT STREQUAL SERIALIZE_HEADER_TEXT)
+            message(FATAL_ERROR
+                "conformance control '${control}' found nothing to sabotage in serialize.h. The line it "
+                "deletes has moved or changed, so the control is no longer proving that deleting "
+                "'${SERIALIZE_CONTROL_RULE_${control}}' turns the corpus red. Update the needle in "
+                "CMakeLists.txt; do not delete the control.")
+        endif()
+        set(dir ${CMAKE_BINARY_DIR}/conformance-controls/${control})
+        file(MAKE_DIRECTORY ${dir})
+        file(WRITE ${dir}/serialize.h "${SERIALIZE_SABOTAGED_TEXT}")
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/conformance.cpp ${dir}/conformance.cpp COPYONLY)
+
+        add_executable(serialize_conformance_control_${control} ${dir}/conformance.cpp ${dir}/serialize.h)
+        set_target_properties(serialize_conformance_control_${control} PROPERTIES OUTPUT_NAME conformance-control-${control})
+        target_compile_options(serialize_conformance_control_${control} PRIVATE ${SERIALIZE_DEV_FLAGS})
+        # The controls always build UNCHECKED. A reader with a rule deleted produces values a
+        # checked build asserts on, and an abort is a hard ctest failure that WILL_FAIL does not
+        # invert — so a control built with assertions live would report a crash where the thing
+        # under test is the corpus's verdict. What must go red here is the corpus, cleanly.
+        target_compile_definitions(serialize_conformance_control_${control} PRIVATE SERIALIZE_RELEASE NDEBUG)
+        add_test(NAME conformance-control-${control}
+                 COMMAND serialize_conformance_control_${control} ${SERIALIZE_CONFORMANCE_VECTORS})
+        set_tests_properties(conformance-control-${control} PROPERTIES WILL_FAIL TRUE)
+    endforeach()
     add_test(NAME asserts COMMAND serialize_asserts)
 
     # THE SAME SUITE A SECOND TIME AT -ffp-contract=on, AND A THIRD TIME AT

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1004,13 +1004,27 @@ operations are:
 
 | file | operation | what it pins |
 |---|---|---|
-| `int_relative.txt` | `int_relative` | the domain, and the refusal of a reconstruction outside it in every tier |
+| `bits.txt` | `bits`, and the `uint8`/`uint16`/`uint32`/`uint64` aliases | every width from 1 to 64, and the low 32-bit group before the high one above 32 |
+| `bool.txt` | `bool` | one bit, and a reader that must not look at the rest of the byte |
+| `uint128.txt` | `uint128` | 128 raw bits, the low 64-bit half first |
+| `align.txt` | `align` | zero bits to the boundary, nothing when already aligned, and non-zero padding refused |
+| `int.txt` | `int` | the width rule, the degenerate range at zero bits, and a decoded value outside `[min,max]` refused |
+| `int64.txt` | `int64` | the same, at the 32/33-bit group boundary and across a span the signed domain cannot hold |
 | `int128.txt` | `int128` | the ranged 128 bit codec, including ranges wider than `2^127` |
+| `fixed.txt` | `fixed` | the offset over the raw bounds at six Q formats, and the degenerate range at zero bits on every storage width |
+| `int_relative.txt` | `int_relative` | the domain, the refusal of a reconstruction outside it in every tier, and each bounded tier's own payload range |
+| `float.txt` | `float` | NaN payloads, a signaling NaN, negative zero and denormals, compared as bit patterns |
+| `double.txt` | `double` | the same at 64 bits, and the low half before the high one |
+| `compressed_float.txt` | `compressed_float` | both clamp witnesses, the values clamp as a field width, and a non-zero `min` decode pinned bit exactly |
+| `bytes.txt` | `bytes` | the align that comes first, and a zero count that still performs it |
+| `string.txt` | `string` | valid UTF-8 accepted, and invalid UTF-8, an interior NUL and an out-of-range length refused |
+| `wstring.txt` | `wstring` | no alignment anywhere, a surrogate pair accepted, and an unpaired surrogate, a group above `0xFFFF` and a zero group refused |
+| `object.txt` | `object` | that it adds no bytes of its own, each vector twinned with the same operations unnested |
+| `sequence.txt` | sequences of operations | alignment after an odd width, a zero-bit field between wide ones, terminal failure, and the measure floor |
+| `message.txt` | the Worked Example's message | three operations across an alignment boundary, byte for byte |
 
-Those are the covered operations today. The operations the corpus does not yet
-reach are the remaining silences below, each owed a vector; adding a file here
-is how one of them becomes a family obligation, and the table above moves with
-the directory.
+Adding a file here is how a rule becomes a family obligation, and the table
+above moves with the directory.
 
 Every implementation vendors and syncs that directory the way it vendors this
 document, and its test suite must run every vector in it. No checker
@@ -1033,20 +1047,11 @@ rather than skipped.
 reading an implementation, each named by the section that owes it and by what a
 vector would pin. The tie-break sentence above stands until this list is empty.
 
-| section | what a vector would pin |
-|---|---|
-| `bits`, `bool`, `uint128` | the 32-bit group split above 32 bits, and the low half first at 128 |
-| `align` and `bytes` | non-zero padding refused, and a zero count that still aligns |
-| `int` and `int64` | a decoded value outside `[min,max]` refused, and a degenerate range that consumes nothing |
-| `fixed` | a negative tie value, which separates half away from zero from an arithmetic shift |
-| `float` and `double` | NaN payloads, a signaling NaN, negative zero and a denormal, compared as bit patterns |
-| `compressed_float` | the clamp witnesses `[0, 8388609]` and `[0, 16777215]` at resolution `1`, the fusion witness `8388608.0` in that band, and a non-zero `min` decode pinned bit exactly |
-| `object` | a nested sequence, which adds no bytes of its own |
-| `string` | valid UTF-8 accepted, and invalid UTF-8, an interior NUL and an out-of-range length refused |
-| `wstring` | a surrogate pair accepted, and an unpaired surrogate, a group above `0xFFFF` and a zero group refused |
-| The Measure Stream | `measure >= bits written` over a sequence vector, at every starting bit position |
-| Reader Obligations | a read past the end refused, and the next read on that stream refused too |
-| Worked Example | the 112-byte golden message as a sequence vector, with its operation sequence |
+| section | what a vector would pin | why the corpus does not carry it |
+|---|---|---|
+| `fixed` | a negative tie value, which separates half away from zero from an arithmetic shift | the rounding happens where a value is quantized into a Q format or narrowed out of one, and no `serialize_fixed` call rounds: the wire round trip is exact, this document says as much, and no record whose input is a byte stream can reach the rule. It needs a record shape this format does not have |
+| `compressed_float` | the fusion witness `8388608.0`, and the between-quanta writer inputs | a vector's input is a stream, so it can pin what a writer left on the wire but not the value a writer was handed. The clamp band's widths and boundaries are pinned; the writer inputs need a record shape this format does not have |
+| Worked Example | the whole 112-byte golden message | this document prints 15 of its bytes and `message.txt` carries exactly those. The rest exist only inside an implementation, and a vector copied off the implementation it judges is the failure this section opens by naming |
 
 **The vector format.** A vector file is text. `#` begins a comment, blank lines
 separate records, and each record is `key` and value, one per line:
@@ -1060,6 +1065,7 @@ separate records, and each record is `key` and value, one per line:
 | `expect` | the word `refused`, or `value = ` and the decoded value, or `bits = 0x` and the decoded bit pattern |
 | `consumed` | bits a conforming reader consumes, accepted reads only |
 | `writer` | the word `canonical`, on a vector that also pins the bytes a writer emits |
+| `measure_at_least` | the smallest number of bits a conforming measure may report, on a sequence |
 
 `consumed` is stated only for accepted reads. **After a refusal the stream
 position is not part of the contract**, so no vector states it and no
@@ -1084,6 +1090,24 @@ parser must accept values up to 128 bits wide. `expect bits = 0x...` is the
 spelling for a value compared as a bit pattern rather than as a number, which
 is how `float` and `double` vectors are stated.
 
+**A sequence vector states more than one operation.** Its `operation` is
+`sequence`, its steps are `param step = ` lines in order, and `expect value`
+lists one entry per step separated by ` | `, with `-` for a step that produces
+no value of its own. Sequences carry what a single-operation record cannot:
+alignment cost, which depends on the bit index the previous operation left
+behind; a zero-bit field, which must leave that index exactly where it found
+it; a nested `object`, spelled `object <n>` to wrap the next `n` steps; and
+terminal failure, where a refusal must poison the stream for every later step
+even where the bytes those steps would read are still present.
+
+**A measure is checked against a floor, never against a number.** A sequence
+may state `measure_at_least`, and a conforming measure must report at least it.
+The key is a floor rather than an equality because a measure is a bound and not
+the packet size: the value stated is the true worst case over every starting
+bit position, so the expected implementation's 7 bits per alignment-performing
+operation passes, a tighter correct bound passes, and the exact-from-zero
+accounting this document calls non-conforming falls below it.
+
 **A harness presents every stream with the slack the contract requires.** The
 bytes of a vector are the stream, and a harness running it against an
 implementation under the eight-byte slack contract allocates that slack behind
@@ -1103,6 +1127,18 @@ this is not running the instrument.
   ports to every implementation: issue a further read on the same stream and
   require that it also fails, consumes no bits, and writes nothing to its own
   destination.
+
+**A gate nobody has seen go red is a claim, not a measurement.** The corpus is
+an instrument, and an instrument is trusted because it has been shown to
+respond. Two controls establish that, and both belong in the test chain rather
+than in a README: a corpus file whose operation has no runner, which every gate
+must reject rather than skip; and a reader with one line of a refusal rule
+deleted, run against the real corpus, which must go red on exactly the vectors
+that pin that rule. A control that stops finding anything to break is a failure
+of the control and not a licence to remove it. This repository carries all
+three as `ctest` targets, the sabotage generated at configure time from a
+scratch copy of the header so that a needle which no longer matches is a hard
+error.
 
 **Conformance vectors must discriminate.** A value taken from the middle of a
 range, or one that lands where every plausible reading agrees, proves nothing —

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1050,7 +1050,7 @@ vector would pin. The tie-break sentence above stands until this list is empty.
 | section | what a vector would pin | why the corpus does not carry it |
 |---|---|---|
 | `fixed` | a negative tie value, which separates half away from zero from an arithmetic shift | the rounding happens where a value is quantized into a Q format or narrowed out of one, and no `serialize_fixed` call rounds: the wire round trip is exact, this document says as much, and no record whose input is a byte stream can reach the rule. It needs a record shape this format does not have |
-| `compressed_float` | the fusion witness `8388608.0`, and the between-quanta writer inputs | a vector's input is a stream, so it can pin what a writer left on the wire but not the value a writer was handed. The clamp band's widths and boundaries are pinned; the writer inputs need a record shape this format does not have |
+| `compressed_float` | the between-quanta writer inputs, and the fusion witness as a WRITE | a vector's input is a stream, so it can pin what a writer left on the wire but not the value a writer was handed. Both clamp declarations' widths, boundaries and refusals are pinned, and `8388608.0` is pinned as a decode in each of them; the writer inputs need a record shape this format does not have |
 | Worked Example | the whole 112-byte golden message | this document prints 15 of its bytes and `message.txt` carries exactly those. The rest exist only inside an implementation, and a vector copied off the implementation it judges is the failure this section opens by naming |
 
 **The vector format.** A vector file is text. `#` begins a comment, blank lines

--- a/conformance-controls/unknown-operation.txt
+++ b/conformance-controls/unknown-operation.txt
@@ -1,0 +1,22 @@
+# A NEGATIVE CONTROL, not a conformance vector. This file is deliberately not in
+# conformance/ and is never run as part of the corpus.
+#
+# STANDARD.md makes the corpus the conformance instrument and requires a
+# suite to run every vector in it. A gate that quietly skips a vector it does
+# not understand is worse than no gate: it reports green over a rule nobody
+# checked, which is the exact failure the family already paid for once.
+#
+# So the contract is that a corpus file whose operation has no runner must
+# FAIL. This file is the vector that proves the contract holds. Both gates —
+# the C++ runner and the Go checker — are run against it and both must go RED.
+# If either ever goes green here, the corpus has stopped being an instrument
+# and every green result it has ever produced is worth re-examining.
+#
+# The operation name below does not exist and never will.
+
+operation no_such_operation
+name control-a-runner-must-fail-on-an-operation-it-cannot-drive
+param whatever = 1
+bytes 00
+expect value = 0
+consumed 8

--- a/conformance.cpp
+++ b/conformance.cpp
@@ -23,21 +23,45 @@
 */
 
 /*
-    Runs the shared conformance corpus through this library's reader.
+    Runs the shared conformance corpus through this library's reader, writer and measure.
 
-    The corpus is the conformance/ directory: one file per covered operation, holding the accepted and
-    refused vectors STANDARD.md's rules require. It is the conformance instrument every
+    The corpus is the conformance/ directory: one file per covered operation, holding the
+    accepted and refused vectors STANDARD.md's rules require. It is the conformance instrument every
     implementation in the family runs, and it is deliberately not generated from this code — a
     suite that regenerates its own expectations proves only that a port agrees with itself.
 
     Each vector states an operation, its parameters, the stream bytes, and either the value a
     conforming reader decodes together with the bits it consumes, or the word `refused`. An
     accepted vector must yield exactly that value and consume exactly that many bits; a refused
-    vector must be refused, must leave the caller's scalar destination unwritten, and must leave
-    the stream terminal, which are the obligations Reader Obligations states for every refusal.
-    Terminality is checked by behavior rather than by an accessor, so the check ports to every
-    implementation in the family: a further read on the same stream must also fail, consume no
-    bits and write nothing.
+    vector must be refused, and must leave the caller's scalar destination unwritten, which is the
+    obligation Reader Obligations states for every refusal. STANDARD.md leaves a caller-owned
+    BUFFER unspecified after a refusal — bytes, string and wstring — so this runner checks the
+    destination only for the scalar operations, exactly as far as the document reaches.
+
+    A vector carrying `writer = canonical` additionally pins the bytes a conforming writer emits
+    for its value: the runner writes the value back and requires the emission to be the vector's
+    bytes exactly, flush included, which is where the trailing-bits writer obligation bites. A
+    vector without the mark binds the reader only.
+
+    A sequence vector carrying `measure_at_least` pins the floor a conforming measure may report,
+    which STANDARD.md makes a bound rather than an equality.
+
+    THE BUFFER CONTRACT. STANDARD.md, "Past-end memory is an implementation contract": the C++
+    implementation loads 64-bit windows at byte granularity and therefore requires its caller to
+    allocate at least 8 bytes beyond the data. Every stream this runner presents carries that
+    slack, and the slack bytes are set to a non-zero pattern rather than zero, so a vector that
+    only passes because uninterpreted bytes past the end read as zero fails here.
+
+    A corpus file whose operation this runner cannot drive is a gap in the runner, not a pass:
+    such a vector FAILS. So does a vector naming a parameter the runner does not understand, and
+    a fixed point vector naming a Q format declaration the runner does not carry — the fixed
+    point declaration is a compile time constant of its call site, so a runner supports a fixed
+    set of them and must say so out loud rather than skip.
+
+    A refused vector must be refused, must leave the caller's scalar destination unwritten, and
+    must leave the stream TERMINAL. Terminality is checked by behavior rather than by an
+    accessor, so the check ports to every implementation in the family: a further read on the
+    same stream must also fail, consume no bits and write nothing.
 
     The vector files are named on the command line, and CMake discovers them: the glob is in
     CMakeLists.txt, with CONFIGURE_DEPENDS so a vendored file that no one named still runs.
@@ -53,29 +77,51 @@
 // ---------------------------------------------------------------------------------------
 // vector file parsing
 
-const int MaxLine = 512;
+const int MaxLine = 1024;
 const int MaxBytes = 256;
+const int MaxSlack = 8;                 // the buffer contract: at least 8 bytes past the data
+const uint8_t SlackFill = 0xA5;         // non-zero, so a read that strays past the end is visible
+const int MaxParams = 8;
+const int MaxSteps = 8;
+
+enum ExpectKind
+{
+    EXPECT_REFUSED,
+    EXPECT_VALUE,
+    EXPECT_BITS                         // compared as a bit pattern, never as a value
+};
+
+struct Param
+{
+    char name[MaxLine];
+    char value[MaxLine];
+};
 
 struct Vector
 {
     char file[MaxLine];
     char operation[MaxLine];
     char name[MaxLine];
-    char previous[MaxLine];
-    char min[MaxLine];
-    char max[MaxLine];
     char expect[MaxLine];
-    uint8_t bytes[MaxBytes + 8];        // + 8: read buffer allocations extend 8 bytes past the data
+    Param params[MaxParams];
+    int numParams;
+    char steps[MaxSteps][MaxLine];
+    int numSteps;
+    uint8_t bytes[MaxBytes + MaxSlack];
     int numBytes;
     int64_t consumed;
     bool hasConsumed;
-    bool refused;
+    int64_t measureAtLeast;
+    bool hasMeasure;
+    bool writerCanonical;
+    ExpectKind expectKind;
 };
 
 static void vector_reset( Vector & vector, const char * file )
 {
     memset( &vector, 0, sizeof( Vector ) );
     strncpy( vector.file, file, MaxLine - 1 );
+    vector.expectKind = EXPECT_VALUE;
 }
 
 static bool vector_empty( const Vector & vector )
@@ -83,15 +129,10 @@ static bool vector_empty( const Vector & vector )
     return vector.operation[0] == '\0';
 }
 
-// strips a trailing comment and surrounding whitespace, in place
+// strips surrounding whitespace, in place
 
 static char * trim( char * text )
 {
-    char * hash = strchr( text, '#' );
-    if ( hash )
-    {
-        *hash = '\0';
-    }
     while ( *text == ' ' || *text == '\t' )
     {
         text++;
@@ -113,9 +154,11 @@ static bool parse_hex_digit( char c, int & out )
     return false;
 }
 
-static bool parse_bytes( const char * text, Vector & vector )
+// hexadecimal byte pairs, whitespace separated, into a byte array
+
+static bool parse_hex_bytes( const char * text, uint8_t * out, int maxBytes, int & numBytes )
 {
-    vector.numBytes = 0;
+    numBytes = 0;
     while ( *text )
     {
         if ( *text == ' ' || *text == '\t' )
@@ -129,19 +172,23 @@ static bool parse_bytes( const char * text, Vector & vector )
         {
             return false;
         }
-        if ( vector.numBytes >= MaxBytes )
+        if ( numBytes >= maxBytes )
         {
             return false;
         }
-        vector.bytes[vector.numBytes++] = (uint8_t) ( high * 16 + low );
+        out[numBytes++] = (uint8_t) ( high * 16 + low );
         text += 2;
     }
     return true;
 }
 
-// decimal to 128 bit, because a vector's value can be wider than any built in strtol
+/*
+    Numbers in a vector are signed decimal or 0x hexadecimal, parsed to 128 bits, because a
+    vector's value can be wider than any built in strtol and the corpus states wide bounds as
+    hexadecimal where the decimal would be unreadable.
+*/
 
-static bool parse_int128( const char * text, serialize::int128_t & out )
+static bool parse_number( const char * text, serialize::int128_t & out )
 {
     bool negative = false;
     if ( *text == '-' ) { negative = true; text++; }
@@ -151,51 +198,45 @@ static bool parse_int128( const char * text, serialize::int128_t & out )
         return false;
     }
     serialize::int128_t value = 0;
-    for ( ; *text; text++ )
+    if ( text[0] == '0' && ( text[1] == 'x' || text[1] == 'X' ) )
     {
-        if ( *text < '0' || *text > '9' )
+        text += 2;
+        if ( *text == '\0' )
         {
             return false;
         }
-        value = value * 10 + serialize::int128_t( *text - '0' );
+        for ( ; *text; text++ )
+        {
+            int digit = 0;
+            if ( !parse_hex_digit( *text, digit ) )
+            {
+                return false;
+            }
+            value = value * 16 + serialize::int128_t( digit );
+        }
+    }
+    else
+    {
+        for ( ; *text; text++ )
+        {
+            if ( *text < '0' || *text > '9' )
+            {
+                return false;
+            }
+            value = value * 10 + serialize::int128_t( *text - '0' );
+        }
     }
     out = negative ? -value : value;
     return true;
 }
 
-static bool parse_int32( const char * text, int32_t & out )
-{
-    char * end = NULL;
-    const long value = strtol( text, &end, 10 );
-    if ( end == text || *end != '\0' )
-    {
-        return false;
-    }
-    out = (int32_t) value;
-    return true;
-}
-
 // ---------------------------------------------------------------------------------------
-// the operations under test, called through the public macros so the vectors exercise the
-// surface a consumer uses rather than the stream methods underneath it
-
-template <typename Stream> bool conformance_int_relative( Stream & stream, int32_t previous, int32_t & current )
-{
-    serialize_int_relative( stream, previous, current );
-    return true;
-}
-
-template <typename Stream> bool conformance_int128( Stream & stream, serialize::int128_t & value, serialize::int128_t min, serialize::int128_t max )
-{
-    serialize_int128( stream, value, min, max );
-    return true;
-}
-
-// ---------------------------------------------------------------------------------------
-// running one vector
+// failure reporting
 
 static int failures = 0;
 static int checked = 0;
+static int writerChecked = 0;
+static int measureChecked = 0;
 
 static void fail( const Vector & vector, const char * detail )
 {
@@ -207,6 +248,7 @@ static void fail( const Vector & vector, const char * detail )
 // rule is testable: the stream is checked by behavior rather than by an accessor, so the same
 // check ports to every implementation in the family. A further read must fail, consume no bits
 // and leave its destination alone.
+
 static void fail_unless_stream_is_terminal( const Vector & vector, serialize::ReadStream & stream )
 {
     uint32_t after = 0xFFFFFFFF;
@@ -227,153 +269,1221 @@ static void fail_unless_stream_is_terminal( const Vector & vector, serialize::Re
     }
 }
 
-// consumed is stated on accepted reads only: after a refusal the stream position is not part of
-// the contract, so no vector states it and no implementation is judged on it
+// ---------------------------------------------------------------------------------------
+// parameter access. A parameter the runner does not understand is a failure rather than a
+// silent default: a vector whose declaration is not the one being exercised proves nothing.
 
-static void fail_on_bits_consumed( const Vector & vector, int64_t bitsProcessed )
+static const char * param_string( const Vector & vector, const char * name )
 {
-    if ( vector.hasConsumed && bitsProcessed != vector.consumed )
+    for ( int i = 0; i < vector.numParams; i++ )
     {
-        printf( "  FAIL %s: consumed %d bits, the corpus states %d [%s]\n", vector.name, (int) bitsProcessed, (int) vector.consumed, vector.file );
-        failures++;
+        if ( strcmp( vector.params[i].name, name ) == 0 )
+        {
+            return vector.params[i].value;
+        }
+    }
+    return NULL;
+}
+
+static bool param_number( const Vector & vector, const char * name, serialize::int128_t & out )
+{
+    const char * text = param_string( vector, name );
+    if ( !text )
+    {
+        return false;
+    }
+    return parse_number( text, out );
+}
+
+static bool param_int( const Vector & vector, const char * name, int64_t & out )
+{
+    serialize::int128_t value = 0;
+    if ( !param_number( vector, name, value ) )
+    {
+        return false;
+    }
+    out = (int64_t) value;
+    return true;
+}
+
+static bool param_float( const Vector & vector, const char * name, float & out )
+{
+    const char * text = param_string( vector, name );
+    if ( !text )
+    {
+        return false;
+    }
+    char * end = NULL;
+    out = (float) strtod( text, &end );
+    return end != text && *end == '\0';
+}
+
+// ---------------------------------------------------------------------------------------
+// stream construction. Every stream the runner hands the reader carries the slack the buffer
+// contract requires, filled with a non-zero pattern so that a decode which depends on memory
+// past the end cannot pass by reading zeros.
+
+struct StreamBuffer
+{
+    uint8_t data[MaxBytes + MaxSlack];
+    int64_t bytes;
+};
+
+static void stream_buffer_init( StreamBuffer & buffer, const Vector & vector )
+{
+    memset( buffer.data, SlackFill, sizeof( buffer.data ) );
+    memcpy( buffer.data, vector.bytes, (size_t) vector.numBytes );
+    buffer.bytes = vector.numBytes;
+}
+
+// ---------------------------------------------------------------------------------------
+// the operations under test, called through the public macros so the vectors exercise the
+// surface a consumer uses rather than the stream methods underneath it
+
+template <typename Stream> bool op_bits( Stream & stream, uint64_t & value, int bits )
+{
+    serialize_bits( stream, value, bits );
+    return true;
+}
+
+template <typename Stream> bool op_bool( Stream & stream, bool & value )
+{
+    serialize_bool( stream, value );
+    return true;
+}
+
+template <typename Stream> bool op_uint128( Stream & stream, serialize::uint128_t & value )
+{
+    serialize_uint128( stream, value );
+    return true;
+}
+
+template <typename Stream> bool op_align( Stream & stream )
+{
+    serialize_align( stream );
+    return true;
+}
+
+template <typename Stream> bool op_int( Stream & stream, int32_t & value, int32_t min, int32_t max )
+{
+    serialize_int( stream, value, min, max );
+    return true;
+}
+
+template <typename Stream> bool op_int64( Stream & stream, int64_t & value, int64_t min, int64_t max )
+{
+    serialize_int64( stream, value, min, max );
+    return true;
+}
+
+template <typename Stream> bool op_int128( Stream & stream, serialize::int128_t & value, serialize::int128_t min, serialize::int128_t max )
+{
+    serialize_int128( stream, value, min, max );
+    return true;
+}
+
+template <typename Stream> bool op_int_relative( Stream & stream, int32_t previous, int32_t & current )
+{
+    serialize_int_relative( stream, previous, current );
+    return true;
+}
+
+template <typename Stream> bool op_float( Stream & stream, float & value )
+{
+    serialize_float( stream, value );
+    return true;
+}
+
+template <typename Stream> bool op_double( Stream & stream, double & value )
+{
+    serialize_double( stream, value );
+    return true;
+}
+
+template <typename Stream> bool op_compressed_float( Stream & stream, float & value, float min, float max, float res )
+{
+    serialize_compressed_float( stream, value, min, max, res );
+    return true;
+}
+
+template <typename Stream> bool op_bytes( Stream & stream, uint8_t * data, int count )
+{
+    serialize_bytes( stream, data, count );
+    return true;
+}
+
+template <typename Stream> bool op_string( Stream & stream, char * string, int bufferSize )
+{
+    serialize_string( stream, string, bufferSize );
+    return true;
+}
+
+template <typename Stream> bool op_wstring( Stream & stream, wchar_t * string, int bufferSize )
+{
+    serialize_wstring( stream, string, bufferSize );
+    return true;
+}
+
+// ---------------------------------------------------------------------------------------
+// fixed point. Every parameter is a compile time constant of the call site, so the runner
+// carries a table of declarations and a vector naming one that is not in it FAILS rather than
+// passes. Adding a declaration to the corpus means adding a row here.
+
+template <int I, int F, int64_t Lo, int64_t Hi, typename Storage, typename Stream>
+bool op_fixed( Stream & stream, Storage & value )
+{
+    serialize_fixed( stream, value, I, F, Lo, Hi );
+    return true;
+}
+
+enum FixedDeclaration
+{
+    FIXED_NONE,
+    FIXED_Q8_8_M100_100,
+    FIXED_Q32_0_0_7,
+    FIXED_Q32_0_0_5,
+    FIXED_Q16_16_7_7,
+    FIXED_Q16_16_M32768_32767,
+    FIXED_Q48_16_0_131072,
+    FIXED_Q112_16_M9_M9,
+    FIXED_Q112_16_0_2P58,
+    FIXED_Q112_16_M2P57_2P57,
+    FIXED_Q64_64_0_0,
+    FIXED_Q64_64_3_3,
+    FIXED_Q64_64_0_INT64MAX
+};
+
+static FixedDeclaration fixed_declaration( int64_t integerBits, int64_t fractionBits, serialize::int128_t min, serialize::int128_t max )
+{
+    const serialize::int128_t two58 = serialize::int128_t( 288230376151711744LL );
+    const serialize::int128_t two57 = serialize::int128_t( 144115188075855872LL );
+    if ( integerBits == 8   && fractionBits == 8  && min == -100 && max == 100 )     return FIXED_Q8_8_M100_100;
+    if ( integerBits == 32  && fractionBits == 0  && min == 0    && max == 7 )       return FIXED_Q32_0_0_7;
+    if ( integerBits == 32  && fractionBits == 0  && min == 0    && max == 5 )       return FIXED_Q32_0_0_5;
+    if ( integerBits == 16  && fractionBits == 16 && min == 7    && max == 7 )       return FIXED_Q16_16_7_7;
+    if ( integerBits == 16  && fractionBits == 16 && min == -32768 && max == 32767 ) return FIXED_Q16_16_M32768_32767;
+    if ( integerBits == 48  && fractionBits == 16 && min == 0    && max == 131072 )  return FIXED_Q48_16_0_131072;
+    if ( integerBits == 112 && fractionBits == 16 && min == -9   && max == -9 )      return FIXED_Q112_16_M9_M9;
+    if ( integerBits == 112 && fractionBits == 16 && min == 0    && max == two58 )   return FIXED_Q112_16_0_2P58;
+    if ( integerBits == 112 && fractionBits == 16 && min == -two57 && max == two57 ) return FIXED_Q112_16_M2P57_2P57;
+    if ( integerBits == 64  && fractionBits == 64 && min == 0    && max == 0 )       return FIXED_Q64_64_0_0;
+    if ( integerBits == 64  && fractionBits == 64 && min == 3    && max == 3 )       return FIXED_Q64_64_3_3;
+    if ( integerBits == 64  && fractionBits == 64 && min == 0    && max == serialize::int128_t( 9223372036854775807LL ) ) return FIXED_Q64_64_0_INT64MAX;
+    return FIXED_NONE;
+}
+
+// The raw value travels through the runner as a 128 bit integer whatever the declaration's
+// storage width, so one code path drives every row of the table above.
+
+template <typename Stream>
+static bool run_fixed_declaration( Stream & stream, FixedDeclaration declaration, serialize::int128_t & raw )
+{
+    switch ( declaration )
+    {
+        case FIXED_Q8_8_M100_100:
+        {
+            int16_t value = (int16_t) (int64_t) raw;
+            if ( !op_fixed<8, 8, -100, 100, int16_t>( stream, value ) ) return false;
+            raw = serialize::int128_t( (int64_t) value );
+            return true;
+        }
+        case FIXED_Q32_0_0_7:
+        {
+            int32_t value = (int32_t) (int64_t) raw;
+            if ( !op_fixed<32, 0, 0, 7, int32_t>( stream, value ) ) return false;
+            raw = serialize::int128_t( (int64_t) value );
+            return true;
+        }
+        case FIXED_Q32_0_0_5:
+        {
+            int32_t value = (int32_t) (int64_t) raw;
+            if ( !op_fixed<32, 0, 0, 5, int32_t>( stream, value ) ) return false;
+            raw = serialize::int128_t( (int64_t) value );
+            return true;
+        }
+        case FIXED_Q16_16_7_7:
+        {
+            int32_t value = (int32_t) (int64_t) raw;
+            if ( !op_fixed<16, 16, 7, 7, int32_t>( stream, value ) ) return false;
+            raw = serialize::int128_t( (int64_t) value );
+            return true;
+        }
+        case FIXED_Q16_16_M32768_32767:
+        {
+            int32_t value = (int32_t) (int64_t) raw;
+            if ( !op_fixed<16, 16, -32768, 32767, int32_t>( stream, value ) ) return false;
+            raw = serialize::int128_t( (int64_t) value );
+            return true;
+        }
+        case FIXED_Q48_16_0_131072:
+        {
+            int64_t value = (int64_t) raw;
+            if ( !op_fixed<48, 16, 0, 131072, int64_t>( stream, value ) ) return false;
+            raw = serialize::int128_t( value );
+            return true;
+        }
+        case FIXED_Q112_16_M9_M9:
+        {
+            serialize::int128_t value = raw;
+            if ( !op_fixed<112, 16, -9, -9, serialize::int128_t>( stream, value ) ) return false;
+            raw = value;
+            return true;
+        }
+        case FIXED_Q112_16_0_2P58:
+        {
+            serialize::int128_t value = raw;
+            if ( !op_fixed<112, 16, 0, 288230376151711744LL, serialize::int128_t>( stream, value ) ) return false;
+            raw = value;
+            return true;
+        }
+        case FIXED_Q112_16_M2P57_2P57:
+        {
+            serialize::int128_t value = raw;
+            if ( !op_fixed<112, 16, -144115188075855872LL, 144115188075855872LL, serialize::int128_t>( stream, value ) ) return false;
+            raw = value;
+            return true;
+        }
+        case FIXED_Q64_64_0_0:
+        {
+            serialize::int128_t value = raw;
+            if ( !op_fixed<64, 64, 0, 0, serialize::int128_t>( stream, value ) ) return false;
+            raw = value;
+            return true;
+        }
+        case FIXED_Q64_64_3_3:
+        {
+            serialize::int128_t value = raw;
+            if ( !op_fixed<64, 64, 3, 3, serialize::int128_t>( stream, value ) ) return false;
+            raw = value;
+            return true;
+        }
+        case FIXED_Q64_64_0_INT64MAX:
+        {
+            serialize::int128_t value = raw;
+            if ( !op_fixed<64, 64, 0, 9223372036854775807LL, serialize::int128_t>( stream, value ) ) return false;
+            raw = value;
+            return true;
+        }
+        default:
+            return false;
     }
 }
 
-static void print_int128( const char * label, serialize::int128_t value )
+// ---------------------------------------------------------------------------------------
+// the step machine, which drives both the single operation files and the sequence files. A
+// single operation vector is a one step sequence whose step is built from the record's own
+// parameters, so there is exactly one execution path and the sequence files cannot drift away
+// from the operation files.
+
+enum StepKind
 {
-    const serialize::uint128_t bits = serialize::uint128_t( value );
-    printf( "%s0x%08X%08X%08X%08X",
-            label,
-            (unsigned int) ( uint64_t( bits >> 96 ) & 0xFFFFFFFF ),
-            (unsigned int) ( uint64_t( bits >> 64 ) & 0xFFFFFFFF ),
-            (unsigned int) ( uint64_t( bits >> 32 ) & 0xFFFFFFFF ),
-            (unsigned int) ( uint64_t( bits ) & 0xFFFFFFFF ) );
+    STEP_BITS,
+    STEP_BOOL,
+    STEP_UINT128,
+    STEP_ALIGN,
+    STEP_INT,
+    STEP_INT64,
+    STEP_INT128,
+    STEP_INT_RELATIVE,
+    STEP_FLOAT,
+    STEP_DOUBLE,
+    STEP_COMPRESSED_FLOAT,
+    STEP_BYTES,
+    STEP_STRING,
+    STEP_WSTRING,
+    STEP_FIXED,
+    STEP_OBJECT                             // opens a nested object over the steps that follow
+};
+
+struct Step
+{
+    StepKind kind;
+    int64_t width;                          // bits, count, buffer_size or preceding_bits
+    serialize::int128_t min;
+    serialize::int128_t max;
+    float fmin;
+    float fmax;
+    float fres;
+    FixedDeclaration fixedDeclaration;
+    int32_t previous;
+
+    // outputs
+    serialize::uint128_t bits;              // the decoded value, as a bit pattern where that is what is pinned
+    serialize::int128_t number;
+    bool boolean;
+    uint8_t buffer[MaxBytes + 1];
+    int bufferBytes;
+    wchar_t wbuffer[MaxBytes + 1];
+    int wbufferUnits;
+};
+
+/*
+    Runs one step against any stream. The destination sentinel rule lives at the call site: for
+    the scalar operations the caller seeds the destination and checks it afterwards, and for the
+    caller-owned buffers it does not, because STANDARD.md leaves those unspecified after a refusal.
+*/
+
+template <typename Stream> static bool run_step( Stream & stream, Step & step )
+{
+    switch ( step.kind )
+    {
+        case STEP_BITS:
+        {
+            uint64_t value = uint64_t( step.bits );
+            const bool ok = op_bits( stream, value, (int) step.width );
+            step.bits = serialize::uint128_t( value );
+            return ok;
+        }
+        case STEP_BOOL:
+            return op_bool( stream, step.boolean );
+
+        case STEP_UINT128:
+        {
+            serialize::uint128_t value = step.bits;
+            const bool ok = op_uint128( stream, value );
+            step.bits = value;
+            return ok;
+        }
+        case STEP_ALIGN:
+            return op_align( stream );
+
+        case STEP_INT:
+        {
+            int32_t value = (int32_t) (int64_t) step.number;
+            const bool ok = op_int( stream, value, (int32_t) (int64_t) step.min, (int32_t) (int64_t) step.max );
+            step.number = serialize::int128_t( (int64_t) value );
+            return ok;
+        }
+        case STEP_INT64:
+        {
+            int64_t value = (int64_t) step.number;
+            const bool ok = op_int64( stream, value, (int64_t) step.min, (int64_t) step.max );
+            step.number = serialize::int128_t( value );
+            return ok;
+        }
+        case STEP_INT128:
+        {
+            serialize::int128_t value = step.number;
+            const bool ok = op_int128( stream, value, step.min, step.max );
+            step.number = value;
+            return ok;
+        }
+        case STEP_INT_RELATIVE:
+        {
+            int32_t value = (int32_t) (int64_t) step.number;
+            const bool ok = op_int_relative( stream, step.previous, value );
+            step.number = serialize::int128_t( (int64_t) value );
+            return ok;
+        }
+        case STEP_FLOAT:
+        {
+            uint32_t pattern = (uint32_t) uint64_t( step.bits );
+            float value;
+            memcpy( &value, &pattern, 4 );
+            const bool ok = op_float( stream, value );
+            memcpy( &pattern, &value, 4 );
+            step.bits = serialize::uint128_t( uint64_t( pattern ) );
+            return ok;
+        }
+        case STEP_DOUBLE:
+        {
+            uint64_t pattern = uint64_t( step.bits );
+            double value;
+            memcpy( &value, &pattern, 8 );
+            const bool ok = op_double( stream, value );
+            memcpy( &pattern, &value, 8 );
+            step.bits = serialize::uint128_t( pattern );
+            return ok;
+        }
+        case STEP_COMPRESSED_FLOAT:
+        {
+            uint32_t pattern = (uint32_t) uint64_t( step.bits );
+            float value;
+            memcpy( &value, &pattern, 4 );
+            const bool ok = op_compressed_float( stream, value, step.fmin, step.fmax, step.fres );
+            memcpy( &pattern, &value, 4 );
+            step.bits = serialize::uint128_t( uint64_t( pattern ) );
+            return ok;
+        }
+        case STEP_BYTES:
+            return op_bytes( stream, step.buffer, (int) step.width );
+
+        case STEP_STRING:
+            return op_string( stream, (char*) step.buffer, (int) step.width );
+
+        case STEP_WSTRING:
+            return op_wstring( stream, step.wbuffer, (int) step.width );
+
+        case STEP_FIXED:
+            return run_fixed_declaration( stream, step.fixedDeclaration, step.number );
+
+        case STEP_OBJECT:
+            // nesting is driven by run_steps, which owns the step range an object wraps; a bare
+            // object step reaching here is a runner bug rather than a vector one
+            return false;
+    }
+    return false;
 }
 
-static void run_int_relative( const Vector & vector )
+// the field of a step that holds the value, which is the destination
+// "a refused primitive read must leave its destination unwritten" reaches
+
+static bool step_value_is_a_bit_pattern( StepKind kind )
 {
-    int32_t previous = 0;
-    if ( !parse_int32( vector.previous, previous ) )
-    {
-        fail( vector, "could not parse the previous parameter" );
-        return;
-    }
-
-    serialize::ReadStream stream( vector.bytes, vector.numBytes );
-
-    const int32_t sentinel = -12345;                // outside the domain, so no accepted vector can produce it
-    int32_t current = sentinel;
-    const bool accepted = conformance_int_relative( stream, previous, current );
-
-    if ( vector.refused )
-    {
-        if ( accepted )
-        {
-            fail( vector, "the read succeeded, the corpus requires refusal" );
-        }
-        else if ( current != sentinel )
-        {
-            fail( vector, "the refused read wrote to the destination" );
-        }
-        else
-        {
-            fail_unless_stream_is_terminal( vector, stream );
-        }
-        return;
-    }
-
-    if ( !accepted )
-    {
-        fail( vector, "the read was refused, the corpus requires it to be accepted" );
-        return;
-    }
-
-    int32_t expected = 0;
-    if ( !parse_int32( vector.expect, expected ) )
-    {
-        fail( vector, "could not parse the expected value" );
-        return;
-    }
-    if ( current != expected )
-    {
-        printf( "  FAIL %s: decoded %d, the corpus states %d [%s]\n", vector.name, (int) current, (int) expected, vector.file );
-        failures++;
-        return;
-    }
-    fail_on_bits_consumed( vector, stream.GetBitsProcessed() );
+    return kind == STEP_BITS || kind == STEP_UINT128 || kind == STEP_FLOAT || kind == STEP_DOUBLE || kind == STEP_COMPRESSED_FLOAT;
 }
 
-static void run_int128( const Vector & vector )
+static bool step_value_is_a_number( StepKind kind )
 {
+    return kind == STEP_INT || kind == STEP_INT64 || kind == STEP_INT128 || kind == STEP_INT_RELATIVE || kind == STEP_FIXED;
+}
+
+/*
+    STANDARD.md, "object": serialize_object invokes the object's own serialize function inline
+    and contributes NO BYTES OF ITS OWN — it is composition, not an encoding, with no framing,
+    length prefix or alignment inserted around it. A step spelled `object <n>` wraps the next n
+    steps in a nested object, so a vector can state the same operations twice, once nested and
+    once flat, and require identical bytes.
+
+    The nested object is driven through the public serialize_object macro rather than by calling
+    the steps directly, so what the vectors exercise is the composition the macro performs.
+*/
+
+template <typename Stream> static bool run_steps( Stream & stream, Step * steps, int count );
+
+static Step * g_failedStep = NULL;      // the step a run stopped on, for the destination check
+
+struct NestedObject
+{
+    Step * steps;
+    int count;
+
+    template <typename Stream> bool Serialize( Stream & stream )
+    {
+        return run_steps( stream, steps, count );
+    }
+};
+
+template <typename Stream> static bool run_nested_object( Stream & stream, NestedObject & object )
+{
+    serialize_object( stream, object );
+    return true;
+}
+
+// advances past the steps a nested object owns, so a top level walk sees one step per object
+
+static int step_span( const Step * steps, int index )
+{
+    if ( steps[index].kind == STEP_OBJECT )
+    {
+        return 1 + (int) steps[index].width;
+    }
+    return 1;
+}
+
+template <typename Stream> static bool run_steps( Stream & stream, Step * steps, int count )
+{
+    for ( int i = 0; i < count; i += step_span( steps, i ) )
+    {
+        if ( steps[i].kind == STEP_OBJECT )
+        {
+            NestedObject object;
+            object.steps = steps + i + 1;
+            object.count = (int) steps[i].width;
+            if ( !run_nested_object( stream, object ) )
+            {
+                return false;
+            }
+            continue;
+        }
+        if ( !run_step( stream, steps[i] ) )
+        {
+            g_failedStep = &steps[i];
+            return false;
+        }
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------------------
+// building steps
+
+static bool step_from_words( const Vector & vector, const char * text, Step & step )
+{
+    memset( &step, 0, sizeof( Step ) );
+    step.fixedDeclaration = FIXED_NONE;
+
+    char work[MaxLine];
+    strncpy( work, text, MaxLine - 1 );
+    work[MaxLine - 1] = '\0';
+
+    const char * words[8];
+    int numWords = 0;
+    char * cursor = work;
+    while ( *cursor && numWords < 8 )
+    {
+        while ( *cursor == ' ' || *cursor == '\t' ) cursor++;
+        if ( *cursor == '\0' ) break;
+        words[numWords++] = cursor;
+        while ( *cursor && *cursor != ' ' && *cursor != '\t' ) cursor++;
+        if ( *cursor ) *cursor++ = '\0';
+    }
+    if ( numWords == 0 )
+    {
+        return false;
+    }
+
+    serialize::int128_t a = 0;
+    serialize::int128_t b = 0;
+
+    if ( strcmp( words[0], "bits" ) == 0 && numWords == 2 && parse_number( words[1], a ) )
+    {
+        step.kind = STEP_BITS;
+        step.width = (int64_t) a;
+        return true;
+    }
+    if ( strcmp( words[0], "bool" ) == 0 && numWords == 1 )
+    {
+        step.kind = STEP_BOOL;
+        return true;
+    }
+    if ( strcmp( words[0], "object" ) == 0 && numWords == 2 && parse_number( words[1], a ) )
+    {
+        step.kind = STEP_OBJECT;
+        step.width = (int64_t) a;
+        return true;
+    }
+    if ( strcmp( words[0], "align" ) == 0 && numWords == 1 )
+    {
+        step.kind = STEP_ALIGN;
+        return true;
+    }
+    if ( strcmp( words[0], "float" ) == 0 && numWords == 1 )
+    {
+        step.kind = STEP_FLOAT;
+        return true;
+    }
+    if ( strcmp( words[0], "bytes" ) == 0 && numWords == 2 && parse_number( words[1], a ) )
+    {
+        step.kind = STEP_BYTES;
+        step.width = (int64_t) a;
+        return true;
+    }
+    if ( strcmp( words[0], "string" ) == 0 && numWords == 2 && parse_number( words[1], a ) )
+    {
+        step.kind = STEP_STRING;
+        step.width = (int64_t) a;
+        return true;
+    }
+    if ( strcmp( words[0], "wstring" ) == 0 && numWords == 2 && parse_number( words[1], a ) )
+    {
+        step.kind = STEP_WSTRING;
+        step.width = (int64_t) a;
+        return true;
+    }
+    if ( strcmp( words[0], "int" ) == 0 && numWords == 3 && parse_number( words[1], a ) && parse_number( words[2], b ) )
+    {
+        step.kind = STEP_INT;
+        step.min = a;
+        step.max = b;
+        return true;
+    }
+    if ( strcmp( words[0], "fixed" ) == 0 && numWords == 5 )
+    {
+        serialize::int128_t ib = 0, fb = 0, lo = 0, hi = 0;
+        if ( !parse_number( words[1], ib ) || !parse_number( words[2], fb ) || !parse_number( words[3], lo ) || !parse_number( words[4], hi ) )
+        {
+            return false;
+        }
+        step.kind = STEP_FIXED;
+        step.fixedDeclaration = fixed_declaration( (int64_t) ib, (int64_t) fb, lo, hi );
+        if ( step.fixedDeclaration == FIXED_NONE )
+        {
+            printf( "  FAIL %s: no runner for this fixed point declaration [%s]\n", vector.name, vector.file );
+            failures++;
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+/*
+    Builds the step list for a vector. A single operation vector becomes a one or two step
+    sequence: the operations whose interesting behaviour only exists at a non-zero bit index
+    take a `preceding_bits` parameter, which becomes a leading bits step.
+*/
+
+static bool build_steps( const Vector & vector, Step * steps, int & numSteps )
+{
+    numSteps = 0;
+
+    if ( strcmp( vector.operation, "sequence" ) == 0 )
+    {
+        for ( int i = 0; i < vector.numSteps; i++ )
+        {
+            if ( numSteps >= MaxSteps ) return false;
+            if ( !step_from_words( vector, vector.steps[i], steps[numSteps] ) ) return false;
+            numSteps++;
+        }
+        return numSteps > 0;
+    }
+
+    int64_t precedingBits = 0;
+    if ( param_int( vector, "preceding_bits", precedingBits ) && precedingBits > 0 )
+    {
+        memset( &steps[numSteps], 0, sizeof( Step ) );
+        steps[numSteps].kind = STEP_BITS;
+        steps[numSteps].width = precedingBits;
+        numSteps++;
+    }
+
+    Step & step = steps[numSteps];
+    memset( &step, 0, sizeof( Step ) );
+    step.fixedDeclaration = FIXED_NONE;
+
+    int64_t width = 0;
     serialize::int128_t min = 0;
     serialize::int128_t max = 0;
-    if ( !parse_int128( vector.min, min ) || !parse_int128( vector.max, max ) )
+
+    if ( strcmp( vector.operation, "bits" ) == 0 )
     {
-        fail( vector, "could not parse the min or max parameter" );
+        if ( !param_int( vector, "bits", width ) ) return false;
+        step.kind = STEP_BITS;
+        step.width = width;
+    }
+    else if ( strcmp( vector.operation, "bool" ) == 0 )
+    {
+        step.kind = STEP_BOOL;
+    }
+    else if ( strcmp( vector.operation, "uint128" ) == 0 )
+    {
+        step.kind = STEP_UINT128;
+    }
+    else if ( strcmp( vector.operation, "align" ) == 0 )
+    {
+        step.kind = STEP_ALIGN;
+    }
+    else if ( strcmp( vector.operation, "int" ) == 0 )
+    {
+        if ( !param_number( vector, "min", min ) || !param_number( vector, "max", max ) ) return false;
+        step.kind = STEP_INT;
+        step.min = min;
+        step.max = max;
+    }
+    else if ( strcmp( vector.operation, "int64" ) == 0 )
+    {
+        if ( !param_number( vector, "min", min ) || !param_number( vector, "max", max ) ) return false;
+        step.kind = STEP_INT64;
+        step.min = min;
+        step.max = max;
+    }
+    else if ( strcmp( vector.operation, "int128" ) == 0 )
+    {
+        if ( !param_number( vector, "min", min ) || !param_number( vector, "max", max ) ) return false;
+        step.kind = STEP_INT128;
+        step.min = min;
+        step.max = max;
+    }
+    else if ( strcmp( vector.operation, "int_relative" ) == 0 )
+    {
+        int64_t previous = 0;
+        if ( !param_int( vector, "previous", previous ) ) return false;
+        step.kind = STEP_INT_RELATIVE;
+        step.previous = (int32_t) previous;
+    }
+    else if ( strcmp( vector.operation, "float" ) == 0 )
+    {
+        step.kind = STEP_FLOAT;
+    }
+    else if ( strcmp( vector.operation, "double" ) == 0 )
+    {
+        step.kind = STEP_DOUBLE;
+    }
+    else if ( strcmp( vector.operation, "compressed_float" ) == 0 )
+    {
+        if ( !param_float( vector, "min", step.fmin ) || !param_float( vector, "max", step.fmax ) || !param_float( vector, "res", step.fres ) ) return false;
+        step.kind = STEP_COMPRESSED_FLOAT;
+    }
+    else if ( strcmp( vector.operation, "bytes" ) == 0 )
+    {
+        if ( !param_int( vector, "count", width ) ) return false;
+        step.kind = STEP_BYTES;
+        step.width = width;
+    }
+    else if ( strcmp( vector.operation, "string" ) == 0 )
+    {
+        if ( !param_int( vector, "buffer_size", width ) ) return false;
+        step.kind = STEP_STRING;
+        step.width = width;
+    }
+    else if ( strcmp( vector.operation, "wstring" ) == 0 )
+    {
+        if ( !param_int( vector, "buffer_size", width ) ) return false;
+        step.kind = STEP_WSTRING;
+        step.width = width;
+    }
+    else if ( strcmp( vector.operation, "fixed" ) == 0 )
+    {
+        int64_t integerBits = 0;
+        int64_t fractionBits = 0;
+        if ( !param_int( vector, "integer_bits", integerBits ) || !param_int( vector, "fraction_bits", fractionBits ) ) return false;
+        if ( !param_number( vector, "min", min ) || !param_number( vector, "max", max ) ) return false;
+        step.kind = STEP_FIXED;
+        step.fixedDeclaration = fixed_declaration( integerBits, fractionBits, min, max );
+        if ( step.fixedDeclaration == FIXED_NONE )
+        {
+            printf( "  FAIL %s: no runner for this fixed point declaration [%s]\n", vector.name, vector.file );
+            failures++;
+            return false;
+        }
+    }
+    else
+    {
+        return false;
+    }
+
+    numSteps++;
+    return true;
+}
+
+// ---------------------------------------------------------------------------------------
+// expectations
+
+static void bytes_to_hex( const uint8_t * data, int count, char * out, int outSize )
+{
+    int written = 0;
+    for ( int i = 0; i < count && written + 3 < outSize; i++ )
+    {
+        const char * digits = "0123456789ABCDEF";
+        if ( written > 0 ) out[written++] = ' ';
+        out[written++] = digits[( data[i] >> 4 ) & 0xF];
+        out[written++] = digits[data[i] & 0xF];
+    }
+    out[written] = '\0';
+}
+
+static void units_to_hex( const wchar_t * units, int count, char * out, int outSize )
+{
+    static const char * digits = "0123456789ABCDEF";
+    int written = 0;
+    for ( int i = 0; i < count; i++ )
+    {
+        // STANDARD.md, "wstring": each 32 bit group carries one UTF-16 CODE UNIT, and a 4 byte
+        // wchar_t platform "converts at the boundary — splits astral code points into surrogate
+        // pairs on write, recombines on read". The corpus states units, so a code point that
+        // came back recombined is split again here and both platforms compare the same text.
+        unsigned int pair[2];
+        int numUnits = 1;
+        const unsigned int codePoint = (unsigned int) units[i];
+        if ( codePoint > 0xFFFF )
+        {
+            const unsigned int offset = codePoint - 0x10000;
+            pair[0] = 0xD800 + ( offset >> 10 );
+            pair[1] = 0xDC00 + ( offset & 0x3FF );
+            numUnits = 2;
+        }
+        else
+        {
+            pair[0] = codePoint;
+        }
+        for ( int u = 0; u < numUnits; u++ )
+        {
+            if ( written + 6 >= outSize ) break;
+            if ( written > 0 ) out[written++] = ' ';
+            out[written++] = digits[( pair[u] >> 12 ) & 0xF];
+            out[written++] = digits[( pair[u] >> 8 ) & 0xF];
+            out[written++] = digits[( pair[u] >> 4 ) & 0xF];
+            out[written++] = digits[pair[u] & 0xF];
+        }
+    }
+    out[written] = '\0';
+}
+
+/*
+    A parameter this runner does not understand is a FAILURE and not a silent default: a vector
+    whose declaration is not the one being exercised proves nothing, and a corpus that grows a
+    parameter must grow a runner to read it. Each operation states the parameters it consumes.
+*/
+
+static bool operation_takes_param( const char * operation, const char * name )
+{
+    if ( strcmp( name, "step" ) == 0 )              return strcmp( operation, "sequence" ) == 0;
+    if ( strcmp( name, "preceding_bits" ) == 0 )    return strcmp( operation, "align" ) == 0 || strcmp( operation, "bytes" ) == 0;
+    if ( strcmp( name, "bits" ) == 0 )              return strcmp( operation, "bits" ) == 0;
+    if ( strcmp( name, "count" ) == 0 )             return strcmp( operation, "bytes" ) == 0;
+    if ( strcmp( name, "buffer_size" ) == 0 )       return strcmp( operation, "string" ) == 0 || strcmp( operation, "wstring" ) == 0;
+    if ( strcmp( name, "previous" ) == 0 )          return strcmp( operation, "int_relative" ) == 0;
+    if ( strcmp( name, "res" ) == 0 )               return strcmp( operation, "compressed_float" ) == 0;
+    if ( strcmp( name, "integer_bits" ) == 0 || strcmp( name, "fraction_bits" ) == 0 )
+                                                    return strcmp( operation, "fixed" ) == 0;
+    if ( strcmp( name, "min" ) == 0 || strcmp( name, "max" ) == 0 )
+    {
+        return strcmp( operation, "int" ) == 0 || strcmp( operation, "int64" ) == 0 || strcmp( operation, "int128" ) == 0
+            || strcmp( operation, "fixed" ) == 0 || strcmp( operation, "compressed_float" ) == 0;
+    }
+    return false;
+}
+
+/*
+    Renders a step's decoded value for a failure message, and decides whether it matches the
+    corpus.
+
+    Numeric values — every integer width, and the float, double and compressed_float bit
+    patterns — are compared as 128 bit PATTERNS: the step's value is taken as its two's
+    complement 128 bit form and the corpus expectation is parsed to the same form, so a
+    hexadecimal expectation and its decimal twin are one expectation, and NOTHING here goes
+    through a float. That last part is the document's requirement, not a convenience:
+    STANDARD.md says conformance vectors for float and double "must compare BIT PATTERNS, NOT
+    VALUES: NaN compares unequal to itself, -0.0 == 0.0, and a tolerance comparison cannot see a
+    quieted signaling bit, so a value-space comparison here proves nothing."
+
+    The remaining kinds have textual spellings the corpus states directly: `true` or `false`,
+    hexadecimal byte pairs for bytes and string payloads, and four digit code units for wstring.
+*/
+
+static void render_hex128( serialize::uint128_t bits, char * out )
+{
+    static const char * digits = "0123456789ABCDEF";
+    out[0] = '0';
+    out[1] = 'x';
+    for ( int i = 0; i < 32; i++ )
+    {
+        const int shift = 124 - i * 4;
+        const uint64_t nibble = uint64_t( bits >> shift ) & 0xF;
+        out[2 + i] = digits[nibble];
+    }
+    out[34] = '\0';
+}
+
+static bool step_pattern( const Step & step, serialize::uint128_t & out )
+{
+    if ( step_value_is_a_bit_pattern( step.kind ) )
+    {
+        out = step.bits;
+        return true;
+    }
+    if ( step_value_is_a_number( step.kind ) )
+    {
+        out = serialize::uint128_t( step.number );
+        return true;
+    }
+    return false;
+}
+
+static void render_step_value( const Step & step, char * out, int outSize )
+{
+    serialize::uint128_t pattern = 0;
+    if ( step_pattern( step, pattern ) )
+    {
+        render_hex128( pattern, out );
         return;
     }
 
-    serialize::ReadStream stream( vector.bytes, vector.numBytes );
+    switch ( step.kind )
+    {
+        case STEP_OBJECT:
+        case STEP_ALIGN:
+            // neither has a value of its own; for align the corpus states the padding it
+            // consumed, which a conforming read always finds zero
+            strncpy( out, "0", (size_t) outSize - 1 );
+            out[outSize - 1] = '\0';
+            return;
 
-    const serialize::int128_t sentinel = serialize::int128_t( -12345 );
-    serialize::int128_t value = sentinel;
-    const bool accepted = conformance_int128( stream, value, min, max );
+        case STEP_BOOL:
+            strncpy( out, step.boolean ? "true" : "false", (size_t) outSize - 1 );
+            out[outSize - 1] = '\0';
+            return;
 
-    if ( vector.refused )
+        case STEP_BYTES:
+            bytes_to_hex( step.buffer, (int) step.width, out, outSize );
+            return;
+
+        case STEP_STRING:
+            bytes_to_hex( step.buffer, (int) strlen( (const char*) step.buffer ), out, outSize );
+            return;
+
+        case STEP_WSTRING:
+        {
+            int units = 0;
+            while ( step.wbuffer[units] != 0 ) units++;
+            units_to_hex( step.wbuffer, units, out, outSize );
+            return;
+        }
+        default:
+            strncpy( out, "?", (size_t) outSize - 1 );
+            out[outSize - 1] = '\0';
+            return;
+    }
+}
+
+static bool expectation_matches( const Step & step, const char * expected )
+{
+    serialize::uint128_t pattern = 0;
+    if ( step_pattern( step, pattern ) )
+    {
+        serialize::int128_t wanted = 0;
+        if ( !parse_number( expected, wanted ) )
+        {
+            return false;
+        }
+        return pattern == serialize::uint128_t( wanted );
+    }
+
+    char rendered[MaxLine];
+    render_step_value( step, rendered, MaxLine );
+    return strcmp( rendered, expected ) == 0;
+}
+
+// splits an expect list into per step entries, on " | "
+
+static int split_expect( const char * text, char entries[MaxSteps][MaxLine] )
+{
+    int count = 0;
+    const char * cursor = text;
+    while ( count < MaxSteps )
+    {
+        const char * bar = strstr( cursor, "|" );
+        char piece[MaxLine];
+        if ( bar )
+        {
+            const size_t length = (size_t) ( bar - cursor );
+            memcpy( piece, cursor, length < MaxLine - 1 ? length : MaxLine - 1 );
+            piece[length < MaxLine - 1 ? length : MaxLine - 1] = '\0';
+        }
+        else
+        {
+            strncpy( piece, cursor, MaxLine - 1 );
+            piece[MaxLine - 1] = '\0';
+        }
+        char * trimmed = trim( piece );
+        strncpy( entries[count], trimmed, MaxLine - 1 );
+        entries[count][MaxLine - 1] = '\0';
+        count++;
+        if ( !bar ) break;
+        cursor = bar + 1;
+    }
+    return count;
+}
+
+// ---------------------------------------------------------------------------------------
+// running one vector
+
+static void run_reader( const Vector & vector, Step * steps, int numSteps )
+{
+    StreamBuffer buffer;
+    stream_buffer_init( buffer, vector );
+
+    serialize::ReadStream stream( buffer.data, buffer.bytes );
+
+    // the sentinel is only meaningful for the scalar operations, which is exactly where
+    // STANDARD.md's "a refused primitive read must leave its destination unwritten" reaches
+    // the sentinels must survive the narrowing this runner performs on the way to each
+    // operation's own width — 32 bits for float and for the ranged int — or a destination the
+    // library correctly left alone still reads as written
+    const serialize::uint128_t sentinelBits = serialize::uint128_t( 0xCAFEF00DULL );
+    const serialize::int128_t sentinelNumber = serialize::int128_t( -1234567 );
+    for ( int i = 0; i < numSteps; i++ )
+    {
+        steps[i].bits = sentinelBits;
+        steps[i].number = sentinelNumber;
+        steps[i].boolean = true;      // a refused bool read must leave this alone
+    }
+
+    g_failedStep = NULL;
+    const bool accepted = run_steps( stream, steps, numSteps );
+
+    if ( vector.expectKind == EXPECT_REFUSED )
     {
         if ( accepted )
         {
             fail( vector, "the read succeeded, the corpus requires refusal" );
+            return;
         }
-        else if ( !( value == sentinel ) )
+
+        // STANDARD.md, "A refused primitive read must leave its destination unwritten". The rule
+        // reaches the scalars only: a read into a caller-owned buffer — bytes, string and
+        // wstring — leaves that buffer's contents unspecified after a refusal, and the document
+        // says so in as many words, so those kinds are not checked here.
+        if ( g_failedStep )
         {
-            fail( vector, "the refused read wrote to the destination" );
+            const Step & step = *g_failedStep;
+            if ( ( step_value_is_a_bit_pattern( step.kind ) && !( step.bits == sentinelBits ) ) ||
+                 ( step_value_is_a_number( step.kind ) && !( step.number == sentinelNumber ) ) ||
+                 ( step.kind == STEP_BOOL && step.boolean != true ) )
+            {
+                fail( vector, "the refused read wrote to the destination" );
+                return;
+            }
         }
-        else
-        {
-            fail_unless_stream_is_terminal( vector, stream );
-        }
+
+        // failure is terminal: a further read on the same stream must fail too, consuming no
+        // bits and writing no destination, however many readable bits the stream still holds
+        fail_unless_stream_is_terminal( vector, stream );
         return;
     }
 
-    if ( !accepted )
+    const int failedStep = accepted ? -1 : 0;
+    if ( failedStep >= 0 )
     {
         fail( vector, "the read was refused, the corpus requires it to be accepted" );
         return;
     }
 
-    serialize::int128_t expected = 0;
-    if ( !parse_int128( vector.expect, expected ) )
+    char entries[MaxSteps][MaxLine];
+    const int numEntries = split_expect( vector.expect, entries );
+
+    // one expect entry per step, objects and aligns included, which state `-`. A leading
+    // preceding_bits step carries no expectation of its own: it exists to place the stream, and
+    // the record states only the operation under test.
+    const int offset = numSteps - numEntries;
+    if ( offset < 0 )
     {
-        fail( vector, "could not parse the expected value" );
+        fail( vector, "the expect list states more values than the vector has steps" );
         return;
     }
-    if ( !( value == expected ) )
+
+    for ( int i = 0; i < numEntries; i++ )
     {
-        printf( "  FAIL %s: decoded ", vector.name );
-        print_int128( "", value );
-        printf( ", the corpus states %s [%s]\n", vector.expect, vector.file );
+        if ( strcmp( entries[i], "-" ) == 0 )
+        {
+            continue;
+        }
+        if ( !expectation_matches( steps[offset + i], entries[i] ) )
+        {
+            char rendered[MaxLine];
+            render_step_value( steps[offset + i], rendered, MaxLine );
+            printf( "  FAIL %s: step %d decoded %s, the corpus states %s [%s]\n",
+                    vector.name, offset + i + 1, rendered, entries[i], vector.file );
+            failures++;
+            return;
+        }
+    }
+
+    if ( vector.hasConsumed && stream.GetBitsProcessed() != vector.consumed )
+    {
+        printf( "  FAIL %s: consumed %d bits, the corpus states %d [%s]\n",
+                vector.name, (int) stream.GetBitsProcessed(), (int) vector.consumed, vector.file );
+        failures++;
+    }
+}
+
+/*
+    The writer leg. A vector marked `writer = canonical` states the bytes a conforming writer
+    emits for its value, so the runner writes the decoded steps back and compares. The
+    comparison covers the whole stream, which is what pins the trailing-bits obligation: the
+    unused bits of the final byte must be zero, and a writer leaking anything into them
+    produces a byte the vector does not carry.
+*/
+
+static void run_writer( const Vector & vector, Step * steps, int numSteps )
+{
+    writerChecked++;
+
+    uint8_t scratch[MaxBytes + 64];
+    memset( scratch, SlackFill, sizeof( scratch ) );
+
+    // the bit writer stores qwords, so the buffer length must be a multiple of 8
+    const int64_t capacity = (int64_t) sizeof( scratch ) & ~(int64_t) 7;
+    serialize::WriteStream stream( scratch, capacity );
+
+    if ( !run_steps( stream, steps, numSteps ) )
+    {
+        fail( vector, "the writer refused a canonical vector" );
+        return;
+    }
+    stream.Flush();
+
+    const int64_t written = stream.GetBytesProcessed();
+    if ( written != vector.numBytes )
+    {
+        printf( "  FAIL %s: the writer emitted %d bytes, the corpus states %d [%s]\n",
+                vector.name, (int) written, vector.numBytes, vector.file );
         failures++;
         return;
     }
-    fail_on_bits_consumed( vector, stream.GetBitsProcessed() );
+    if ( written > 0 && memcmp( stream.GetData(), vector.bytes, (size_t) written ) != 0 )
+    {
+        char got[MaxLine];
+        char want[MaxLine];
+        bytes_to_hex( stream.GetData(), (int) written, got, MaxLine );
+        bytes_to_hex( vector.bytes, vector.numBytes, want, MaxLine );
+        printf( "  FAIL %s: the writer emitted %s, the corpus states %s [%s]\n",
+                vector.name, got, want, vector.file );
+        failures++;
+    }
+}
+
+/*
+    The measure leg. STANDARD.md makes a measure a BOUND and not the packet size — "it need not
+    be exact, and cannot be" — so the corpus states a floor and the check is an inequality. A
+    measure that computes alignment from a running bit index starting at zero under-counts every
+    unaligned start and falls below the floor, which is the non-conforming accounting the
+    document names.
+*/
+
+static void run_measure( const Vector & vector, Step * steps, int numSteps )
+{
+    measureChecked++;
+
+    serialize::MeasureStream stream;
+    if ( !run_steps( stream, steps, numSteps ) )
+    {
+        fail( vector, "the measure refused a step; a measure refuses nothing at runtime" );
+        return;
+    }
+
+    if ( stream.GetBitsProcessed() < vector.measureAtLeast )
+    {
+        printf( "  FAIL %s: measured %d bits, the corpus requires at least %d [%s]\n",
+                vector.name, (int) stream.GetBitsProcessed(), (int) vector.measureAtLeast, vector.file );
+        failures++;
+    }
 }
 
 static void run_vector( const Vector & vector )
 {
     checked++;
-    if ( strcmp( vector.operation, "int_relative" ) == 0 )
+
+    for ( int i = 0; i < vector.numParams; i++ )
     {
-        run_int_relative( vector );
+        if ( !operation_takes_param( vector.operation, vector.params[i].name ) )
+        {
+            printf( "  FAIL %s: no runner for parameter '%s' on operation '%s' [%s]\n",
+                    vector.name, vector.params[i].name, vector.operation, vector.file );
+            failures++;
+            return;
+        }
     }
-    else if ( strcmp( vector.operation, "int128" ) == 0 )
+    if ( vector.numSteps > 0 && strcmp( vector.operation, "sequence" ) != 0 )
     {
-        run_int128( vector );
+        fail( vector, "steps are only meaningful on a sequence" );
+        return;
     }
-    else
+
+    Step steps[MaxSteps];
+    int numSteps = 0;
+    if ( !build_steps( vector, steps, numSteps ) )
     {
         // a corpus file this runner does not know how to drive is a gap in the runner, not a pass
-        fail( vector, "no runner for this operation" );
+        fail( vector, "no runner for this operation, or for one of its parameters" );
+        return;
+    }
+
+    run_reader( vector, steps, numSteps );
+
+    if ( vector.expectKind != EXPECT_REFUSED )
+    {
+        // the reader leg leaves the decoded values in the steps, which is what the writer and
+        // the measure are handed: a canonical vector's round trip is decode then re-emit
+        if ( vector.writerCanonical )
+        {
+            run_writer( vector, steps, numSteps );
+        }
+        if ( vector.hasMeasure )
+        {
+            run_measure( vector, steps, numSteps );
+        }
     }
 }
 
@@ -395,6 +1505,10 @@ static bool run_file( const char * path )
     char line[MaxLine];
     while ( fgets( line, sizeof( line ), file ) )
     {
+        if ( line[0] == '#' )
+        {
+            continue;                   // a comment begins at the start of a line and nowhere else
+        }
         char * text = trim( line );
         if ( *text == '\0' )
         {
@@ -435,27 +1549,32 @@ static bool run_file( const char * path )
             *equals = '\0';
             const char * paramName = trim( value );
             const char * paramValue = trim( equals + 1 );
-            if ( strcmp( paramName, "previous" ) == 0 )
+            if ( strcmp( paramName, "step" ) == 0 )
             {
-                strncpy( vector.previous, paramValue, MaxLine - 1 );
+                if ( vector.numSteps >= MaxSteps )
+                {
+                    printf( "  FAIL %s: too many steps\n", path );
+                    failures++;
+                    continue;
+                }
+                strncpy( vector.steps[vector.numSteps], paramValue, MaxLine - 1 );
+                vector.numSteps++;
             }
-            else if ( strcmp( paramName, "min" ) == 0 )
+            else if ( vector.numParams < MaxParams )
             {
-                strncpy( vector.min, paramValue, MaxLine - 1 );
-            }
-            else if ( strcmp( paramName, "max" ) == 0 )
-            {
-                strncpy( vector.max, paramValue, MaxLine - 1 );
+                strncpy( vector.params[vector.numParams].name, paramName, MaxLine - 1 );
+                strncpy( vector.params[vector.numParams].value, paramValue, MaxLine - 1 );
+                vector.numParams++;
             }
             else
             {
-                printf( "  FAIL %s: no runner for parameter '%s'\n", path, paramName );
+                printf( "  FAIL %s: too many parameters\n", path );
                 failures++;
             }
         }
         else if ( strcmp( key, "bytes" ) == 0 )
         {
-            if ( !parse_bytes( value, vector ) )
+            if ( !parse_hex_bytes( value, vector.bytes, MaxBytes, vector.numBytes ) )
             {
                 printf( "  FAIL %s: malformed bytes line\n", path );
                 failures++;
@@ -465,7 +1584,7 @@ static bool run_file( const char * path )
         {
             if ( strcmp( value, "refused" ) == 0 )
             {
-                vector.refused = true;
+                vector.expectKind = EXPECT_REFUSED;
             }
             else
             {
@@ -476,6 +1595,22 @@ static bool run_file( const char * path )
                     failures++;
                     continue;
                 }
+                *equals = '\0';
+                const char * expectKey = trim( value );
+                if ( strcmp( expectKey, "bits" ) == 0 )
+                {
+                    vector.expectKind = EXPECT_BITS;
+                }
+                else if ( strcmp( expectKey, "value" ) == 0 )
+                {
+                    vector.expectKind = EXPECT_VALUE;
+                }
+                else
+                {
+                    printf( "  FAIL %s: unknown expect kind '%s'\n", path, expectKey );
+                    failures++;
+                    continue;
+                }
                 strncpy( vector.expect, trim( equals + 1 ), MaxLine - 1 );
             }
         }
@@ -483,6 +1618,21 @@ static bool run_file( const char * path )
         {
             vector.consumed = (int64_t) strtol( value, NULL, 10 );
             vector.hasConsumed = true;
+        }
+        else if ( strcmp( key, "measure_at_least" ) == 0 )
+        {
+            vector.measureAtLeast = (int64_t) strtol( value, NULL, 10 );
+            vector.hasMeasure = true;
+        }
+        else if ( strcmp( key, "writer" ) == 0 )
+        {
+            if ( strcmp( value, "canonical" ) != 0 )
+            {
+                printf( "  FAIL %s: unknown writer mode '%s'\n", path, value );
+                failures++;
+                continue;
+            }
+            vector.writerCanonical = true;
         }
         else
         {
@@ -515,7 +1665,8 @@ int main( int argc, char ** argv )
         run_file( argv[i] );
     }
 
-    printf( "%d vectors from %d file(s), %d failure(s)\n", checked, argc - 1, failures );
+    printf( "%d vectors from %d file(s): %d writer checks, %d measure checks, %d failure(s)\n",
+            checked, argc - 1, writerChecked, measureChecked, failures );
 
     if ( checked == 0 )
     {

--- a/conformance.cpp
+++ b/conformance.cpp
@@ -197,7 +197,14 @@ static bool parse_number( const char * text, serialize::int128_t & out )
     {
         return false;
     }
-    serialize::int128_t value = 0;
+
+    // The accumulation runs in the UNSIGNED domain and the sign is applied there too. The corpus
+    // states 128 bit bounds at both extremes -- the full signed range's minimum, and the unsigned
+    // maximum as a decimal -- and accumulating either of those in a signed type overflows, which
+    // is undefined behaviour rather than the wrap the value needs. Unsigned arithmetic wraps by
+    // definition, so the digits land where they should and the two's complement reading happens
+    // once, at the end.
+    serialize::uint128_t value = 0;
     if ( text[0] == '0' && ( text[1] == 'x' || text[1] == 'X' ) )
     {
         text += 2;
@@ -212,7 +219,7 @@ static bool parse_number( const char * text, serialize::int128_t & out )
             {
                 return false;
             }
-            value = value * 16 + serialize::int128_t( digit );
+            value = value * serialize::uint128_t( 16 ) + serialize::uint128_t( digit );
         }
     }
     else
@@ -223,10 +230,14 @@ static bool parse_number( const char * text, serialize::int128_t & out )
             {
                 return false;
             }
-            value = value * 10 + serialize::int128_t( *text - '0' );
+            value = value * serialize::uint128_t( 10 ) + serialize::uint128_t( *text - '0' );
         }
     }
-    out = negative ? -value : value;
+    if ( negative )
+    {
+        value = serialize::uint128_t( 0 ) - value;
+    }
+    out = serialize::int128_t( value );
     return true;
 }
 
@@ -749,7 +760,7 @@ static bool step_value_is_a_number( StepKind kind )
     the steps directly, so what the vectors exercise is the composition the macro performs.
 */
 
-template <typename Stream> static bool run_steps( Stream & stream, Step * steps, int count );
+template <typename Stream> static bool run_steps( Stream & stream, Step * steps, int count, int * stoppedAt = NULL );
 
 static Step * g_failedStep = NULL;      // the step a run stopped on, for the destination check
 
@@ -781,7 +792,7 @@ static int step_span( const Step * steps, int index )
     return 1;
 }
 
-template <typename Stream> static bool run_steps( Stream & stream, Step * steps, int count )
+template <typename Stream> static bool run_steps( Stream & stream, Step * steps, int count, int * stoppedAt )
 {
     for ( int i = 0; i < count; i += step_span( steps, i ) )
     {
@@ -792,6 +803,7 @@ template <typename Stream> static bool run_steps( Stream & stream, Step * steps,
             object.count = (int) steps[i].width;
             if ( !run_nested_object( stream, object ) )
             {
+                if ( stoppedAt ) *stoppedAt = i;
                 return false;
             }
             continue;
@@ -799,6 +811,7 @@ template <typename Stream> static bool run_steps( Stream & stream, Step * steps,
         if ( !run_step( stream, steps[i] ) )
         {
             g_failedStep = &steps[i];
+            if ( stoppedAt ) *stoppedAt = i;
             return false;
         }
     }
@@ -1291,7 +1304,8 @@ static void run_reader( const Vector & vector, Step * steps, int numSteps )
     }
 
     g_failedStep = NULL;
-    const bool accepted = run_steps( stream, steps, numSteps );
+    int stoppedAt = -1;
+    const bool accepted = run_steps( stream, steps, numSteps, &stoppedAt );
 
     if ( vector.expectKind == EXPECT_REFUSED )
     {
@@ -1317,8 +1331,25 @@ static void run_reader( const Vector & vector, Step * steps, int numSteps )
             }
         }
 
-        // failure is terminal: a further read on the same stream must fail too, consuming no
-        // bits and writing no destination, however many readable bits the stream still holds
+        // Failure is terminal, and a sequence states its own successors: every step after the
+        // failing one must fail too, however many readable bits the stream still holds. The
+        // vectors are built so a reader without the latch passes the successor, and one of them
+        // makes the successor a DEGENERATE RANGE — a read that consumes no bits and would
+        // otherwise always succeed, which is the case an implementation checking the length
+        // before the width gets wrong.
+        for ( int i = stoppedAt + step_span( steps, stoppedAt ); i < numSteps; i += step_span( steps, i ) )
+        {
+            if ( run_steps( stream, steps + i, step_span( steps, i ) ) )
+            {
+                printf( "  FAIL %s: step %d succeeded after step %d was refused; failure must be terminal [%s]\n",
+                        vector.name, i + 1, stoppedAt + 1, vector.file );
+                failures++;
+                return;
+            }
+        }
+
+        // and the same rule against a read the vector does not name, so every refused vector
+        // carries the terminality check and not only the sequences that spell a successor
         fail_unless_stream_is_terminal( vector, stream );
         return;
     }

--- a/conformance.cpp
+++ b/conformance.cpp
@@ -1501,9 +1501,13 @@ static void run_vector( const Vector & vector )
         return;
     }
 
+    const int failuresBefore = failures;
     run_reader( vector, steps, numSteps );
 
-    if ( vector.expectKind != EXPECT_REFUSED )
+    // the writer and the measure are handed the values the reader decoded, so running them after
+    // a reader failure reports a second failure about a value that was never decoded. One vector,
+    // one diagnosis.
+    if ( vector.expectKind != EXPECT_REFUSED && failures == failuresBefore )
     {
         // the reader leg leaves the decoded values in the steps, which is what the writer and
         // the measure are handed: a canonical vector's round trip is decode then re-emit

--- a/conformance/align.txt
+++ b/conformance/align.txt
@@ -1,0 +1,116 @@
+# serialize conformance vectors: serialize_align
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "align": pads with ZERO BITS until the bit index is a multiple
+# of 8, and if the stream is already aligned NOTHING is written. "Readers must
+# verify that the padding bits are zero and fail the read if they are not."
+#
+# An align at bit index 0 is a no-op, so every interesting property of this
+# operation lives at a non-zero bit index. `preceding_bits` places the stream
+# there: the reader first performs serialize_bits over that width and discards
+# the value, then performs the align under test. `consumed` counts both.
+#
+# `value` is the padding the align consumed, which STANDARD.md requires to be
+# zero on every accepted read — so every accepted vector here states 0, and
+# every refusal is a stream whose padding is not zero.
+#
+# On a `writer = canonical` vector the writer leg emits the `preceding_bits`
+# bits the reader just decoded and then performs the align, and the result must
+# be the vector's bytes: that is what pins "pads with zero bits" and "if the
+# stream is already aligned, nothing is written" on the write side.
+#
+# The align never reads past the end: the padding always lies inside the byte
+# the preceding bits are in, and a vector's stream is a whole number of bytes.
+# So the past-end rule has no vector in this file, and that is the rule's
+# absence rather than a gap.
+
+# Already aligned: nothing is consumed. An implementation that pads a whole
+# byte when the index is already a multiple of 8 runs off the end of this
+# one-byte stream and refuses it.
+
+operation align
+name align-no-op-when-already-aligned
+param preceding_bits = 8
+bytes AB
+expect value = 0
+consumed 8
+writer canonical
+
+# The strongest form of the same rule: at bit index 0 the stream is aligned, so
+# the align consumes nothing — proved from an EMPTY stream, where any read at
+# all is an error.
+
+operation align
+name align-no-op-at-bit-index-zero
+param preceding_bits = 0
+bytes
+expect value = 0
+consumed 0
+writer canonical
+
+operation align
+name align-pads-one-bit
+param preceding_bits = 7
+bytes 7F
+expect value = 0
+consumed 8
+writer canonical
+
+operation align
+name align-pads-four-bits
+param preceding_bits = 4
+bytes 0A
+expect value = 0
+consumed 8
+writer canonical
+
+operation align
+name align-pads-seven-bits
+param preceding_bits = 1
+bytes 01
+expect value = 0
+consumed 8
+writer canonical
+
+# The padding must be zero, and readers must fail the read otherwise. Each
+# refusal below shares its `preceding_bits` with an accepted vector above, so a
+# reader that refuses on the bit index rather than on the padding contents
+# fails the accepted twin.
+
+operation align
+name align-refuse-one-non-zero-pad-bit
+param preceding_bits = 7
+bytes FF
+expect refused
+
+operation align
+name align-refuse-four-non-zero-pad-bits
+param preceding_bits = 4
+bytes AA
+expect refused
+
+operation align
+name align-refuse-seven-non-zero-pad-bits
+param preceding_bits = 1
+bytes FF
+expect refused
+
+# Only the highest padding bit is set. A reader that checks the first padding
+# bit, or that tests the padding one bit at a time and stops early, accepts
+# this stream; the document requires all of the padding to be zero.
+
+operation align
+name align-refuse-only-the-highest-pad-bit-set
+param preceding_bits = 1
+bytes 81
+expect refused
+
+# Only the lowest padding bit is set — the mirror of the vector above.
+
+operation align
+name align-refuse-only-the-lowest-pad-bit-set
+param preceding_bits = 1
+bytes 03
+expect refused

--- a/conformance/bits.txt
+++ b/conformance/bits.txt
@@ -1,0 +1,180 @@
+# serialize conformance vectors: serialize_bits
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "bits": the low `bits` bits of the value, where `bits` is in
+# [1,64]. For bits <= 32 a single group; for bits > 32 the LOW 32 BITS FIRST as
+# a 32-bit group, then the remaining bits - 32 high bits. The fixed width
+# helpers serialize_uint8 / uint16 / uint32 / uint64 are aliases for exactly
+# this and carry no range information of their own, so they are covered here
+# rather than in files of their own; the vectors that stand for them say so in
+# their names.
+#
+# `bits` has no range rule: every bit pattern of the stated width is a legal
+# value, so the only refusal STANDARD.md states for this operation is reading
+# past the end of the stream ("Reader Obligations"). Every refusal vector below
+# is that rule, and each has an accepted twin over the same width so a reader
+# that refuses on the width rather than on the remaining length fails the twin.
+
+operation bits
+name bits-1-zero
+param bits = 1
+bytes 00
+expect value = 0
+consumed 1
+writer canonical
+
+operation bits
+name bits-1-one
+param bits = 1
+bytes 01
+expect value = 1
+consumed 1
+writer canonical
+
+# The low bit is the value; STANDARD.md, "Trailing bits": readers must not
+# reject a stream for the contents of the unused bits of the final byte. This
+# vector is reader-only because no conforming writer emits those bits set.
+
+operation bits
+name bits-1-reader-ignores-trailing-bits
+param bits = 1
+bytes FF
+expect value = 1
+consumed 1
+
+operation bits
+name bits-8-alias-uint8
+param bits = 8
+bytes 7F
+expect value = 127
+consumed 8
+writer canonical
+
+operation bits
+name bits-8-max
+param bits = 8
+bytes FF
+expect value = 255
+consumed 8
+writer canonical
+
+operation bits
+name bits-16-alias-uint16
+param bits = 16
+bytes 34 12
+expect value = 4660
+consumed 16
+writer canonical
+
+operation bits
+name bits-24
+param bits = 24
+bytes EF CD AB
+expect value = 11259375
+consumed 24
+writer canonical
+
+operation bits
+name bits-32-alias-uint32
+param bits = 32
+bytes EF BE AD DE
+expect value = 3735928559
+consumed 32
+writer canonical
+
+operation bits
+name bits-32-max
+param bits = 32
+bytes FF FF FF FF
+expect value = 4294967295
+consumed 32
+writer canonical
+
+# The 32/33 boundary, where the single group becomes low-32-then-high. A writer
+# that emits the high group first puts this value's single set bit in bit 0
+# instead of bit 32 and produces 01 00 00 00 00.
+
+operation bits
+name bits-33-low-group-precedes-high-group
+param bits = 33
+bytes 00 00 00 00 01
+expect value = 4294967296
+consumed 33
+writer canonical
+
+operation bits
+name bits-33-max
+param bits = 33
+bytes FF FF FF FF 01
+expect value = 8589934591
+consumed 33
+writer canonical
+
+operation bits
+name bits-64-alias-uint64
+param bits = 64
+bytes F0 DE BC 9A 78 56 34 12
+expect value = 1311768467463790320
+consumed 64
+writer canonical
+
+operation bits
+name bits-64-high-half-only
+param bits = 64
+bytes 00 00 00 00 FF FF FF FF
+expect value = 18446744069414584320
+consumed 64
+writer canonical
+
+operation bits
+name bits-64-low-half-only
+param bits = 64
+bytes FF FF FF FF 00 00 00 00
+expect value = 4294967295
+consumed 64
+writer canonical
+
+operation bits
+name bits-64-max
+param bits = 64
+bytes FF FF FF FF FF FF FF FF
+expect value = 18446744073709551615
+consumed 64
+writer canonical
+
+# Reading past the end. Each refusal states a width the stream cannot supply;
+# the accepted twin above it supplies exactly enough.
+
+operation bits
+name bits-refuse-past-end-empty-stream
+param bits = 1
+bytes
+expect refused
+
+operation bits
+name bits-refuse-past-end-16-of-8
+param bits = 16
+bytes FF
+expect refused
+
+operation bits
+name bits-accept-16-of-16
+param bits = 16
+bytes FF FF
+expect value = 65535
+consumed 16
+writer canonical
+
+operation bits
+name bits-refuse-past-end-33-of-32
+param bits = 33
+bytes FF FF FF FF
+expect refused
+
+operation bits
+name bits-refuse-past-end-64-of-56
+param bits = 64
+bytes FF FF FF FF FF FF FF
+expect refused

--- a/conformance/bool.txt
+++ b/conformance/bool.txt
@@ -1,0 +1,47 @@
+# serialize conformance vectors: serialize_bool
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "bool": one bit, 1 for true and 0 for false. There is no range
+# rule — both bit values are legal — so the only refusal STANDARD.md states for
+# this operation is reading past the end of the stream.
+
+operation bool
+name bool-false
+bytes 00
+expect value = false
+consumed 1
+writer canonical
+
+operation bool
+name bool-true
+bytes 01
+expect value = true
+consumed 1
+writer canonical
+
+# STANDARD.md, "Trailing bits": readers must not reject a stream for the
+# contents of the unused bits of the final byte, and no read operation examines
+# them. A reader that tests the whole byte rather than the low bit fails this.
+# Reader-only: no conforming writer emits those bits set.
+
+operation bool
+name bool-true-reader-ignores-trailing-bits
+bytes FF
+expect value = true
+consumed 1
+
+# Only the low bit is the value. A reader that tests the byte against zero
+# would call this true.
+
+operation bool
+name bool-false-with-higher-bits-set
+bytes FE
+expect value = false
+consumed 1
+
+operation bool
+name bool-refuse-past-end-empty-stream
+bytes
+expect refused

--- a/conformance/bytes.txt
+++ b/conformance/bytes.txt
@@ -1,0 +1,124 @@
+# serialize conformance vectors: serialize_bytes
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "bytes": ALIGNS FIRST, then writes `count` raw bytes. "The
+# alignment is part of the format, not an optimization — a reader that does not
+# align will desynchronize." `count` is not written; both sides agree on it.
+#
+# `count` may be zero, and "the alignment is performed regardless": a
+# zero-length serialize_bytes pads to the byte boundary and writes nothing
+# else. Skipping the alignment when count is zero desynchronizes every field
+# that follows, and a round-trip self-test cannot catch it because both halves
+# skip the same align — so the corpus must, and does, below.
+#
+# `preceding_bits` places the stream at a non-aligned bit index before the
+# operation, exactly as in align.txt; without it the operation's own align is
+# always a no-op and the format's load-bearing clause goes untested. `value` is
+# the decoded payload as hexadecimal byte pairs, empty for count = 0.
+#
+# Two refusal rules reach this operation: the alignment padding must be zero
+# ("align"), and reading past the end must fail ("Reader Obligations"). Note
+# that STANDARD.md leaves the buffer's contents UNSPECIFIED after a refused
+# read into a caller-owned buffer, so no vector here states anything about it.
+
+operation bytes
+name bytes-zero-count-aligned-start
+param preceding_bits = 0
+param count = 0
+bytes
+expect value =
+consumed 0
+writer canonical
+
+# The load-bearing clause: count = 0 still performs the align. Three bits of
+# value, then five bits of zero padding. An implementation that skips the align
+# when count is zero consumes 3 bits here instead of 8.
+
+operation bytes
+name bytes-zero-count-still-performs-the-align
+param preceding_bits = 3
+param count = 0
+bytes 05
+expect value =
+consumed 8
+writer canonical
+
+operation bytes
+name bytes-zero-count-refuse-non-zero-align-padding
+param preceding_bits = 3
+param count = 0
+bytes FD
+expect refused
+
+operation bytes
+name bytes-single-byte-aligned-start
+param preceding_bits = 0
+param count = 1
+bytes FF
+expect value = FF
+consumed 8
+writer canonical
+
+operation bytes
+name bytes-all-zero
+param preceding_bits = 0
+param count = 3
+bytes 00 00 00
+expect value = 00 00 00
+consumed 24
+writer canonical
+
+# The golden message's byte block.
+
+operation bytes
+name bytes-seven-bytes-aligned-start
+param preceding_bits = 0
+param count = 7
+bytes DE AD BE EF CA FE 01
+expect value = DE AD BE EF CA FE 01
+consumed 56
+writer canonical
+
+operation bytes
+name bytes-after-a-partial-byte
+param preceding_bits = 4
+param count = 2
+bytes 0A AB CD
+expect value = AB CD
+consumed 24
+writer canonical
+
+operation bytes
+name bytes-refuse-non-zero-align-padding
+param preceding_bits = 4
+param count = 2
+bytes FA AB CD
+expect refused
+
+operation bytes
+name bytes-refuse-past-end
+param preceding_bits = 0
+param count = 4
+bytes DE AD BE
+expect refused
+
+# The align lands exactly on the end of the stream and there is nothing left
+# for the payload. A reader that checks the length before aligning accepts.
+
+operation bytes
+name bytes-refuse-past-end-after-the-align
+param preceding_bits = 1
+param count = 1
+bytes 01
+expect refused
+
+operation bytes
+name bytes-accept-one-byte-after-the-align
+param preceding_bits = 1
+param count = 1
+bytes 01 5A
+expect value = 5A
+consumed 16
+writer canonical

--- a/conformance/compressed_float.txt
+++ b/conformance/compressed_float.txt
@@ -1,0 +1,322 @@
+# serialize conformance vectors: serialize_compressed_float
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "compressed_float": let delta = max - min and
+# values = delta / res, CLAMPED TO [1, 4294967040] (the largest float below
+# 2^32). Then max_integer_value = ceil( values ) and
+# bits = bits_required( 0, max_integer_value ). The high end of that clamp is
+# what keeps bits_required's 32-bit form well defined, and it is visible on the
+# wire as the field's width — the `bits-clamped` vectors below pin it.
+#
+# The reader divides the integer by max_integer_value, multiplies by delta, and
+# adds min. "The reader's arithmetic is pinned the same way" as the writer's:
+# it is float32 with EVERY STEP ROUNDING — the quotient rounds, the product
+# rounds BEFORE min is added, and the sum rounds. An implementation must not
+# widen any step to double, and must not contract the multiply and the add into
+# a fused multiply-add: fused, the decode rounds once instead of twice, and
+# whenever min is non-zero the decoded value can land one ulp away from the
+# conformant result. "Conformance vectors over a non-zero-min range must pin
+# decoded values BIT-EXACTLY — a tolerance comparison cannot see a one-ulp
+# divergence." Every expectation here is therefore `expect bits`.
+#
+# The corpus is a reader instrument and these are reader vectors. The writer's
+# own discriminating band — the between-quanta inputs and the fused-writer
+# witness 8388608.0 — is a property of the value chosen for a write, which no
+# record whose input is a byte stream can state; that gap is reported with this
+# corpus rather than papered over. What the writer side leaves on the wire IS
+# pinned here: the two declarations the document names for the integer clamp,
+# [0, 8388609] and [0, 16777215] at resolution 1, appear below as the widths
+# and accept boundaries a reader must agree with.
+#
+# The refusal rules are "Readers must reject an integer greater than
+# max_integer_value" and reading past the end. Non-finite inputs and non-finite
+# declarations are non-conforming on the WRITE side and "the read path is
+# untouched: the poison is in the declaration or the input value, never on the
+# wire, so there is nothing for a reader to refuse" — so no vector here states
+# one, and that is the document's ruling rather than a gap.
+
+# [0,10] at resolution 0.01: values = 1000 exactly, max_integer_value = 1000,
+# ten bits.
+
+operation compressed_float
+name compressed-float-zero-integer-over-0-10
+param min = 0
+param max = 10
+param res = 0.01
+bytes 00 00
+expect bits = 0x00000000
+consumed 10
+
+# The golden message's field: integer 500, which normalizes to exactly 0.5 and
+# lands exactly on a quantum, where float32, double and a fused multiply-add
+# all produce the same answer. It is the on-quantum ANCHOR and it can never
+# discriminate; it is here to keep the width and the decode honest, and the
+# vectors that can fail are below it.
+
+operation compressed_float
+name compressed-float-on-quantum-anchor-over-0-10
+param min = 0
+param max = 10
+param res = 0.01
+bytes F4 01
+expect bits = 0x40A00000
+consumed 10
+
+# Integer 1 over [0,10]: float32( 1 / 1000 ) * 10 + 0, two roundings.
+
+operation compressed_float
+name compressed-float-integer-one-over-0-10
+param min = 0
+param max = 10
+param res = 0.01
+bytes 01 00
+expect bits = 0x3C23D70B
+consumed 10
+
+operation compressed_float
+name compressed-float-accepts-max-integer-value-over-0-10
+param min = 0
+param max = 10
+param res = 0.01
+bytes E8 03
+expect bits = 0x41200000
+consumed 10
+
+operation compressed_float
+name compressed-float-refuse-integer-one-past-max-integer-value
+param min = 0
+param max = 10
+param res = 0.01
+bytes E9 03
+expect refused
+
+operation compressed_float
+name compressed-float-refuse-integer-all-ten-bits
+param min = 0
+param max = 10
+param res = 0.01
+bytes FF 03
+expect refused
+
+# A NON-ZERO min, where the reader's second rounding becomes visible: the
+# product rounds BEFORE min is added, and a fused decode lands one ulp away.
+# [-100,100] at resolution 0.01: values = 20000, fifteen bits.
+
+operation compressed_float
+name compressed-float-nonzero-min-integer-zero
+param min = -100
+param max = 100
+param res = 0.01
+bytes 00 00
+expect bits = 0xC2C80000
+consumed 15
+
+# Integer 10000 normalizes to exactly 0.5; the product is exactly 100.0 and the
+# sum is exactly +0.0. The on-quantum anchor for this declaration.
+
+operation compressed_float
+name compressed-float-nonzero-min-midpoint
+param min = -100
+param max = 100
+param res = 0.01
+bytes 10 27
+expect bits = 0x00000000
+consumed 15
+
+# Integer 384 over [-100,100]: the format's answer is 0xC2C051EC and a fused
+# reader decode is 0xC2C051EB. One ulp, invisible to any tolerance comparison,
+# and it changes the bytes a re-encode produces — which is how a fusing
+# platform breaks round-tripping with a conforming one.
+
+operation compressed_float
+name compressed-float-nonzero-min-fused-decode-differs-by-one-ulp
+param min = -100
+param max = 100
+param res = 0.01
+bytes 80 01
+expect bits = 0xC2C051EC
+consumed 15
+
+# Integer 5743 over [-100,100], the family's brute-forced off-quantum value.
+
+operation compressed_float
+name compressed-float-nonzero-min-off-quantum
+param min = -100
+param max = 100
+param res = 0.01
+bytes 6F 16
+expect bits = 0xC22A47AE
+consumed 15
+
+operation compressed_float
+name compressed-float-nonzero-min-accepts-max-integer-value
+param min = -100
+param max = 100
+param res = 0.01
+bytes 20 4E
+expect bits = 0x42C80000
+consumed 15
+
+operation compressed_float
+name compressed-float-nonzero-min-refuse-integer-one-past-max-integer-value
+param min = -100
+param max = 100
+param res = 0.01
+bytes 21 4E
+expect refused
+
+operation compressed_float
+name compressed-float-nonzero-min-refuse-integer-all-fifteen-bits
+param min = -100
+param max = 100
+param res = 0.01
+bytes FF 7F
+expect refused
+
+# The integer clamp's band, the first of the two declarations STANDARD.md names
+# (schema#109, adopted 2026-08-23): [0, 8388609] at resolution 1. Here
+# max_integer_value is 8388609 and the field is 24 bits, so codes 8388610
+# through 16777215 are expressible and every one of them is the "reader
+# rejects" class the ruling closes. The accept boundary is the largest legal
+# code and the refusal is exactly one past it.
+
+operation compressed_float
+name compressed-float-clamp-band-accepts-max-integer-value
+param min = 0
+param max = 8388609
+param res = 1
+bytes 01 00 80
+expect bits = 0x4B000001
+consumed 24
+
+operation compressed_float
+name compressed-float-clamp-band-refuse-integer-one-past-max-integer-value
+param min = 0
+param max = 8388609
+param res = 1
+bytes 02 00 80
+expect refused
+
+operation compressed_float
+name compressed-float-clamp-band-refuse-integer-all-twenty-four-bits
+param min = 0
+param max = 8388609
+param res = 1
+bytes FF FF FF
+expect refused
+
+operation compressed_float
+name compressed-float-clamp-band-integer-zero
+param min = 0
+param max = 8388609
+param res = 1
+bytes 00 00 00
+expect bits = 0x00000000
+consumed 24
+
+# The second declaration STANDARD.md names, [0, 16777215] at resolution 1 —
+# the wire-divergence class, where implementations historically disagreed about
+# the bytes because the rounded sum could exceed the field. Here
+# max_integer_value is 16777215, which is exactly the largest 24-bit code, so
+# EVERY code is legal and this declaration has no refusal vector: the rule's
+# absence rather than a gap. What it pins is the width, which is 24 and not 25.
+
+operation compressed_float
+name compressed-float-wire-divergence-band-accepts-max-integer-value
+param min = 0
+param max = 16777215
+param res = 1
+bytes FF FF FF
+expect bits = 0x4B7FFFFF
+consumed 24
+
+operation compressed_float
+name compressed-float-wire-divergence-band-integer-zero
+param min = 0
+param max = 16777215
+param res = 1
+bytes 00 00 00
+expect bits = 0x00000000
+consumed 24
+
+# The HIGH end of the values clamp, which is visible on the wire as the field's
+# width. delta is 2^33 and res is 1, so values is 8589934592 — above
+# 4294967040, so it clamps there and max_integer_value is 4294967040, giving a
+# 32-bit field. Without the clamp the width would be 34 bits and the reader
+# would consume two bits too many, so `consumed 32` is what pins the rule.
+
+operation compressed_float
+name compressed-float-values-clamped-at-the-high-end
+param min = 0
+param max = 8589934592
+param res = 1
+bytes 00 FF FF FF
+expect bits = 0x50000000
+consumed 32
+
+operation compressed_float
+name compressed-float-values-clamped-integer-zero
+param min = 0
+param max = 8589934592
+param res = 1
+bytes 00 00 00 00
+expect bits = 0x00000000
+consumed 32
+
+operation compressed_float
+name compressed-float-values-clamped-refuse-integer-one-past-max-integer-value
+param min = 0
+param max = 8589934592
+param res = 1
+bytes 01 FF FF FF
+expect refused
+
+operation compressed_float
+name compressed-float-values-clamped-refuse-integer-all-thirty-two-bits
+param min = 0
+param max = 8589934592
+param res = 1
+bytes FF FF FF FF
+expect refused
+
+# The LOW end of the values clamp: delta / res is below 1, so values clamps to
+# 1, max_integer_value is 1 and the field is a single bit. Every code is legal
+# at that width, so this declaration has no refusal vector.
+
+operation compressed_float
+name compressed-float-values-clamped-at-the-low-end-zero
+param min = 0
+param max = 1
+param res = 10
+bytes 00
+expect bits = 0x00000000
+consumed 1
+
+operation compressed_float
+name compressed-float-values-clamped-at-the-low-end-one
+param min = 0
+param max = 1
+param res = 10
+bytes 01
+expect bits = 0x3F800000
+consumed 1
+
+# Reading past the end.
+
+operation compressed_float
+name compressed-float-refuse-past-end-8-of-10
+param min = 0
+param max = 10
+param res = 0.01
+bytes FF
+expect refused
+
+operation compressed_float
+name compressed-float-refuse-past-end-empty-stream
+param min = 0
+param max = 10
+param res = 0.01
+bytes
+expect refused

--- a/conformance/compressed_float.txt
+++ b/conformance/compressed_float.txt
@@ -191,6 +191,22 @@ bytes 01 00 80
 expect bits = 0x4B000001
 consumed 24
 
+# 2^23 itself, the value STANDARD.md names as the fusion witness: "measured
+# exhaustively over [0, 16777215] at resolution 1, a fused writer moves
+# 4,194,304 inputs (every even float in the top binade), the first being 2^23
+# itself." That witness is a writer INPUT and no record whose own input is a
+# byte stream can state it, so what is pinned here is the reader's side of the
+# same band, at the same value, in both declarations the ruling names.
+
+operation compressed_float
+name compressed-float-clamp-band-fusion-witness-value
+param min = 0
+param max = 8388609
+param res = 1
+bytes 00 00 80
+expect bits = 0x4B000000
+consumed 24
+
 operation compressed_float
 name compressed-float-clamp-band-refuse-integer-one-past-max-integer-value
 param min = 0
@@ -230,6 +246,15 @@ param max = 16777215
 param res = 1
 bytes FF FF FF
 expect bits = 0x4B7FFFFF
+consumed 24
+
+operation compressed_float
+name compressed-float-wire-divergence-band-fusion-witness-value
+param min = 0
+param max = 16777215
+param res = 1
+bytes 00 00 80
+expect bits = 0x4B000000
 consumed 24
 
 operation compressed_float

--- a/conformance/double.txt
+++ b/conformance/double.txt
@@ -1,0 +1,148 @@
+# serialize conformance vectors: serialize_double
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "double": the 64 bits of the IEEE-754 double-precision
+# representation, written as one 64-bit group — which is serialize_bits over 64
+# bits, so the low 32-bit group precedes the high one and the bytes on an
+# aligned stream are the value in little-endian order.
+#
+# "Bit transparency — both directions" binds this operation exactly as it binds
+# float, and so does the comparison rule: these vectors compare BIT PATTERNS,
+# not values. Every expectation below is `expect bits`.
+#
+# There is no range rule and no refusal of any pattern, so the only refusal
+# STANDARD.md states for this operation is reading past the end.
+
+operation double
+name double-positive-zero
+bytes 00 00 00 00 00 00 00 00
+expect bits = 0x0000000000000000
+consumed 64
+writer canonical
+
+operation double
+name double-negative-zero
+bytes 00 00 00 00 00 00 00 80
+expect bits = 0x8000000000000000
+consumed 64
+writer canonical
+
+operation double
+name double-one
+bytes 00 00 00 00 00 00 F0 3F
+expect bits = 0x3FF0000000000000
+consumed 64
+writer canonical
+
+# The golden message's double field, 1/3.
+
+operation double
+name double-one-third
+bytes 55 55 55 55 55 55 D5 3F
+expect bits = 0x3FD5555555555555
+consumed 64
+writer canonical
+
+# The whole value sits in one half or the other, so an implementation that
+# writes the high 32-bit group first swaps these two vectors' bytes.
+
+operation double
+name double-low-half-only
+bytes EF CD AB 89 00 00 00 00
+expect bits = 0x0000000089ABCDEF
+consumed 64
+writer canonical
+
+operation double
+name double-high-half-only
+bytes 00 00 00 00 EF CD AB 89
+expect bits = 0x89ABCDEF00000000
+consumed 64
+writer canonical
+
+operation double
+name double-positive-infinity
+bytes 00 00 00 00 00 00 F0 7F
+expect bits = 0x7FF0000000000000
+consumed 64
+writer canonical
+
+operation double
+name double-negative-infinity
+bytes 00 00 00 00 00 00 F0 FF
+expect bits = 0xFFF0000000000000
+consumed 64
+writer canonical
+
+operation double
+name double-quiet-nan
+bytes 00 00 00 00 00 00 F8 7F
+expect bits = 0x7FF8000000000000
+consumed 64
+writer canonical
+
+# A SIGNALING NaN: the quiet bit is clear, and a reader that quiets NaNs
+# rewrites it to 0x7FF8000000000001.
+
+operation double
+name double-signaling-nan
+bytes 01 00 00 00 00 00 F0 7F
+expect bits = 0x7FF0000000000001
+consumed 64
+writer canonical
+
+operation double
+name double-nan-with-payload
+bytes 00 00 00 00 00 AD FE 7F
+expect bits = 0x7FFEAD0000000000
+consumed 64
+writer canonical
+
+operation double
+name double-negative-nan-all-payload-bits
+bytes FF FF FF FF FF FF FF FF
+expect bits = 0xFFFFFFFFFFFFFFFF
+consumed 64
+writer canonical
+
+operation double
+name double-smallest-positive-denormal
+bytes 01 00 00 00 00 00 00 00
+expect bits = 0x0000000000000001
+consumed 64
+writer canonical
+
+operation double
+name double-largest-denormal
+bytes FF FF FF FF FF FF 0F 00
+expect bits = 0x000FFFFFFFFFFFFF
+consumed 64
+writer canonical
+
+operation double
+name double-smallest-positive-normal
+bytes 00 00 00 00 00 00 10 00
+expect bits = 0x0010000000000000
+consumed 64
+writer canonical
+
+operation double
+name double-largest-finite
+bytes FF FF FF FF FF FF EF 7F
+expect bits = 0x7FEFFFFFFFFFFFFF
+consumed 64
+writer canonical
+
+# Reading past the end.
+
+operation double
+name double-refuse-past-end-56-of-64
+bytes FF FF FF FF FF FF FF
+expect refused
+
+operation double
+name double-refuse-past-end-empty-stream
+bytes
+expect refused

--- a/conformance/fixed.txt
+++ b/conformance/fixed.txt
@@ -1,0 +1,421 @@
+# serialize conformance vectors: serialize_fixed
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "fixed (Q format, ranged)": a value in an integer storage type
+# of exactly integer_bits + fraction_bits bits, the stored integer being the
+# real value scaled by 2^fraction_bits. The encoding is an offset encoding over
+# the RAW (scaled) bounds:
+#
+#     raw_min = min << fraction_bits
+#     raw_max = max << fraction_bits
+#     bits    = bit length of ( raw_max - raw_min )
+#
+# and raw_value - raw_min is written in that many bits, split into 32-bit
+# groups from least significant upward exactly as serialize_bits splits wide
+# values. With fraction_bits = 0 the operation IS a ranged integer, and for
+# storage of 64 bits or fewer the bytes are identical to serialize_int64 over
+# the raw bounds.
+#
+# `value` is the RAW stored integer, not the real value: the raw integer is
+# what the wire carries and what the round trip is exact in, and stating it
+# avoids every question of how a real value is spelled in each of the nine
+# implementations' number syntax. raw = real * 2^fraction_bits.
+#
+# All four parameters are compile-time constants of the call site, so a runner
+# supports a fixed set of declarations and a vector naming a declaration the
+# runner does not carry must FAIL rather than pass — the same contract the
+# corpus states for an operation with no runner. The declarations used here are
+# Q8.8, Q32.0, Q16.16, Q48.16, Q112.16 and Q64.64.
+#
+# The refusal rules are "Readers must check that the decoded offset is at most
+# raw_max - raw_min and fail otherwise — reject, never clamp", and reading past
+# the end.
+
+# The document's own worked example: Q8.8 over +/- 100 whole units, raw_min
+# -25600, raw range 51200, 16 bits. The golden message's bytes are C0 60, the
+# offset 0x60C0 = 24768, and the raw value -832, which is -3.25 in Q8.8.
+
+operation fixed
+name fixed-q8-8-worked-example
+param integer_bits = 8
+param fraction_bits = 8
+param min = -100
+param max = 100
+bytes C0 60
+expect value = -832
+consumed 16
+writer canonical
+
+operation fixed
+name fixed-q8-8-accepts-its-raw-minimum
+param integer_bits = 8
+param fraction_bits = 8
+param min = -100
+param max = 100
+bytes 00 00
+expect value = -25600
+consumed 16
+writer canonical
+
+operation fixed
+name fixed-q8-8-accepts-offset-equal-to-the-raw-span
+param integer_bits = 8
+param fraction_bits = 8
+param min = -100
+param max = 100
+bytes 00 C8
+expect value = 25600
+consumed 16
+writer canonical
+
+operation fixed
+name fixed-q8-8-refuse-offset-one-past-the-raw-span
+param integer_bits = 8
+param fraction_bits = 8
+param min = -100
+param max = 100
+bytes 01 C8
+expect refused
+
+operation fixed
+name fixed-q8-8-refuse-offset-all-ones
+param integer_bits = 8
+param fraction_bits = 8
+param min = -100
+param max = 100
+bytes FF FF
+expect refused
+
+# fraction_bits = 0: the operation is a ranged integer.
+
+operation fixed
+name fixed-zero-fraction-bits-is-a-ranged-int
+param integer_bits = 32
+param fraction_bits = 0
+param min = 0
+param max = 7
+bytes 05
+expect value = 5
+consumed 3
+writer canonical
+
+operation fixed
+name fixed-zero-fraction-bits-accepts-its-maximum
+param integer_bits = 32
+param fraction_bits = 0
+param min = 0
+param max = 5
+bytes 05
+expect value = 5
+consumed 3
+writer canonical
+
+operation fixed
+name fixed-zero-fraction-bits-refuse-offset-one-past-the-span
+param integer_bits = 32
+param fraction_bits = 0
+param min = 0
+param max = 5
+bytes 06
+expect refused
+
+# A degenerate range is legal and costs ZERO BITS — on every storage width.
+# STANDARD.md is explicit that the storage width must not change this: a
+# Q112.16 field over a degenerate range costs zero bits, not fraction_bits of
+# zeros. The wide rows below are the widths where the implementations
+# historically behaved four different ways.
+
+operation fixed
+name fixed-degenerate-range-q16-16
+param integer_bits = 16
+param fraction_bits = 16
+param min = 7
+param max = 7
+bytes
+expect value = 458752
+consumed 0
+writer canonical
+
+operation fixed
+name fixed-degenerate-range-q112-16-negative
+param integer_bits = 112
+param fraction_bits = 16
+param min = -9
+param max = -9
+bytes
+expect value = -589824
+consumed 0
+writer canonical
+
+operation fixed
+name fixed-degenerate-range-q64-64-zero
+param integer_bits = 64
+param fraction_bits = 64
+param min = 0
+param max = 0
+bytes
+expect value = 0
+consumed 0
+writer canonical
+
+# The strongest form: a wide raw value recovered from an EMPTY stream, so any
+# read at all is an error and a pass proves zero bits rather than
+# fraction_bits of zeros.
+
+operation fixed
+name fixed-degenerate-range-q64-64-nonzero
+param integer_bits = 64
+param fraction_bits = 64
+param min = 3
+param max = 3
+bytes
+expect value = 55340232221128654848
+consumed 0
+writer canonical
+
+# A 32-bit raw span: the last width written as a single group.
+
+operation fixed
+name fixed-q16-16-raw-span-32-bits
+param integer_bits = 16
+param fraction_bits = 16
+param min = -32768
+param max = 32767
+bytes EF BE AD DE
+expect value = 1588444911
+consumed 32
+writer canonical
+
+operation fixed
+name fixed-q16-16-accepts-offset-equal-to-the-raw-span
+param integer_bits = 16
+param fraction_bits = 16
+param min = -32768
+param max = 32767
+bytes 00 00 FF FF
+expect value = 2147418112
+consumed 32
+writer canonical
+
+operation fixed
+name fixed-q16-16-refuse-offset-one-past-the-raw-span
+param integer_bits = 16
+param fraction_bits = 16
+param min = -32768
+param max = 32767
+bytes 01 00 FF FF
+expect refused
+
+operation fixed
+name fixed-q16-16-refuse-offset-all-ones
+param integer_bits = 16
+param fraction_bits = 16
+param min = -32768
+param max = 32767
+bytes FF FF FF FF
+expect refused
+
+# A 34-bit raw span in Q48.16: two groups, 32 bits then a 2-bit remainder.
+
+operation fixed
+name fixed-q48-16-raw-span-34-bits-two-groups
+param integer_bits = 48
+param fraction_bits = 16
+param min = 0
+param max = 131072
+bytes 00 00 00 00 01
+expect value = 4294967296
+consumed 34
+writer canonical
+
+operation fixed
+name fixed-q48-16-accepts-offset-equal-to-the-raw-span
+param integer_bits = 48
+param fraction_bits = 16
+param min = 0
+param max = 131072
+bytes 00 00 00 00 02
+expect value = 8589934592
+consumed 34
+writer canonical
+
+operation fixed
+name fixed-q48-16-refuse-offset-one-past-the-raw-span
+param integer_bits = 48
+param fraction_bits = 16
+param min = 0
+param max = 131072
+bytes 01 00 00 00 02
+expect refused
+
+# A 75-bit raw span in Q112.16 — the golden message's wide field shape: two
+# full 32-bit groups from the bottom, then an 11-bit remainder on top. Each of
+# the three vectors below puts a single set bit in one group, so a decoder that
+# assembles the groups in the wrong order, or puts the remainder anywhere but
+# the most significant position, decodes the wrong value for one of them.
+
+operation fixed
+name fixed-q112-16-raw-span-75-bits-group-one
+param integer_bits = 112
+param fraction_bits = 16
+param min = 0
+param max = 288230376151711744
+bytes 00 00 00 00 01 00 00 00 00 00
+expect value = 4294967296
+consumed 75
+writer canonical
+
+operation fixed
+name fixed-q112-16-raw-span-75-bits-group-two
+param integer_bits = 112
+param fraction_bits = 16
+param min = 0
+param max = 288230376151711744
+bytes 00 00 00 00 00 00 00 00 01 00
+expect value = 18446744073709551616
+consumed 75
+writer canonical
+
+operation fixed
+name fixed-q112-16-accepts-offset-equal-to-the-raw-span
+param integer_bits = 112
+param fraction_bits = 16
+param min = 0
+param max = 288230376151711744
+bytes 00 00 00 00 00 00 00 00 00 04
+expect value = 18889465931478580854784
+consumed 75
+writer canonical
+
+operation fixed
+name fixed-q112-16-refuse-offset-one-past-the-raw-span
+param integer_bits = 112
+param fraction_bits = 16
+param min = 0
+param max = 288230376151711744
+bytes 01 00 00 00 00 00 00 00 00 04
+expect refused
+
+operation fixed
+name fixed-q112-16-refuse-offset-all-ones
+param integer_bits = 112
+param fraction_bits = 16
+param min = 0
+param max = 288230376151711744
+bytes FF FF FF FF FF FF FF FF FF 07
+expect refused
+
+# The same width with a negative raw minimum, so the offset must be added to a
+# negative raw base at 128-bit precision.
+
+operation fixed
+name fixed-q112-16-negative-raw-minimum-decodes-zero
+param integer_bits = 112
+param fraction_bits = 16
+param min = -144115188075855872
+param max = 144115188075855872
+bytes 00 00 00 00 00 00 00 00 00 02
+expect value = 0
+consumed 75
+writer canonical
+
+operation fixed
+name fixed-q112-16-negative-raw-minimum-accepts-its-minimum
+param integer_bits = 112
+param fraction_bits = 16
+param min = -144115188075855872
+param max = 144115188075855872
+bytes 00 00 00 00 00 00 00 00 00 00
+expect value = -9444732965739290427392
+consumed 75
+writer canonical
+
+# A 127-bit raw span in Q64.64 — four groups, the golden message's widest field.
+# Over a zero minimum the decoded raw value is the offset itself. The span is
+# raw_max = ( 2^63 - 1 ) << 64 = 2^127 - 2^64, whose bit length is 127 and not
+# 128: an implementation that rounds the width up to the storage width reads one
+# bit too many and every vector here goes red.
+
+operation fixed
+name fixed-q64-64-raw-span-127-bits-group-one
+param integer_bits = 64
+param fraction_bits = 64
+param min = 0
+param max = 9223372036854775807
+bytes 00 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00
+expect value = 4294967296
+consumed 127
+writer canonical
+
+operation fixed
+name fixed-q64-64-raw-span-127-bits-group-two
+param integer_bits = 64
+param fraction_bits = 64
+param min = 0
+param max = 9223372036854775807
+bytes 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00
+expect value = 18446744073709551616
+consumed 127
+writer canonical
+
+operation fixed
+name fixed-q64-64-raw-span-127-bits-group-three
+param integer_bits = 64
+param fraction_bits = 64
+param min = 0
+param max = 9223372036854775807
+bytes 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00
+expect value = 79228162514264337593543950336
+consumed 127
+writer canonical
+
+operation fixed
+name fixed-q64-64-accepts-offset-equal-to-the-raw-span
+param integer_bits = 64
+param fraction_bits = 64
+param min = 0
+param max = 9223372036854775807
+bytes 00 00 00 00 00 00 00 00 FF FF FF FF FF FF FF 7F
+expect value = 170141183460469231713240559642174554112
+consumed 127
+writer canonical
+
+operation fixed
+name fixed-q64-64-refuse-offset-one-past-the-raw-span
+param integer_bits = 64
+param fraction_bits = 64
+param min = 0
+param max = 9223372036854775807
+bytes 01 00 00 00 00 00 00 00 FF FF FF FF FF FF FF 7F
+expect refused
+
+operation fixed
+name fixed-q64-64-refuse-offset-all-ones
+param integer_bits = 64
+param fraction_bits = 64
+param min = 0
+param max = 9223372036854775807
+bytes FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF 7F
+expect refused
+
+# Reading past the end.
+
+operation fixed
+name fixed-refuse-past-end
+param integer_bits = 8
+param fraction_bits = 8
+param min = -100
+param max = 100
+bytes C0
+expect refused
+
+operation fixed
+name fixed-refuse-past-end-empty-stream
+param integer_bits = 16
+param fraction_bits = 16
+param min = -32768
+param max = 32767
+bytes
+expect refused

--- a/conformance/float.txt
+++ b/conformance/float.txt
@@ -1,0 +1,162 @@
+# serialize conformance vectors: serialize_float
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "float": the 32 bits of the IEEE-754 single-precision
+# representation, written as a 32-bit group. No conversion, no compression.
+#
+# "Bit transparency — both directions": every bit pattern is legal on the wire
+# — NaNs with any payload, signaling NaNs, infinities, negative zero, denormals
+# — and the reader reproduces the transmitted pattern exactly. It must not
+# canonicalize, quiet, flush, or refuse any of them. There is no reader
+# latitude: a reader that rejects NaN, or canonicalizes payloads, does not
+# conform.
+#
+# The document also states how these vectors must be compared: "Conformance
+# vectors for these operations must compare BIT PATTERNS, NOT VALUES: NaN
+# compares unequal to itself, -0.0 == 0.0, and a tolerance comparison cannot
+# see a quieted signaling bit, so a value-space comparison here proves
+# nothing." Every expectation below is therefore `expect bits`, and a runner
+# that compares these as floats fails the NaN rows by construction and passes
+# the negative-zero row while a canonicalizing reader is broken.
+#
+# There is no range rule and no refusal of any pattern, so the only refusal
+# STANDARD.md states for this operation is reading past the end.
+
+operation float
+name float-positive-zero
+bytes 00 00 00 00
+expect bits = 0x00000000
+consumed 32
+writer canonical
+
+# -0.0 compares EQUAL to 0.0 in value space, so only a bit comparison can see a
+# reader that canonicalizes the sign of zero.
+
+operation float
+name float-negative-zero
+bytes 00 00 00 80
+expect bits = 0x80000000
+consumed 32
+writer canonical
+
+operation float
+name float-one
+bytes 00 00 80 3F
+expect bits = 0x3F800000
+consumed 32
+writer canonical
+
+operation float
+name float-negative-one
+bytes 00 00 80 BF
+expect bits = 0xBF800000
+consumed 32
+writer canonical
+
+# The golden message's float field.
+
+operation float
+name float-pi
+bytes DB 0F 49 40
+expect bits = 0x40490FDB
+consumed 32
+writer canonical
+
+operation float
+name float-positive-infinity
+bytes 00 00 80 7F
+expect bits = 0x7F800000
+consumed 32
+writer canonical
+
+operation float
+name float-negative-infinity
+bytes 00 00 80 FF
+expect bits = 0xFF800000
+consumed 32
+writer canonical
+
+operation float
+name float-quiet-nan
+bytes 00 00 C0 7F
+expect bits = 0x7FC00000
+consumed 32
+writer canonical
+
+# A SIGNALING NaN: the quiet bit is clear. A reader that quiets NaNs — which
+# many language runtimes do on an ordinary load and store — turns this into
+# 0x7FC00001, and no tolerance comparison can see the difference.
+
+operation float
+name float-signaling-nan
+bytes 01 00 80 7F
+expect bits = 0x7F800001
+consumed 32
+writer canonical
+
+# A NaN carrying a payload. A reader that canonicalizes NaNs loses it.
+
+operation float
+name float-nan-with-payload
+bytes 00 AD DE 7F
+expect bits = 0x7FDEAD00
+consumed 32
+writer canonical
+
+operation float
+name float-negative-nan-all-payload-bits
+bytes FF FF FF FF
+expect bits = 0xFFFFFFFF
+consumed 32
+writer canonical
+
+# Denormals, which a reader that flushes subnormals to zero destroys.
+
+operation float
+name float-smallest-positive-denormal
+bytes 01 00 00 00
+expect bits = 0x00000001
+consumed 32
+writer canonical
+
+operation float
+name float-largest-denormal
+bytes FF FF 7F 00
+expect bits = 0x007FFFFF
+consumed 32
+writer canonical
+
+operation float
+name float-negative-denormal
+bytes 01 00 00 80
+expect bits = 0x80000001
+consumed 32
+writer canonical
+
+operation float
+name float-smallest-positive-normal
+bytes 00 00 80 00
+expect bits = 0x00800000
+consumed 32
+writer canonical
+
+operation float
+name float-largest-finite
+bytes FF FF 7F 7F
+expect bits = 0x7F7FFFFF
+consumed 32
+writer canonical
+
+# Reading past the end.
+
+operation float
+name float-refuse-past-end-24-of-32
+bytes 00 00 00
+expect refused
+
+operation float
+name float-refuse-past-end-empty-stream
+bytes
+expect refused

--- a/conformance/int.txt
+++ b/conformance/int.txt
@@ -1,0 +1,263 @@
+# serialize conformance vectors: serialize_int
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "int (ranged)": the width is
+#
+#     bits_required( min, max ) = ( min == max ) ? 0 : 32 - count_leading_zeros( max - min )
+#
+# and `value - min` is written in that many bits. The document names the
+# consequences and this file pins each of them: [0,7] costs 3 bits, [0,8] costs
+# 4, and a degenerate range where min == max costs ZERO BITS with the value
+# taken from the range alone.
+#
+# Two refusal rules reach this operation. "Readers must check that the decoded
+# value lies within [min,max] and fail otherwise" — in offset form, an offset
+# greater than max - min, which is expressible whenever the span is not one
+# less than a power of two. And reading past the end must fail. Every refusal
+# below carries an accepted twin one step inside the same edge, sharing the
+# declaration, so a reader that refuses on the declaration rather than on the
+# decoded value fails the twin.
+
+operation int
+name int-degenerate-range-zero-bits
+param min = 42
+param max = 42
+bytes
+expect value = 42
+consumed 0
+writer canonical
+
+operation int
+name int-degenerate-range-negative
+param min = -1000
+param max = -1000
+bytes
+expect value = -1000
+consumed 0
+writer canonical
+
+operation int
+name int-degenerate-range-at-int32-min
+param min = -2147483648
+param max = -2147483648
+bytes
+expect value = -2147483648
+consumed 0
+writer canonical
+
+# The document's own pair: [0,7] is 3 bits, [0,8] is 4. An implementation that
+# computes the width from the count of values rather than the span gets one of
+# these wrong, and the `consumed` line is what catches it.
+
+operation int
+name int-range-0-7-costs-three-bits
+param min = 0
+param max = 7
+bytes 05
+expect value = 5
+consumed 3
+writer canonical
+
+operation int
+name int-range-0-7-accepts-its-maximum
+param min = 0
+param max = 7
+bytes 07
+expect value = 7
+consumed 3
+writer canonical
+
+operation int
+name int-range-0-8-costs-four-bits
+param min = 0
+param max = 8
+bytes 08
+expect value = 8
+consumed 4
+writer canonical
+
+# [0,8] is four bits, so offsets 9 through 15 are expressible and every one of
+# them must be refused — reject, never clamp.
+
+operation int
+name int-range-0-8-refuse-offset-one-past-the-span
+param min = 0
+param max = 8
+bytes 09
+expect refused
+
+operation int
+name int-range-0-8-refuse-offset-fifteen
+param min = 0
+param max = 8
+bytes 0F
+expect refused
+
+operation int
+name int-range-0-1-single-bit-zero
+param min = 0
+param max = 1
+bytes 00
+expect value = 0
+consumed 1
+writer canonical
+
+operation int
+name int-range-0-1-single-bit-one
+param min = 0
+param max = 1
+bytes 01
+expect value = 1
+consumed 1
+writer canonical
+
+operation int
+name int-range-0-2-accepts-its-maximum
+param min = 0
+param max = 2
+bytes 02
+expect value = 2
+consumed 2
+writer canonical
+
+operation int
+name int-range-0-2-refuse-offset-three
+param min = 0
+param max = 2
+bytes 03
+expect refused
+
+# A negative min: the offset is value - min, and the reader adds min back. The
+# golden message's narrow int field.
+
+operation int
+name int-negative-min-golden-field
+param min = -100
+param max = 100
+bytes 3F
+expect value = -37
+consumed 8
+writer canonical
+
+operation int
+name int-negative-min-accepts-its-minimum
+param min = -100
+param max = 100
+bytes 00
+expect value = -100
+consumed 8
+writer canonical
+
+operation int
+name int-negative-min-accepts-its-maximum
+param min = -100
+param max = 100
+bytes C8
+expect value = 100
+consumed 8
+writer canonical
+
+operation int
+name int-negative-min-refuse-offset-one-past-the-span
+param min = -100
+param max = 100
+bytes C9
+expect refused
+
+operation int
+name int-negative-min-refuse-offset-all-ones
+param min = -100
+param max = 100
+bytes FF
+expect refused
+
+# The full int32 range is 32 bits, and every 32-bit offset is legal over it, so
+# this declaration has no refusal vector — that is the rule's absence, not a
+# gap. The span is 2^32 - 1, which a reader computing max - min in a signed
+# 32-bit type overflows; the maximum vector is where that shows.
+
+operation int
+name int-full-int32-range-golden-field
+param min = -2147483648
+param max = 2147483647
+bytes EB 32 A4 78
+expect value = -123456789
+consumed 32
+writer canonical
+
+operation int
+name int-full-int32-range-minimum
+param min = -2147483648
+param max = 2147483647
+bytes 00 00 00 00
+expect value = -2147483648
+consumed 32
+writer canonical
+
+operation int
+name int-full-int32-range-maximum
+param min = -2147483648
+param max = 2147483647
+bytes FF FF FF FF
+expect value = 2147483647
+consumed 32
+writer canonical
+
+# A 31-bit span whose maximum offset is one below the width's maximum: the
+# widest declaration in this file that can express a refusal.
+
+operation int
+name int-span-31-bits-accepts-its-maximum
+param min = 0
+param max = 2147483646
+bytes FE FF FF 7F
+expect value = 2147483646
+consumed 31
+writer canonical
+
+operation int
+name int-span-31-bits-refuse-offset-one-past-the-span
+param min = 0
+param max = 2147483646
+bytes FF FF FF 7F
+expect refused
+
+# Reading past the end. [0,1000] is 10 bits and one byte cannot supply them.
+
+operation int
+name int-refuse-past-end
+param min = 0
+param max = 1000
+bytes FF
+expect refused
+
+operation int
+name int-accept-ten-bits-of-ten
+param min = 0
+param max = 1000
+bytes E8 03
+expect value = 1000
+consumed 10
+writer canonical
+
+operation int
+name int-refuse-past-end-empty-stream
+param min = 0
+param max = 1
+bytes
+expect refused
+
+# A degenerate range consumes nothing, so it succeeds on an empty stream where
+# every other declaration fails: the same empty stream, two verdicts, decided
+# by the declaration alone.
+
+operation int
+name int-degenerate-range-accepts-the-empty-stream
+param min = 7
+param max = 7
+bytes
+expect value = 7
+consumed 0
+writer canonical

--- a/conformance/int128.txt
+++ b/conformance/int128.txt
@@ -3,6 +3,26 @@
 # The format is specified in STANDARD.md, "The vector format". Records are
 # separated by blank lines.
 #
+# STANDARD.md, "int128 (ranged)": bits_required128( min, max ) bits, with min
+# and max converted to the UNSIGNED 128-bit domain first "so a range wider than
+# 2^127 is exact rather than overflowing". The offset value - min is computed
+# in that same unsigned domain and written in 32-bit groups from least
+# significant upward — bits <= 32 is a single group, otherwise full 32-bit
+# groups from the bottom with the final group carrying the remainder, up to
+# four groups.
+#
+# Where the range fits 64 bits or fewer the bytes are identical to
+# serialize_int64 over the same bounds, so the narrow vectors below repeat
+# int64.txt's declarations deliberately: a field widened from 64 to 128 bits
+# must not change the wire.
+#
+# Do not confuse this with serialize_uint128, which is not ranged and always
+# costs a full 128 bits; that operation has its own file.
+#
+# The refusal rules are "Readers must check that the decoded offset is at most
+# max - min in the unsigned domain and fail otherwise — reject, never clamp",
+# and reading past the end.
+
 # A degenerate range is legal and costs zero bits: STANDARD.md, "int (ranged)"
 # for the rule and "int128 (ranged)" for the width. The stream is empty, the
 # reader consumes nothing, and the value comes from min. A reader that requires
@@ -15,3 +35,180 @@ param max = 1267650600228229401496703205383
 bytes
 expect value = 1267650600228229401496703205383
 consumed 0
+writer canonical
+
+operation int128
+name int128-degenerate-range-negative
+param min = -1267650600228229401496703205376
+param max = -1267650600228229401496703205376
+bytes
+expect value = -1267650600228229401496703205376
+consumed 0
+writer canonical
+
+# Narrow ranges: byte-identical to serialize_int64 over the same bounds.
+
+operation int128
+name int128-narrow-range-matches-int64
+param min = 0
+param max = 7
+bytes 05
+expect value = 5
+consumed 3
+writer canonical
+
+operation int128
+name int128-64-bit-span-matches-int64
+param min = -9223372036854775808
+param max = 9223372036854775807
+bytes 00 00 00 00 00 00 00 80
+expect value = 0
+consumed 64
+writer canonical
+
+# The library's additive pin, decoded here by the document alone: bounds of
+# +/- 2^70 span 2^71 and need 72 bits, so this load-bears the THREE-group
+# structure — 32 bits, 32 bits, then an 8-bit remainder on top. A decoder that
+# assembles the groups in the wrong order, or puts the remainder anywhere but
+# the most significant position, decodes the wrong value.
+
+operation int128
+name int128-72-bit-span-three-groups
+param min = -1180591620717411303424
+param max = 1180591620717411303424
+bytes 11 32 54 76 98 BA DC FE 3F
+expect value = -0x0123456789ABCDEF
+consumed 72
+writer canonical
+
+operation int128
+name int128-72-bit-span-accepts-its-minimum
+param min = -1180591620717411303424
+param max = 1180591620717411303424
+bytes 00 00 00 00 00 00 00 00 00
+expect value = -1180591620717411303424
+consumed 72
+writer canonical
+
+operation int128
+name int128-72-bit-span-accepts-offset-equal-to-the-span
+param min = -1180591620717411303424
+param max = 1180591620717411303424
+bytes 00 00 00 00 00 00 00 00 80
+expect value = 1180591620717411303424
+consumed 72
+writer canonical
+
+operation int128
+name int128-72-bit-span-refuse-offset-one-past-the-span
+param min = -1180591620717411303424
+param max = 1180591620717411303424
+bytes 01 00 00 00 00 00 00 00 80
+expect refused
+
+operation int128
+name int128-72-bit-span-refuse-offset-all-ones
+param min = -1180591620717411303424
+param max = 1180591620717411303424
+bytes FF FF FF FF FF FF FF FF FF
+expect refused
+
+# The full 128-bit range: the span is 2^128 - 1, which is exactly what "min and
+# max are converted to the unsigned 128-bit domain first" buys. Four groups,
+# and every 128-bit offset is legal, so this declaration has no refusal vector.
+
+operation int128
+name int128-full-range-zero
+param min = -170141183460469231731687303715884105728
+param max = 170141183460469231731687303715884105727
+bytes 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 80
+expect value = 0
+consumed 128
+writer canonical
+
+operation int128
+name int128-full-range-minimum
+param min = -170141183460469231731687303715884105728
+param max = 170141183460469231731687303715884105727
+bytes 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+expect value = -170141183460469231731687303715884105728
+consumed 128
+writer canonical
+
+operation int128
+name int128-full-range-maximum
+param min = -170141183460469231731687303715884105728
+param max = 170141183460469231731687303715884105727
+bytes FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
+expect value = 170141183460469231731687303715884105727
+consumed 128
+writer canonical
+
+# The widest declaration that can express a refusal: the span is 2^128 - 2, one
+# below the width's maximum. An implementation that computes the span in the
+# SIGNED 128-bit domain overflows here and cannot decide either vector.
+
+operation int128
+name int128-128-bit-span-accepts-its-maximum
+param min = -170141183460469231731687303715884105728
+param max = 170141183460469231731687303715884105726
+bytes FE FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
+expect value = 170141183460469231731687303715884105726
+consumed 128
+writer canonical
+
+operation int128
+name int128-128-bit-span-refuse-offset-one-past-the-span
+param min = -170141183460469231731687303715884105728
+param max = 170141183460469231731687303715884105726
+bytes FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
+expect refused
+
+# The group boundaries, one vector per group, over a zero minimum so the decoded
+# value is the offset itself. The bounds are SIGNED, so the widest declaration
+# with a zero minimum is [ 0, 2^127 - 1 ], a 127-bit span across four groups —
+# three full ones and a 31-bit remainder — and each vector puts a single set bit
+# in one group to prove that group's position in the stream.
+
+operation int128
+name int128-group-boundary-bit-32
+param min = 0
+param max = 170141183460469231731687303715884105727
+bytes 00 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00
+expect value = 4294967296
+consumed 127
+writer canonical
+
+operation int128
+name int128-group-boundary-bit-64
+param min = 0
+param max = 170141183460469231731687303715884105727
+bytes 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00
+expect value = 18446744073709551616
+consumed 127
+writer canonical
+
+operation int128
+name int128-group-boundary-bit-96
+param min = 0
+param max = 170141183460469231731687303715884105727
+bytes 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00
+expect value = 79228162514264337593543950336
+consumed 127
+writer canonical
+
+# Reading past the end. A 101-bit field cannot be read from eight bytes.
+
+operation int128
+name int128-refuse-past-end
+param min = 0
+param max = 1267650600228229401496703205376
+bytes FF FF FF FF FF FF FF FF
+expect refused
+
+operation int128
+name int128-refuse-past-end-empty-stream
+param min = 0
+param max = 1
+bytes
+expect refused

--- a/conformance/int64.txt
+++ b/conformance/int64.txt
@@ -1,0 +1,223 @@
+# serialize conformance vectors: serialize_int64
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "int64 (ranged)": the 64-bit counterpart of the ranged integer
+# and the only ranged 64-bit operation. bits_required64( min, max ) bits are
+# used; "if that is 32 or fewer, the value is written as a single group of that
+# many bits; otherwise the low 32 bits are written first, followed by the
+# remaining bits - 32 high bits."
+#
+# Do not confuse this with serialize_uint64, which is not ranged and always
+# costs a full 64 bits; that operation is covered in bits.txt, whose aliases it
+# is one of. The names are similar and the encodings are not.
+#
+# The refusal rules are the ranged integer's: a decoded value outside [min,max]
+# — in offset form an offset greater than max - min — and reading past the end.
+# The span is computed in the unsigned 64-bit domain, so the widest
+# declarations here are where an implementation that subtracts in a signed type
+# diverges.
+
+operation int64
+name int64-degenerate-range-zero-bits
+param min = 1234567890123456789
+param max = 1234567890123456789
+bytes
+expect value = 1234567890123456789
+consumed 0
+writer canonical
+
+operation int64
+name int64-degenerate-range-at-int64-min
+param min = -9223372036854775808
+param max = -9223372036854775808
+bytes
+expect value = -9223372036854775808
+consumed 0
+writer canonical
+
+# A narrow range produces the same bytes as serialize_int over the same bounds.
+
+operation int64
+name int64-narrow-range-matches-int
+param min = 0
+param max = 7
+bytes 05
+expect value = 5
+consumed 3
+writer canonical
+
+operation int64
+name int64-single-bit-range
+param min = -1
+param max = 0
+bytes 01
+expect value = 0
+consumed 1
+writer canonical
+
+# Exactly 32 bits: the last width written as a single group.
+
+operation int64
+name int64-span-exactly-32-bits-single-group
+param min = 0
+param max = 4294967295
+bytes EF BE AD DE
+expect value = 3735928559
+consumed 32
+writer canonical
+
+operation int64
+name int64-span-exactly-32-bits-accepts-its-maximum
+param min = 0
+param max = 4294967295
+bytes FF FF FF FF
+expect value = 4294967295
+consumed 32
+writer canonical
+
+# One wider: 33 bits, the first width that splits into a low 32-bit group and a
+# high remainder. The set bit lands in the high group, so an implementation
+# that writes the high group first puts it in bit 0 instead of bit 32.
+
+operation int64
+name int64-span-33-bits-low-group-precedes-high-group
+param min = 0
+param max = 4294967296
+bytes 00 00 00 00 01
+expect value = 4294967296
+consumed 33
+writer canonical
+
+# The vector above is also this declaration's accept boundary: the span is
+# 2^32, so offset 2^32 is the largest legal offset and the next one is refused.
+
+operation int64
+name int64-span-33-bits-refuse-offset-one-past-the-span
+param min = 0
+param max = 4294967296
+bytes 01 00 00 00 01
+expect refused
+
+operation int64
+name int64-span-33-bits-accepts-its-full-width
+param min = 0
+param max = 8589934591
+bytes FF FF FF FF 01
+expect value = 8589934591
+consumed 33
+writer canonical
+
+# A 42-bit span with negative bounds: 32 bits in the low group and 10 in the
+# high one, and the offset must be added to a negative raw minimum.
+
+operation int64
+name int64-span-42-bits-negative-bounds
+param min = -1099511627776
+param max = 1099511627776
+bytes 00 00 00 00 00 01
+expect value = 0
+consumed 42
+writer canonical
+
+operation int64
+name int64-span-42-bits-accepts-its-minimum
+param min = -1099511627776
+param max = 1099511627776
+bytes 00 00 00 00 00 00
+expect value = -1099511627776
+consumed 42
+writer canonical
+
+operation int64
+name int64-span-42-bits-accepts-its-maximum
+param min = -1099511627776
+param max = 1099511627776
+bytes 00 00 00 00 00 02
+expect value = 1099511627776
+consumed 42
+writer canonical
+
+operation int64
+name int64-span-42-bits-refuse-offset-one-past-the-span
+param min = -1099511627776
+param max = 1099511627776
+bytes 01 00 00 00 00 02
+expect refused
+
+# The full int64 range: the span is 2^64 - 1, so the width is 64 and every
+# 64-bit offset is legal. No refusal vector exists for this declaration, which
+# is the rule's absence rather than a gap.
+
+operation int64
+name int64-full-range-zero
+param min = -9223372036854775808
+param max = 9223372036854775807
+bytes 00 00 00 00 00 00 00 80
+expect value = 0
+consumed 64
+writer canonical
+
+operation int64
+name int64-full-range-minimum
+param min = -9223372036854775808
+param max = 9223372036854775807
+bytes 00 00 00 00 00 00 00 00
+expect value = -9223372036854775808
+consumed 64
+writer canonical
+
+operation int64
+name int64-full-range-maximum
+param min = -9223372036854775808
+param max = 9223372036854775807
+bytes FF FF FF FF FF FF FF FF
+expect value = 9223372036854775807
+consumed 64
+writer canonical
+
+# The widest declaration that can express a refusal: the span is 2^64 - 2, one
+# below the width's maximum. An implementation computing max - min in a signed
+# 64-bit type overflows here and cannot decide either vector correctly.
+
+operation int64
+name int64-span-64-bits-accepts-its-maximum
+param min = -9223372036854775808
+param max = 9223372036854775806
+bytes FE FF FF FF FF FF FF FF
+expect value = 9223372036854775806
+consumed 64
+writer canonical
+
+operation int64
+name int64-span-64-bits-refuse-offset-one-past-the-span
+param min = -9223372036854775808
+param max = 9223372036854775806
+bytes FF FF FF FF FF FF FF FF
+expect refused
+
+# Reading past the end.
+
+operation int64
+name int64-refuse-past-end-41-of-32
+param min = 0
+param max = 1099511627776
+bytes FF FF FF FF
+expect refused
+
+operation int64
+name int64-accept-41-bits-of-41
+param min = 0
+param max = 1099511627776
+bytes 00 00 00 00 00 01
+expect value = 1099511627776
+consumed 41
+writer canonical
+
+operation int64
+name int64-refuse-past-end-empty-stream
+param min = 0
+param max = 1
+bytes
+expect refused

--- a/conformance/int_relative.txt
+++ b/conformance/int_relative.txt
@@ -4,11 +4,62 @@
 # separated by blank lines. `consumed` appears on accepted reads only, because
 # after a refusal the stream position is not part of the contract.
 #
-# Every refusal here is the domain rule: STANDARD.md, "int_relative", where the
-# domain is 0 to 2^31 - 1 inclusive and reconstruction is checked in every
-# tier. Each refusal has an accept twin one step inside the domain, sharing its
-# bytes, so a reader that refuses on the bytes rather than on the reconstructed
-# value fails the twin.
+# STANDARD.md, "int_relative": a ladder of one-bit flags, each answering "does
+# it fit in this tier?", with the tier names this file uses taken from the
+# document's own table:
+#
+#     one-bit      1              —                                exactly 1
+#     bounded-3    0 1            serialize_int( d, 2, 6 )         2 – 6
+#     bounded-5    0 0 1          serialize_int( d, 7, 23 )        7 – 23
+#     bounded-9    0 0 0 1        serialize_int( d, 24, 280 )      24 – 280
+#     bounded-13   0 0 0 0 1      serialize_int( d, 281, 4377 )    281 – 4377
+#     bounded-17   0 0 0 0 0 1    serialize_int( d, 4378, 69914 )  4378 – 69914
+#     absolute     0 0 0 0 0 0    current as 32 raw bits           anything
+#
+# Three refusal rules reach this operation, and this file carries all three in
+# every tier they can occur in.
+#
+# 1. The DOMAIN and the ordering. "Every tier's reconstruction must be
+#    checked": the reader reconstructs current in a width that cannot wrap and
+#    must refuse unless current lies in 0 .. 2^31 - 1 and is strictly greater
+#    than previous. That binds in the one-bit tier, in each of the five
+#    bounded tiers, and in the absolute tier. Each refusal below has an accept
+#    twin one step inside the domain, SHARING ITS BYTES, so a reader that
+#    refuses on the bytes rather than on the reconstructed value fails the twin.
+#
+# 2. The BOUNDED PAYLOAD's own range. Each bounded tier's payload is a ranged
+#    integer whose span is not one less than a power of two, so an offset past
+#    the span is expressible in the tier's width and "readers must check that
+#    the decoded value lies within [min,max] and fail otherwise" applies inside
+#    the ladder exactly as it does anywhere else. Every bounded tier carries
+#    that refusal below, at one past the span and at the width's maximum, each
+#    beside the accepted vector that pins the span's top.
+#
+# 3. Reading PAST THE END, in the flags and in each tier's payload.
+#
+# A writer emits the FIRST tier a difference fits, so the absolute-tier vectors
+# whose difference is small are reader-only: no conforming writer produces
+# them, and marking them `writer = canonical` would demand wire the document
+# forbids. The tier-first-fit vectors carry the mark instead.
+
+# ---------------------------------------------------------------------------
+# the one-bit tier
+
+# An empty stream cannot supply even the ladder's first flag.
+
+operation int_relative
+name ladder-refuse-past-end-empty-stream
+param previous = 100
+bytes
+expect refused
+
+operation int_relative
+name one-bit-accept
+param previous = 100
+bytes 01
+expect value = 101
+consumed 1
+writer canonical
 
 operation int_relative
 name one-bit-refuse-past-domain
@@ -22,6 +73,39 @@ param previous = 2147483646
 bytes 01
 expect value = 2147483647
 consumed 1
+writer canonical
+
+# ---------------------------------------------------------------------------
+# the bounded-3 tier: payload serialize_int( d, 2, 6 ), span 4 in 3 bits, so
+# offsets 5 through 7 are expressible and must be refused
+
+operation int_relative
+name bounded-3-accept-low
+param previous = 100
+bytes 02
+expect value = 102
+consumed 5
+writer canonical
+
+operation int_relative
+name bounded-3-accept-high
+param previous = 100
+bytes 12
+expect value = 106
+consumed 5
+writer canonical
+
+operation int_relative
+name bounded-3-refuse-payload-one-past-the-span
+param previous = 100
+bytes 16
+expect refused
+
+operation int_relative
+name bounded-3-refuse-payload-all-three-bits
+param previous = 100
+bytes 1E
+expect refused
 
 operation int_relative
 name bounded-3-refuse-past-domain
@@ -35,6 +119,39 @@ param previous = 2147483645
 bytes 02
 expect value = 2147483647
 consumed 5
+writer canonical
+
+# ---------------------------------------------------------------------------
+# the bounded-5 tier: payload serialize_int( d, 7, 23 ), span 16 in 5 bits, so
+# offsets 17 through 31 are expressible and must be refused
+
+operation int_relative
+name bounded-5-accept-low
+param previous = 100
+bytes 04
+expect value = 107
+consumed 8
+writer canonical
+
+operation int_relative
+name bounded-5-accept-high
+param previous = 100
+bytes 84
+expect value = 123
+consumed 8
+writer canonical
+
+operation int_relative
+name bounded-5-refuse-payload-one-past-the-span
+param previous = 100
+bytes 8C
+expect refused
+
+operation int_relative
+name bounded-5-refuse-payload-all-five-bits
+param previous = 100
+bytes FC
+expect refused
 
 operation int_relative
 name bounded-5-refuse-past-domain
@@ -48,6 +165,39 @@ param previous = 2147483640
 bytes 04
 expect value = 2147483647
 consumed 8
+writer canonical
+
+# ---------------------------------------------------------------------------
+# the bounded-9 tier: payload serialize_int( d, 24, 280 ), span 256 in 9 bits,
+# so offsets 257 through 511 are expressible and must be refused
+
+operation int_relative
+name bounded-9-accept-low
+param previous = 100
+bytes 08 00
+expect value = 124
+consumed 13
+writer canonical
+
+operation int_relative
+name bounded-9-accept-high
+param previous = 100
+bytes 08 10
+expect value = 380
+consumed 13
+writer canonical
+
+operation int_relative
+name bounded-9-refuse-payload-one-past-the-span
+param previous = 100
+bytes 18 10
+expect refused
+
+operation int_relative
+name bounded-9-refuse-payload-all-nine-bits
+param previous = 100
+bytes F8 1F
+expect refused
 
 operation int_relative
 name bounded-9-refuse-past-domain
@@ -61,6 +211,45 @@ param previous = 2147483623
 bytes 08 00
 expect value = 2147483647
 consumed 13
+writer canonical
+
+operation int_relative
+name bounded-9-refuse-past-end-payload-truncated
+param previous = 100
+bytes 08
+expect refused
+
+# ---------------------------------------------------------------------------
+# the bounded-13 tier: payload serialize_int( d, 281, 4377 ), span 4096 in 13
+# bits, so offsets 4097 through 8191 are expressible and must be refused
+
+operation int_relative
+name bounded-13-accept-low
+param previous = 100
+bytes 10 00 00
+expect value = 381
+consumed 18
+writer canonical
+
+operation int_relative
+name bounded-13-accept-high
+param previous = 100
+bytes 10 00 02
+expect value = 4477
+consumed 18
+writer canonical
+
+operation int_relative
+name bounded-13-refuse-payload-one-past-the-span
+param previous = 100
+bytes 30 00 02
+expect refused
+
+operation int_relative
+name bounded-13-refuse-payload-all-thirteen-bits
+param previous = 100
+bytes F0 FF 03
+expect refused
 
 operation int_relative
 name bounded-13-refuse-past-domain
@@ -74,6 +263,48 @@ param previous = 2147483366
 bytes 10 00 00
 expect value = 2147483647
 consumed 18
+writer canonical
+
+operation int_relative
+name bounded-13-refuse-past-end-payload-truncated
+param previous = 100
+bytes 10 00
+expect refused
+
+# ---------------------------------------------------------------------------
+# the bounded-17 tier: payload serialize_int( d, 4378, 69914 ), span 65536 in
+# 17 bits, so offsets 65537 through 131071 are expressible and must be refused.
+# This is the tier a decoder is most likely to be missing outright, in which
+# case its flag is read as the start of the absolute form and everything after
+# it shifts.
+
+operation int_relative
+name bounded-17-accept-low
+param previous = 100
+bytes 20 00 00
+expect value = 4478
+consumed 23
+writer canonical
+
+operation int_relative
+name bounded-17-accept-high
+param previous = 100
+bytes 20 00 40
+expect value = 70014
+consumed 23
+writer canonical
+
+operation int_relative
+name bounded-17-refuse-payload-one-past-the-span
+param previous = 100
+bytes 60 00 40
+expect refused
+
+operation int_relative
+name bounded-17-refuse-payload-all-seventeen-bits
+param previous = 100
+bytes E0 FF 7F
+expect refused
 
 operation int_relative
 name bounded-17-refuse-past-domain
@@ -87,6 +318,39 @@ param previous = 2147479269
 bytes 20 00 00
 expect value = 2147483647
 consumed 23
+writer canonical
+
+operation int_relative
+name bounded-17-refuse-past-end-payload-truncated
+param previous = 100
+bytes 20 00
+expect refused
+
+# ---------------------------------------------------------------------------
+# the absolute tier. "The final tier transmits current, not the difference."
+# Its 32 raw bits are UNSIGNED, so a value with the top bit set is outside the
+# domain and must be refused; a reader that takes the group into a signed
+# sequence type first has already left the domain, and the two readings
+# disagree about the same byte sequence.
+#
+# A writer reaches this tier only when the difference exceeds 69914, so the
+# small-difference vectors here are reader-only.
+
+operation int_relative
+name absolute-accept-domain-maximum
+param previous = 100
+bytes C0 FF FF FF 1F
+expect value = 2147483647
+consumed 38
+writer canonical
+
+operation int_relative
+name absolute-accept-first-difference-past-the-last-tier
+param previous = 100
+bytes C0 5F 44 00 00
+expect value = 70015
+consumed 38
+writer canonical
 
 operation int_relative
 name absolute-refuse-not-increasing
@@ -102,6 +366,18 @@ expect value = 2147483647
 consumed 38
 
 operation int_relative
+name absolute-refuse-current-equal-to-previous
+param previous = 100
+bytes 00 19 00 00 00
+expect refused
+
+operation int_relative
+name absolute-refuse-current-below-previous
+param previous = 100
+bytes 80 0C 00 00 00
+expect refused
+
+operation int_relative
 name absolute-refuse-top-bit-set
 param previous = 100
 bytes 00 00 00 00 20
@@ -114,8 +390,8 @@ bytes C0 FF FF FF 3F
 expect refused
 
 operation int_relative
-name absolute-accept-domain-maximum
+name absolute-refuse-past-end-payload-truncated
 param previous = 100
-bytes C0 FF FF FF 1F
-expect value = 2147483647
-consumed 38
+bytes 00 00 00 00
+expect refused
+

--- a/conformance/message.txt
+++ b/conformance/message.txt
@@ -1,0 +1,48 @@
+# serialize conformance vectors: the message STANDARD.md works through
+#
+# The format is specified in STANDARD.md, "The vector format". Records use the
+# sequence spelling documented at the head of conformance/sequence.txt.
+#
+# STANDARD.md's "Worked Example" decodes a run of the library's golden message
+# field by field, and states the bytes it decodes: the 13-byte wide-string run
+#
+#     0xE3 0x21 0x00 0x00 0xC0 0x21 0x00 0x00 0x00 0x22 0x00 0x00 0x00
+#
+# then "The message then aligns and continues with four fixed point fields. The
+# first is serialize_fixed( value, 8, 8, -100, +100 ) — Q8.8, so raw_min is
+# -100 << 8 = -25600, the raw range is 51200, and the field costs 16 bits. The
+# next two bytes of the golden vector are 0xC0 0x60, which is the offset
+# 0x60C0 = 24768; adding raw_min gives a raw value of -832, which is -3.25 in
+# Q8.8 — exactly the value the golden message stores."
+#
+# That is a real multi-operation message whose every byte the document itself
+# supplies, and this file is it: a wstring, the align that follows it, and the
+# fixed point field the align makes room for. It is the cheapest way to confirm
+# an independent implementation is correct, and it is the one place in this
+# corpus where three different operations meet across an alignment boundary
+# with a byte-for-byte expectation the page prints in full.
+#
+# It is a FRAGMENT of the 112-byte golden and not the whole of it, deliberately.
+# The remaining fields' bytes appear nowhere in STANDARD.md; they exist only as
+# an array inside serialize.h, and lifting them here would put an
+# implementation's output into the corpus, which is the one thing the corpus
+# must never contain — "no checker reimplements the codec and then checks that
+# reimplementation against itself", and a vector copied off the implementation
+# it is meant to judge is the same failure wearing a different coat. Shipping
+# the full golden needs the document to print the rest of its bytes; that is
+# filed as an underdetermination rather than worked around here.
+#
+# The wide string ends at bit 99, three bits into byte 12, so the align pads
+# the remaining five bits of that byte — which is why the document's 13-byte
+# run ends in 0x00 and the fixed point field begins on byte 13.
+
+operation sequence
+name message-worked-example-wstring-align-fixed
+param step = wstring 8
+param step = align
+param step = fixed 8 8 -100 100
+bytes E3 21 00 00 C0 21 00 00 00 22 00 00 00 C0 60
+expect value = 043C 0438 0440 | - | -832
+consumed 120
+measure_at_least 122
+writer canonical

--- a/conformance/object.txt
+++ b/conformance/object.txt
@@ -1,0 +1,114 @@
+# serialize conformance vectors: serialize_object
+#
+# The format is specified in STANDARD.md, "The vector format". Records use the
+# sequence spelling documented at the head of conformance/sequence.txt, with one
+# addition: a step spelled `object <n>` wraps the NEXT n steps in a nested
+# object, and states `-` in the expect list because it produces no value of its
+# own.
+#
+# STANDARD.md, "object": serialize_object "invokes the object's own serialize
+# function inline. It contributes NO BYTES OF ITS OWN — it is composition, not
+# an encoding. Whatever the nested object writes appears at exactly this
+# position in the stream, with no framing, length prefix, or alignment inserted
+# around it."
+#
+# That rule is a statement about two streams being the same, so every vector
+# here has a twin in sequence.txt or below it carrying the same operations
+# unnested: same bytes, same consumption, same values. An implementation that
+# inserts a length, a tag or an alignment around a nested object produces
+# different bytes for the nested vector than for its flat twin, and one of the
+# pair goes red.
+#
+# The operation has no refusal rule of its own — it consumes nothing and decides
+# nothing — so the refusals below are the nested operations' own, and what they
+# pin is that a refusal inside a nested object propagates out of it rather than
+# being swallowed by the composition.
+
+# The flat twin, for comparison: four bits, a bool, then a byte.
+
+operation sequence
+name object-flat-twin
+param step = bits 4
+param step = bool
+param step = bits 8
+bytes 5A 0D
+expect value = 10 | true | 106
+consumed 13
+writer canonical
+
+# The same three operations, all three inside one nested object. Identical bytes
+# and identical consumption: the object added nothing.
+
+operation sequence
+name object-adds-no-bytes-of-its-own
+param step = object 3
+param step = bits 4
+param step = bool
+param step = bits 8
+bytes 5A 0D
+expect value = - | 10 | true | 106
+consumed 13
+writer canonical
+
+# The nested object in the middle of a stream, with operations before and after
+# it, so a framing byte would show up between them rather than at an end.
+
+operation sequence
+name object-nested-in-the-middle-of-a-stream
+param step = bits 4
+param step = object 1
+param step = bool
+param step = bits 8
+bytes 5A 0D
+expect value = 10 | - | true | 106
+consumed 13
+writer canonical
+
+# No alignment is inserted around a nested object. The object here holds a
+# single 3-bit field and is followed by a byte-aligned operation; if the
+# composition aligned on entry or exit, the bytes would move.
+
+operation sequence
+name object-inserts-no-alignment
+param step = object 1
+param step = bits 3
+param step = bits 8
+bytes 05 00
+expect value = - | 5 | 0
+consumed 11
+writer canonical
+
+# An object containing an operation that itself aligns: the align belongs to the
+# nested operation and lands where the nested operation puts it, not at the
+# object boundary.
+
+operation sequence
+name object-containing-an-aligning-operation
+param step = bits 3
+param step = object 1
+param step = bytes 1
+bytes 05 AB
+expect value = 5 | - | AB
+consumed 16
+measure_at_least 18
+writer canonical
+
+# A refusal inside a nested object propagates out of it. The nested align finds
+# non-zero padding, and the read must fail — the composition must not swallow
+# the refusal, and the operation after the object must refuse too.
+
+operation sequence
+name object-refusal-propagates-out-of-the-nesting
+param step = bits 3
+param step = object 1
+param step = align
+param step = bits 8
+bytes FD AB
+expect refused
+
+operation sequence
+name object-refusal-past-the-end-propagates
+param step = object 1
+param step = bits 16
+bytes FF
+expect refused

--- a/conformance/sequence.txt
+++ b/conformance/sequence.txt
@@ -1,0 +1,199 @@
+# serialize conformance vectors: sequences of operations
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# Every other file in this corpus tests one operation in isolation, from bit
+# index zero. That misses everything the format says about operations meeting
+# each other: alignment cost depends on the bit index the previous operation
+# left behind, a zero-bit field must leave the index exactly where it found it,
+# and a refusal must poison the stream for everything after it. Those are
+# rules STANDARD.md states and a single-operation record cannot express, so
+# they live here.
+#
+# A sequence record's steps are given as repeated `param step` lines, one
+# operation each, in order. The step spellings are:
+#
+#     bits <n>                                       bool
+#     align                                          float
+#     bytes <count>                                  int <min> <max>
+#     string <buffer_size>                           wstring <buffer_size>
+#     fixed <integer_bits> <fraction_bits> <min> <max>
+#
+# `expect value` lists one entry per step in order, separated by ` | `, with
+# `-` for a step that produces no value of its own. `consumed` is the total
+# for the whole sequence.
+#
+# `expect refused` means the sequence must be refused, and it carries the
+# TERMINAL FAILURE rule with it: STANDARD.md says "nothing after a failing
+# operation has a defined position, so nothing after it is interpretable, and
+# it must be the stream that enforces that rather than the caller's
+# discipline", so a runner must check not only that the failing step refuses
+# but that EVERY LATER STEP REFUSES TOO — even where the stream still holds
+# bytes those steps could have read. The refusing sequences below are built so
+# that a reader without the latch passes the failing step's successor.
+#
+# `measure_at_least` states the smallest number of bits a conforming measure
+# may report for the sequence, and a measure must report at least it. It is a
+# FLOOR and not an equality, because STANDARD.md makes a measure a bound and
+# not the packet size: "a measure must report a size sufficient to serialize
+# the message at any starting bit position. It need not be exact, and cannot
+# be." Each floor below is the true worst case over every starting bit
+# position — exact width for every operation, plus the most an alignment can
+# cost where the sequence contains one — so an implementation charging the
+# document's expected 7 bits per alignment-performing operation passes, and so
+# does a tighter correct bound, while the non-conforming exact-from-zero
+# accounting the document names fails.
+
+# The document's own measure example, verbatim: "{ bits(8); align; bits(8) } is
+# 16 bits — 2 bytes — written from an aligned start, where the align is a
+# no-op; written from bit offset 1, the align pads 7 bits and the message spans
+# 23 bits — 3 bytes of room needed. The exact-from-zero answer of 2 bytes is
+# not sufficient at every starting position, which is the one thing a measure
+# is for. The conservative answer — 8 + 7 + 8 = 23 bits — is sufficient
+# everywhere." A measure reporting 16 fails this record and a measure
+# reporting 23 passes it.
+
+operation sequence
+name sequence-measure-worked-example
+param step = bits 8
+param step = align
+param step = bits 8
+bytes AB CD
+expect value = 171 | - | 205
+consumed 16
+measure_at_least 23
+writer canonical
+
+# The align actually pads here, because the preceding operation left the index
+# at bit 3. Read consumption and measure floor differ, which is the point.
+
+operation sequence
+name sequence-align-pads-after-an-odd-width
+param step = bits 3
+param step = align
+param step = bits 8
+bytes 05 AB
+expect value = 5 | - | 171
+consumed 16
+measure_at_least 18
+writer canonical
+
+# The same stream with the padding set. The align refuses, and the bits(8)
+# after it must refuse as well although byte 1 is present and readable — that
+# is the terminal-failure rule, and a reader whose failure does not latch
+# decodes 171 from the third step.
+
+operation sequence
+name sequence-refusal-is-terminal-after-bad-alignment
+param step = bits 3
+param step = align
+param step = bits 8
+bytes FD AB
+expect refused
+
+# A second align costs nothing, because the first one left the stream aligned.
+
+operation sequence
+name sequence-second-align-is-a-no-op
+param step = bits 1
+param step = align
+param step = align
+param step = bits 8
+bytes 01 AB
+expect value = 1 | - | - | 171
+consumed 16
+measure_at_least 16
+writer canonical
+
+# serialize_bytes aligns first, so it realigns a stream left mid-byte — and it
+# is that align, not the payload, that the measure floor charges for.
+
+operation sequence
+name sequence-bytes-realigns-a-mid-byte-stream
+param step = bits 5
+param step = bytes 2
+bytes 15 AB CD
+expect value = 21 | AB CD
+consumed 24
+measure_at_least 28
+writer canonical
+
+# A degenerate range costs zero bits, so the second wide field must begin at
+# bit 32 exactly. An implementation that charges any bits at all for the
+# degenerate int shifts every bit after it and decodes the wrong second value.
+
+operation sequence
+name sequence-zero-bit-field-between-wide-ones
+param step = bits 32
+param step = int 5 5
+param step = bits 32
+bytes EF BE AD DE 78 56 34 12
+expect value = 3735928559 | 5 | 305419896
+consumed 64
+measure_at_least 64
+writer canonical
+
+# The narrow string aligns and the wide string does not, in one stream: the
+# string ends byte-aligned at bit 32, and the wstring's three-bit length field
+# then puts its single character at bit 35. An implementation that mirrors the
+# narrow path in the wide one moves every byte from index 4 onward.
+
+operation sequence
+name sequence-string-aligns-and-wstring-does-not
+param step = string 16
+param step = wstring 8
+bytes 03 61 62 63 09 02 00 00 00
+expect value = 61 62 63 | 0041
+consumed 67
+measure_at_least 70
+writer canonical
+
+# float is bit-transparent at any bit index, and nothing aligns around it: the
+# bool before it leaves the stream at bit 1 and the 32-bit group runs from
+# there to bit 33.
+
+operation sequence
+name sequence-float-unaligned-between-bools
+param step = bool
+param step = float
+param step = bool
+bytes 01 00 00 7F 02
+expect value = true | 0x3F800000 | true
+consumed 34
+measure_at_least 34
+writer canonical
+
+# Terminal failure after a RANGE refusal rather than an alignment one. The
+# ranged int over [0,8] is four bits and the stream carries offset 9, which
+# must be refused; the bits(8) after it must refuse too, although twelve
+# readable bits remain.
+
+operation sequence
+name sequence-refusal-is-terminal-after-a-range-refusal
+param step = int 0 8
+param step = bits 8
+bytes 09 AB
+expect refused
+
+# Terminal failure after a PAST-END refusal, with a zero-bit operation as the
+# successor: a degenerate range consumes nothing and would otherwise always
+# succeed, so this is the vector a reader that treats "consumes no bits" as
+# "cannot fail" gets wrong.
+
+operation sequence
+name sequence-refusal-is-terminal-before-a-zero-bit-field
+param step = bits 16
+param step = int 7 7
+bytes FF
+expect refused
+
+# Terminal failure inside a composite: the string's payload runs past the end,
+# and the wstring after it must refuse rather than resynchronize.
+
+operation sequence
+name sequence-refusal-is-terminal-after-a-string-refusal
+param step = string 16
+param step = wstring 8
+bytes 06 67 6F 6C
+expect refused

--- a/conformance/string.txt
+++ b/conformance/string.txt
@@ -1,0 +1,340 @@
+# serialize conformance vectors: serialize_string
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "string": a null-terminated narrow string, written as
+#
+#   1. the length, as serialize_int( length, 0, buffer_size - 1 ) — so the bit
+#      cost depends on buffer_size, which both sides must agree on;
+#   2. the characters, as serialize_bytes — WHICH ALIGNS.
+#
+# The terminator is not transmitted; the reader appends it. Because
+# buffer_size is an operand rather than a transmitted value, the same string
+# serialized against different buffer sizes produces different bytes, and the
+# vectors below pin three buffer sizes for that reason.
+#
+# `value` is the transmitted payload as hexadecimal byte pairs, empty for the
+# empty string. Spelling it as bytes rather than as text keeps this file pure
+# ASCII and keeps the expectation free of any question about how each of the
+# nine implementations quotes a string.
+#
+# Four refusal rules reach this operation:
+#
+#   * the length field's own range rule, when buffer_size - 1 is not one less
+#     than a power of two, so a length past the buffer is expressible;
+#   * the alignment padding must be zero, inherited from serialize_bytes;
+#   * INVALID UTF-8 fails the read — "the payload the contract above promises
+#     is the payload the reader insists on";
+#   * an INTERIOR NUL fails the read — a zero byte anywhere among the length
+#     transmitted bytes, which "gives the payload two lengths" and is its own
+#     rule because NUL is well-formed UTF-8;
+#
+# and reading past the end. Every UTF-8 refusal below is paired with the
+# nearest well-formed accept, so a reader that refuses a whole byte class
+# rather than the malformed sequence fails the twin.
+#
+# STANDARD.md leaves the buffer's contents UNSPECIFIED after a refused read
+# into a caller-owned buffer, so no vector here states anything about it.
+
+# buffer_size 16: the length field is bits_required( 0, 15 ) = 4 bits, then
+# four bits of alignment padding, so the payload starts at byte 1.
+
+operation string
+name string-golden
+param buffer_size = 16
+bytes 06 67 6F 6C 64 65 6E
+expect value = 67 6F 6C 64 65 6E
+consumed 56
+writer canonical
+
+# The empty string reaches serialize_bytes with count zero, which "pads to the
+# byte boundary and writes nothing else". The align is performed regardless: an
+# implementation that skips it when the payload is empty consumes 4 bits here
+# instead of 8 and desynchronizes everything after it.
+
+operation string
+name string-empty-still-performs-the-align
+param buffer_size = 16
+bytes 00
+expect value =
+consumed 8
+writer canonical
+
+operation string
+name string-single-byte
+param buffer_size = 16
+bytes 01 41
+expect value = 41
+consumed 16
+writer canonical
+
+operation string
+name string-fills-the-buffer
+param buffer_size = 16
+bytes 0F 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F
+expect value = 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F
+consumed 128
+writer canonical
+
+# buffer_size 8: a three-bit length field, so the same payload produces
+# different bytes than it does above. The alignment absorbs five bits here
+# instead of four, and the payload still starts at byte 1.
+
+operation string
+name string-buffer-size-8-three-bit-length
+param buffer_size = 8
+bytes 04 74 65 73 74
+expect value = 74 65 73 74
+consumed 40
+writer canonical
+
+# buffer_size 1: the length field is serialize_int( length, 0, 0 ), a
+# DEGENERATE RANGE, so it costs zero bits and the only representable string is
+# the empty one. The align at bit index 0 is a no-op, the payload is empty, and
+# the whole operation consumes nothing at all — from an empty stream, where any
+# read is an error.
+
+operation string
+name string-buffer-size-1-zero-bit-length-field
+param buffer_size = 1
+bytes
+expect value =
+consumed 0
+writer canonical
+
+# The length field's range rule: buffer_size 10 gives bits_required( 0, 9 ) = 4
+# bits, so lengths 10 through 15 are expressible and must be refused.
+
+operation string
+name string-accepts-the-longest-length
+param buffer_size = 10
+bytes 09 31 32 33 34 35 36 37 38 39
+expect value = 31 32 33 34 35 36 37 38 39
+consumed 80
+writer canonical
+
+operation string
+name string-refuse-length-one-past-the-buffer
+param buffer_size = 10
+bytes 0A
+expect refused
+
+operation string
+name string-refuse-length-all-four-bits
+param buffer_size = 10
+bytes 0F
+expect refused
+
+# The alignment padding must be zero. The low four bits are a length of 1, the
+# high four are the padding, and only the padding differs between this vector
+# and string-single-byte above.
+
+operation string
+name string-refuse-non-zero-align-padding
+param buffer_size = 16
+bytes F1 41
+expect refused
+
+# Reading past the end, in the length field and in the payload.
+
+operation string
+name string-refuse-past-end-payload-truncated
+param buffer_size = 16
+bytes 06 67 6F 6C
+expect refused
+
+operation string
+name string-refuse-past-end-empty-stream
+param buffer_size = 16
+bytes
+expect refused
+
+# ---------------------------------------------------------------------------
+# the interior NUL rule. A conforming writer derives length from strlen, so no
+# zero byte can reach the wire from conformance; a stream carrying one gives
+# the payload two lengths — the wire length and the strlen every consumer
+# downstream computes — and everything between them rides invisibly past
+# whichever side uses the other. The rule is "a zero byte ANYWHERE among the
+# length transmitted bytes", so the first, a middle and the last byte each get
+# a vector: a reader that only scans strictly-interior positions accepts two of
+# these three.
+
+operation string
+name string-refuse-nul-as-the-only-byte
+param buffer_size = 16
+bytes 01 00
+expect refused
+
+operation string
+name string-refuse-nul-as-the-first-byte
+param buffer_size = 16
+bytes 03 00 61 62
+expect refused
+
+operation string
+name string-refuse-nul-in-the-middle
+param buffer_size = 16
+bytes 03 61 00 62
+expect refused
+
+operation string
+name string-refuse-nul-as-the-last-byte
+param buffer_size = 16
+bytes 03 61 62 00
+expect refused
+
+operation string
+name string-accept-the-same-three-bytes-without-a-nul
+param buffer_size = 16
+bytes 03 61 62 63
+expect value = 61 62 63
+consumed 32
+writer canonical
+
+# ---------------------------------------------------------------------------
+# the UTF-8 well-formedness rule. Each refusal is paired with the nearest
+# well-formed sequence, usually the code point one step away from the malformed
+# one, so a reader that refuses a byte class wholesale fails the accept.
+
+operation string
+name string-accept-shortest-two-byte-sequence
+param buffer_size = 16
+bytes 02 C2 80
+expect value = C2 80
+consumed 24
+writer canonical
+
+operation string
+name string-refuse-overlong-two-byte-nul
+param buffer_size = 16
+bytes 02 C0 80
+expect refused
+
+operation string
+name string-refuse-overlong-two-byte-slash
+param buffer_size = 16
+bytes 02 C1 AF
+expect refused
+
+operation string
+name string-accept-shortest-three-byte-sequence
+param buffer_size = 16
+bytes 03 E0 A0 80
+expect value = E0 A0 80
+consumed 32
+writer canonical
+
+operation string
+name string-refuse-overlong-three-byte-slash
+param buffer_size = 16
+bytes 03 E0 80 AF
+expect refused
+
+operation string
+name string-accept-just-below-the-surrogate-block
+param buffer_size = 16
+bytes 03 ED 9F BF
+expect value = ED 9F BF
+consumed 32
+writer canonical
+
+operation string
+name string-refuse-surrogate-encoded-in-utf8
+param buffer_size = 16
+bytes 03 ED A0 80
+expect refused
+
+operation string
+name string-refuse-low-surrogate-encoded-in-utf8
+param buffer_size = 16
+bytes 03 ED BF BF
+expect refused
+
+operation string
+name string-accept-just-above-the-surrogate-block
+param buffer_size = 16
+bytes 03 EE 80 80
+expect value = EE 80 80
+consumed 32
+writer canonical
+
+operation string
+name string-accept-astral-code-point
+param buffer_size = 16
+bytes 04 F0 9F 92 A9
+expect value = F0 9F 92 A9
+consumed 40
+writer canonical
+
+operation string
+name string-accept-the-largest-code-point
+param buffer_size = 16
+bytes 04 F4 8F BF BF
+expect value = F4 8F BF BF
+consumed 40
+writer canonical
+
+operation string
+name string-refuse-code-point-above-10FFFF
+param buffer_size = 16
+bytes 04 F4 90 80 80
+expect refused
+
+operation string
+name string-refuse-five-byte-sequence
+param buffer_size = 16
+bytes 05 F8 88 80 80 80
+expect refused
+
+operation string
+name string-refuse-lone-continuation-byte
+param buffer_size = 16
+bytes 01 80
+expect refused
+
+operation string
+name string-refuse-continuation-byte-after-ascii
+param buffer_size = 16
+bytes 02 41 BF
+expect refused
+
+operation string
+name string-refuse-truncated-two-byte-sequence
+param buffer_size = 16
+bytes 01 C3
+expect refused
+
+operation string
+name string-accept-the-same-two-byte-sequence-completed
+param buffer_size = 16
+bytes 02 C3 A9
+expect value = C3 A9
+consumed 24
+writer canonical
+
+operation string
+name string-refuse-truncated-three-byte-sequence
+param buffer_size = 16
+bytes 02 E2 82
+expect refused
+
+operation string
+name string-accept-the-same-three-byte-sequence-completed
+param buffer_size = 16
+bytes 03 E2 82 AC
+expect value = E2 82 AC
+consumed 32
+writer canonical
+
+operation string
+name string-refuse-byte-fe
+param buffer_size = 16
+bytes 01 FE
+expect refused
+
+operation string
+name string-refuse-byte-ff
+param buffer_size = 16
+bytes 01 FF
+expect refused

--- a/conformance/uint128.txt
+++ b/conformance/uint128.txt
@@ -1,0 +1,65 @@
+# serialize conformance vectors: serialize_uint128
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "uint128": a 128-bit unsigned integer, ALWAYS 128 bits on the
+# wire, the LOW 64-BIT HALF FIRST and then the high half, each half written
+# exactly as serialize_bits( half, 64 ). When the stream is byte aligned the
+# result is the 16 bytes of the value in little-endian order.
+#
+# Do not confuse this with serialize_int128, which is ranged. This operation
+# carries no bounds and has no range rule, so the only refusal STANDARD.md
+# states for it is reading past the end of the stream.
+#
+# The half order is the thing an implementation gets wrong, so the two vectors
+# that put the whole value in one half are the discriminating pair: an
+# implementation that writes the high half first swaps their bytes.
+
+operation uint128
+name uint128-zero
+bytes 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+expect value = 0
+consumed 128
+writer canonical
+
+operation uint128
+name uint128-low-half-only
+bytes 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+expect value = 1
+consumed 128
+writer canonical
+
+operation uint128
+name uint128-high-half-only
+bytes 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00
+expect value = 18446744073709551616
+consumed 128
+writer canonical
+
+# The library's additive pin, decoded here by the document alone:
+# 0x0123456789ABCDEFFEDCBA9876543210, low half 0xFEDCBA9876543210 first.
+
+operation uint128
+name uint128-distinct-halves
+bytes 10 32 54 76 98 BA DC FE EF CD AB 89 67 45 23 01
+expect value = 0x0123456789ABCDEFFEDCBA9876543210
+consumed 128
+writer canonical
+
+operation uint128
+name uint128-max
+bytes FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
+expect value = 340282366920938463463374607431768211455
+consumed 128
+writer canonical
+
+operation uint128
+name uint128-refuse-past-end-15-bytes
+bytes 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+expect refused
+
+operation uint128
+name uint128-refuse-past-end-empty-stream
+bytes
+expect refused

--- a/conformance/wstring.txt
+++ b/conformance/wstring.txt
@@ -1,0 +1,271 @@
+# serialize conformance vectors: serialize_wstring
+#
+# The format is specified in STANDARD.md, "The vector format". Records are
+# separated by blank lines.
+#
+# STANDARD.md, "wstring": a null-terminated wide string where buffer_size
+# counts WIDE CHARACTERS, NOT BYTES, written as
+#
+#   1. the length, as serialize_int( length, 0, buffer_size - 1 );
+#   2. each character as a 32-BIT GROUP, in order.
+#
+# "NO ALIGNMENT IS PERFORMED ANYWHERE IN THIS OPERATION — this is the one place
+# where the wide-string path deliberately differs from its narrow counterpart,
+# which aligns via serialize_bytes. An implementation that mirrors the narrow
+# string path here will produce the wrong bytes." Every accepted vector below
+# has a length field narrower than a byte, so the first character always begins
+# mid-byte and a stray align moves every byte after it.
+#
+# Each 32-bit group carries one UTF-16 CODE UNIT, not one code point. `value`
+# is therefore stated as the transmitted code units, four hexadecimal digits
+# each, and that is the wire-level truth on every platform: a 4-byte wchar_t
+# implementation converts at the boundary — splitting astral code points into
+# surrogate pairs on write and recombining on read — so its runner compares
+# after re-splitting, and both platforms owe the same bytes.
+#
+# Four refusal rules reach this operation:
+#
+#   * the length field's own range rule, when buffer_size - 1 is not one less
+#     than a power of two;
+#   * a GROUP ABOVE 0xFFFF is not a UTF-16 code unit and "the reader must
+#     refuse it on every platform, whatever the local wchar_t can hold" —
+#     refusal does not depend on the platform, so the same byte sequence is
+#     refused everywhere;
+#   * an UNPAIRED SURROGATE fails the read: a high surrogate (0xD800–0xDBFF)
+#     not immediately followed by a low surrogate (0xDC00–0xDFFF), a low
+#     surrogate not immediately preceded by a high surrogate, or a high
+#     surrogate as the final transmitted group. Well-formed surrogate PAIRS
+#     remain valid — they are how astral text travels;
+#   * an INTERIOR NUL fails the read — a zero group among the length
+#     transmitted groups, by the same two-lengths logic as string;
+#
+# and reading past the end.
+
+# The document's own worked example, quoted in "Worked Example": a wchar_t[8]
+# buffer holding three characters, producing this 13-byte run. buffer_size 8
+# makes the length field bits_required( 0, 7 ) = 3 bits, and the first
+# character begins immediately at bit 3 — the low 5 bits of 0xE3 are the low 5
+# bits of 0x043C. Total 3 + 3x32 = 99 bits.
+
+operation wstring
+name wstring-worked-example
+param buffer_size = 8
+bytes E3 21 00 00 C0 21 00 00 00 22 00 00 00
+expect value = 043C 0438 0440
+consumed 99
+writer canonical
+
+# No alignment, stated as bluntly as the corpus can state it: a one-bit length
+# field, so the character occupies bits 1 through 32. An implementation that
+# aligns before the characters starts them at bit 8 and produces entirely
+# different bytes.
+
+operation wstring
+name wstring-no-alignment-before-the-characters
+param buffer_size = 2
+bytes 83 00 00 00 00
+expect value = 0041
+consumed 33
+writer canonical
+
+operation wstring
+name wstring-empty
+param buffer_size = 8
+bytes 00
+expect value =
+consumed 3
+writer canonical
+
+# buffer_size 1: the length field is serialize_int( length, 0, 0 ), a
+# degenerate range costing zero bits, and there is no alignment to perform, so
+# the whole operation consumes nothing — from an empty stream.
+
+operation wstring
+name wstring-buffer-size-1-zero-bit-length-field
+param buffer_size = 1
+bytes
+expect value =
+consumed 0
+writer canonical
+
+operation wstring
+name wstring-single-basic-plane-character
+param buffer_size = 8
+bytes 09 02 00 00 00
+expect value = 0041
+consumed 35
+writer canonical
+
+# ---------------------------------------------------------------------------
+# the group-above-0xFFFF rule, pinned at exactly the boundary: 0xFFFF is a
+# legal code unit and 0x10000 is not, and the two streams differ by one bit.
+
+operation wstring
+name wstring-accept-group-ffff
+param buffer_size = 8
+bytes F9 FF 07 00 00
+expect value = FFFF
+consumed 35
+writer canonical
+
+operation wstring
+name wstring-refuse-group-one-above-ffff
+param buffer_size = 8
+bytes 01 00 08 00 00
+expect refused
+
+operation wstring
+name wstring-refuse-group-all-thirty-two-bits
+param buffer_size = 8
+bytes F9 FF FF FF 07
+expect refused
+
+# ---------------------------------------------------------------------------
+# the unpaired-surrogate rule, at both ends of both surrogate blocks, each
+# beside the nearest code unit that is not a surrogate.
+
+operation wstring
+name wstring-accept-just-below-the-surrogate-block
+param buffer_size = 8
+bytes F9 BF 06 00 00
+expect value = D7FF
+consumed 35
+writer canonical
+
+operation wstring
+name wstring-refuse-first-high-surrogate-alone
+param buffer_size = 8
+bytes 01 C0 06 00 00
+expect refused
+
+operation wstring
+name wstring-refuse-last-high-surrogate-alone
+param buffer_size = 8
+bytes F9 DF 06 00 00
+expect refused
+
+operation wstring
+name wstring-refuse-first-low-surrogate-alone
+param buffer_size = 8
+bytes 01 E0 06 00 00
+expect refused
+
+operation wstring
+name wstring-refuse-last-low-surrogate-alone
+param buffer_size = 8
+bytes F9 FF 06 00 00
+expect refused
+
+operation wstring
+name wstring-accept-just-above-the-surrogate-block
+param buffer_size = 8
+bytes 01 00 07 00 00
+expect value = E000
+consumed 35
+writer canonical
+
+# A well-formed surrogate pair is how astral text travels, and it must be
+# accepted. This is U+1F4A9 as its pair, D83D DCA9.
+
+operation wstring
+name wstring-accept-surrogate-pair
+param buffer_size = 8
+bytes EA C1 06 00 48 E5 06 00 00
+expect value = D83D DCA9
+consumed 67
+writer canonical
+
+operation wstring
+name wstring-refuse-high-surrogate-followed-by-a-non-surrogate
+param buffer_size = 8
+bytes EA C1 06 00 08 02 00 00 00
+expect refused
+
+operation wstring
+name wstring-refuse-low-surrogate-not-preceded-by-a-high-one
+param buffer_size = 8
+bytes 4A E5 06 00 E8 C1 06 00 00
+expect refused
+
+operation wstring
+name wstring-refuse-high-surrogate-as-the-final-group
+param buffer_size = 8
+bytes 0A 02 00 00 E8 C1 06 00 00
+expect refused
+
+# ---------------------------------------------------------------------------
+# the interior NUL rule, in each position a zero group can occupy.
+
+operation wstring
+name wstring-refuse-nul-as-the-only-group
+param buffer_size = 8
+bytes 01 00 00 00 00
+expect refused
+
+operation wstring
+name wstring-refuse-nul-as-the-first-of-two-groups
+param buffer_size = 8
+bytes 02 00 00 00 08 02 00 00 00
+expect refused
+
+operation wstring
+name wstring-refuse-nul-as-the-final-group
+param buffer_size = 8
+bytes 0A 02 00 00 00 00 00 00 00
+expect refused
+
+# The accept twin of the vector above: the same stream with a non-zero second
+# group, so the only difference between the two verdicts is the group's value.
+
+operation wstring
+name wstring-accept-two-basic-plane-groups
+param buffer_size = 8
+bytes 0A 02 00 00 10 02 00 00 00
+expect value = 0041 0042
+consumed 67
+writer canonical
+
+# ---------------------------------------------------------------------------
+# the length field's range rule: buffer_size 5 gives bits_required( 0, 4 ) = 3
+# bits, so lengths 5, 6 and 7 are expressible and must be refused.
+
+operation wstring
+name wstring-accept-length-inside-a-five-character-buffer
+param buffer_size = 5
+bytes 09 02 00 00 00
+expect value = 0041
+consumed 35
+writer canonical
+
+operation wstring
+name wstring-refuse-length-one-past-the-buffer
+param buffer_size = 5
+bytes 05
+expect refused
+
+operation wstring
+name wstring-refuse-length-all-three-bits
+param buffer_size = 5
+bytes 07
+expect refused
+
+# ---------------------------------------------------------------------------
+# reading past the end, in the length field and in the groups.
+
+operation wstring
+name wstring-refuse-past-end-second-group-truncated
+param buffer_size = 8
+bytes EA C1 06 00
+expect refused
+
+operation wstring
+name wstring-refuse-past-end-first-group-truncated
+param buffer_size = 8
+bytes 09 02
+expect refused
+
+operation wstring
+name wstring-refuse-past-end-empty-stream
+param buffer_size = 8
+bytes
+expect refused

--- a/tools/conformance/corpus.go
+++ b/tools/conformance/corpus.go
@@ -1,0 +1,1073 @@
+// Runs the shared conformance corpus against a decoder, encoder and measure written from
+// STANDARD.md alone.
+//
+// This is the second half of what this tool does. verify_standard.go decodes the library's own
+// pinned emissions with a decoder written from the document; this file runs the corpus in
+// conformance/ the same way. The two ask different questions and neither replaces the other:
+// one asks whether the document describes the bytes the implementations emit, the other asks
+// whether the document's own vector files say what the document says.
+//
+// NOTHING HERE CONSULTS serialize.h. The decoders are the ones verify_standard.go already
+// carries — the LSB-first bit packing, the ranged widths, the alignment rules, the relative
+// integer ladder, the fixed point offset encoding, the two-rounding compressed float — and the
+// encoder and the measure below are written from the same text. That independence is the point:
+// a corpus checked only by the implementation it judges proves that the implementation agrees
+// with itself, and the family already paid for that mistake once.
+//
+// A corpus file whose operation this checker cannot drive is a gap in the checker, not a pass:
+// such a vector FAILS, exactly as it does in the C++ runner.
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// ---------------------------------------------------------------------------
+// the bit writer, which is the reader's mirror: STANDARD.md, "General
+// Conventions", bits packed least-significant-bit first.
+
+type BitWriter struct {
+	b []byte
+	i int
+}
+
+func (w *BitWriter) bits(v uint64, n int) {
+	for k := 0; k < n; k++ {
+		if w.i/8 >= len(w.b) {
+			w.b = append(w.b, 0)
+		}
+		if (v>>uint(k))&1 != 0 {
+			w.b[w.i/8] |= 1 << uint(w.i%8)
+		}
+		w.i++
+	}
+}
+
+// align pads with ZERO BITS to the next byte boundary, and writes nothing when
+// the stream is already aligned.
+func (w *BitWriter) align() {
+	pad := (8 - (w.i % 8)) % 8
+	w.bits(0, pad)
+}
+
+func (w *BitWriter) writeBytes(data []byte) {
+	w.align()
+	for _, c := range data {
+		w.bits(uint64(c), 8)
+	}
+}
+
+// flush rounds the stream up to a whole byte. STANDARD.md, "Trailing bits":
+// writers must emit ZERO in the unused bits of the final byte, which this
+// writer does by construction because it never sets a bit it was not asked to.
+func (w *BitWriter) flush() []byte {
+	for w.i%8 != 0 {
+		w.bits(0, 1)
+	}
+	return w.b
+}
+
+// ---------------------------------------------------------------------------
+// the operations, as steps. One step description drives the decode, the encode
+// and the measure, so the three cannot drift apart.
+
+type stepKind int
+
+const (
+	stepBits stepKind = iota
+	stepBool
+	stepUint128
+	stepAlign
+	stepInt
+	stepInt64
+	stepInt128
+	stepIntRelative
+	stepFloat
+	stepDouble
+	stepCompressedFloat
+	stepBytes
+	stepString
+	stepWString
+	stepFixed
+	// stepObject wraps the steps that follow it. STANDARD.md, "object": it
+	// contributes NO BYTES OF ITS OWN — composition, not an encoding — so the
+	// nested run is exactly the steps it wraps and nothing else.
+	stepObject
+)
+
+type step struct {
+	kind         stepKind
+	width        int64 // bits, count, buffer_size or preceding_bits
+	fractionBits uint
+	lo, hi       *big.Int
+	fmin, fmax   float32
+	fres         float32
+	previous     int64
+
+	// decoded outputs
+	number *big.Int
+	bits   *big.Int
+	flag   bool
+	data   []byte
+	units  []uint16
+}
+
+// aligns reports whether the step performs an alignment, which is what the
+// measure charges the worst case for: STANDARD.md, "The Measure Stream", names
+// align, bytes and string and nothing else.
+func (s *step) aligns() bool {
+	return s.kind == stepAlign || s.kind == stepBytes || s.kind == stepString
+}
+
+// bitsRequiredBig is STANDARD.md's rule at any width: zero for a degenerate
+// range, otherwise the bit length of the span.
+func bitsRequiredBig(span *big.Int) int {
+	if span.Sign() == 0 {
+		return 0
+	}
+	return span.BitLen()
+}
+
+// readGroups reads n bits as 32-bit groups from least significant upward, the
+// splitting rule serialize_bits, int128 and the wide fixed point path share.
+func readGroups(r *BitReader, n int) (*big.Int, error) {
+	v := new(big.Int)
+	for g := 0; g < n; g += 32 {
+		w := 32
+		if n-g < 32 {
+			w = n - g
+		}
+		grp, err := r.bits(w)
+		if err != nil {
+			return nil, err
+		}
+		v.Or(v, new(big.Int).Lsh(new(big.Int).SetUint64(grp), uint(g)))
+	}
+	return v, nil
+}
+
+func writeGroups(w *BitWriter, v *big.Int, n int) {
+	for g := 0; g < n; g += 32 {
+		width := 32
+		if n-g < 32 {
+			width = n - g
+		}
+		grp := new(big.Int).Rsh(v, uint(g))
+		grp.And(grp, new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(width)), big.NewInt(1)))
+		w.bits(grp.Uint64(), width)
+	}
+}
+
+var mod128 = new(big.Int).Lsh(big.NewInt(1), 128)
+
+func toUnsigned128(x *big.Int) *big.Int { return new(big.Int).Mod(x, mod128) }
+
+func toSigned128(x *big.Int) *big.Int {
+	out := toUnsigned128(x)
+	if out.Cmp(new(big.Int).Lsh(big.NewInt(1), 127)) >= 0 {
+		out.Sub(out, mod128)
+	}
+	return out
+}
+
+// rangedSpan is the span of a ranged operation, computed in the unsigned domain
+// of its width — the thing an implementation subtracting in a signed type gets
+// wrong at the widest declarations.
+func (s *step) rangedSpan() *big.Int {
+	return toUnsigned128(new(big.Int).Sub(s.hi, s.lo))
+}
+
+func (s *step) rawBounds() (*big.Int, *big.Int) {
+	return new(big.Int).Lsh(s.lo, s.fractionBits), new(big.Int).Lsh(s.hi, s.fractionBits)
+}
+
+// ---------------------------------------------------------------------------
+// decode
+
+// stepSpan is one step, plus the steps a nested object owns.
+func stepSpan(steps []*step, i int) int {
+	if steps[i].kind == stepObject {
+		return 1 + int(steps[i].width)
+	}
+	return 1
+}
+
+// decodeSteps walks a step list, descending into each nested object. The
+// descent is the whole of what serialize_object does: no framing, no length
+// prefix and no alignment around it.
+func decodeSteps(r *BitReader, steps []*step) (int, error) {
+	for i := 0; i < len(steps); i += stepSpan(steps, i) {
+		if steps[i].kind == stepObject {
+			if j, err := decodeSteps(r, steps[i+1:i+1+int(steps[i].width)]); err != nil {
+				return i + 1 + j, err
+			}
+			continue
+		}
+		if err := decodeStep(r, steps[i]); err != nil {
+			return i, err
+		}
+	}
+	return -1, nil
+}
+
+func encodeSteps(w *BitWriter, steps []*step) error {
+	for i := 0; i < len(steps); i += stepSpan(steps, i) {
+		if steps[i].kind == stepObject {
+			if err := encodeSteps(w, steps[i+1:i+1+int(steps[i].width)]); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := encodeStep(w, steps[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func decodeStep(r *BitReader, s *step) error {
+	switch s.kind {
+	case stepBits:
+		v, err := readGroups(r, int(s.width))
+		if err != nil {
+			return err
+		}
+		s.bits = v
+		return nil
+
+	case stepBool:
+		v, err := r.bits(1)
+		if err != nil {
+			return err
+		}
+		s.flag = v == 1
+		return nil
+
+	case stepUint128:
+		lo, err := readGroups(r, 64)
+		if err != nil {
+			return err
+		}
+		hi, err := readGroups(r, 64)
+		if err != nil {
+			return err
+		}
+		s.bits = new(big.Int).Or(new(big.Int).Lsh(hi, 64), lo)
+		return nil
+
+	case stepAlign:
+		return r.align()
+
+	case stepInt, stepInt64, stepInt128:
+		span := s.rangedSpan()
+		n := bitsRequiredBig(span)
+		v, err := readGroups(r, n)
+		if err != nil {
+			return err
+		}
+		if v.Cmp(span) > 0 {
+			return fmt.Errorf("ranged offset %s exceeds span %s — reject, never clamp", v, span)
+		}
+		s.number = toSigned128(new(big.Int).Add(v, s.lo))
+		return nil
+
+	case stepIntRelative:
+		v, err := relative(r, s.previous)
+		if err != nil {
+			return err
+		}
+		s.number = big.NewInt(v)
+		return nil
+
+	case stepFloat:
+		v, err := r.bits(32)
+		if err != nil {
+			return err
+		}
+		s.bits = new(big.Int).SetUint64(v)
+		return nil
+
+	case stepDouble:
+		v, err := readGroups(r, 64)
+		if err != nil {
+			return err
+		}
+		s.bits = v
+		return nil
+
+	case stepCompressedFloat:
+		f, err := decodeCompressedFloat(r, s.fmin, s.fmax, s.fres)
+		if err != nil {
+			return err
+		}
+		s.bits = new(big.Int).SetUint64(uint64(math.Float32bits(f)))
+		return nil
+
+	case stepBytes:
+		b, err := r.readBytes(int(s.width))
+		if err != nil {
+			return err
+		}
+		s.data = append([]byte(nil), b...)
+		return nil
+
+	case stepString:
+		n, err := decodeRangedInt(r, 0, s.width-1)
+		if err != nil {
+			return err
+		}
+		b, err := r.readBytes(int(n))
+		if err != nil {
+			return err
+		}
+		// STANDARD.md: invalid UTF-8 fails the read, and so does an interior
+		// NUL — a zero byte anywhere among the transmitted bytes.
+		if !utf8.Valid(b) {
+			return fmt.Errorf("string payload is not well-formed UTF-8")
+		}
+		for _, c := range b {
+			if c == 0 {
+				return fmt.Errorf("string payload carries an interior NUL")
+			}
+		}
+		s.data = append([]byte(nil), b...)
+		return nil
+
+	case stepWString:
+		n, err := decodeRangedInt(r, 0, s.width-1)
+		if err != nil {
+			return err
+		}
+		units := make([]uint16, 0, n)
+		for i := int64(0); i < n; i++ {
+			g, err := r.bits(32)
+			if err != nil {
+				return err
+			}
+			// a group above 0xFFFF is not a UTF-16 code unit, and the reader
+			// must refuse it on every platform
+			if g > 0xFFFF {
+				return fmt.Errorf("wstring group 0x%X is above 0xFFFF and is not a code unit", g)
+			}
+			if g == 0 {
+				return fmt.Errorf("wstring payload carries an interior NUL group")
+			}
+			units = append(units, uint16(g))
+		}
+		if err := checkUTF16(units); err != nil {
+			return err
+		}
+		s.units = units
+		return nil
+
+	case stepFixed:
+		rawLo, rawHi := s.rawBounds()
+		span := new(big.Int).Sub(rawHi, rawLo)
+		n := bitsRequiredBig(span)
+		v, err := readGroups(r, n)
+		if err != nil {
+			return err
+		}
+		if v.Cmp(span) > 0 {
+			return fmt.Errorf("fixed offset %s exceeds raw span %s — reject, never clamp", v, span)
+		}
+		s.number = new(big.Int).Add(v, rawLo)
+		return nil
+	}
+	return fmt.Errorf("no decoder for this step")
+}
+
+// decodeRangedInt is the length field shared by string and wstring.
+func decodeRangedInt(r *BitReader, lo, hi int64) (int64, error) {
+	return sint(r, lo, hi)
+}
+
+// checkUTF16 applies STANDARD.md's unpaired-surrogate rule: a high surrogate
+// not immediately followed by a low one, a low surrogate not immediately
+// preceded by a high one, or a high surrogate as the final transmitted group.
+func checkUTF16(units []uint16) error {
+	for i := 0; i < len(units); i++ {
+		u := units[i]
+		if u >= 0xD800 && u <= 0xDBFF {
+			if i+1 >= len(units) {
+				return fmt.Errorf("wstring ends on a high surrogate 0x%04X", u)
+			}
+			next := units[i+1]
+			if next < 0xDC00 || next > 0xDFFF {
+				return fmt.Errorf("wstring high surrogate 0x%04X is not followed by a low surrogate", u)
+			}
+			i++
+			continue
+		}
+		if u >= 0xDC00 && u <= 0xDFFF {
+			return fmt.Errorf("wstring low surrogate 0x%04X is not preceded by a high surrogate", u)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// encode, for the vectors carrying `writer = canonical`
+
+func encodeStep(w *BitWriter, s *step) error {
+	switch s.kind {
+	case stepBits:
+		writeGroups(w, s.bits, int(s.width))
+	case stepBool:
+		if s.flag {
+			w.bits(1, 1)
+		} else {
+			w.bits(0, 1)
+		}
+	case stepUint128:
+		lowMask := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 64), big.NewInt(1))
+		writeGroups(w, new(big.Int).And(s.bits, lowMask), 64)
+		writeGroups(w, new(big.Int).Rsh(s.bits, 64), 64)
+	case stepAlign:
+		w.align()
+	case stepInt, stepInt64, stepInt128:
+		span := s.rangedSpan()
+		writeGroups(w, toUnsigned128(new(big.Int).Sub(s.number, s.lo)), bitsRequiredBig(span))
+	case stepIntRelative:
+		encodeRelative(w, s.previous, s.number.Int64())
+	case stepFloat:
+		w.bits(s.bits.Uint64(), 32)
+	case stepDouble:
+		writeGroups(w, s.bits, 64)
+	case stepCompressedFloat:
+		f := math.Float32frombits(uint32(s.bits.Uint64()))
+		maxIntegerValue, n := compressedFloatParams(s.fmin, s.fmax, s.fres)
+		_ = maxIntegerValue
+		w.bits(quantizeCompressedFloat(f, s.fmin, s.fmax, s.fres), n)
+	case stepBytes:
+		w.writeBytes(s.data)
+	case stepString:
+		writeGroups(w, big.NewInt(int64(len(s.data))), bitsRequiredBig(big.NewInt(s.width-1)))
+		w.writeBytes(s.data)
+	case stepWString:
+		writeGroups(w, big.NewInt(int64(len(s.units))), bitsRequiredBig(big.NewInt(s.width-1)))
+		for _, u := range s.units {
+			w.bits(uint64(u), 32)
+		}
+	case stepFixed:
+		rawLo, rawHi := s.rawBounds()
+		span := new(big.Int).Sub(rawHi, rawLo)
+		writeGroups(w, new(big.Int).Sub(s.number, rawLo), bitsRequiredBig(span))
+	default:
+		return fmt.Errorf("no encoder for this step")
+	}
+	return nil
+}
+
+// encodeRelative emits the FIRST tier the difference fits, which is the
+// canonical encoding STANDARD.md's ladder defines.
+func encodeRelative(w *BitWriter, prev, current int64) {
+	d := current - prev
+	if d == 1 {
+		w.bits(1, 1)
+		return
+	}
+	tiers := []struct{ lo, hi int64 }{{2, 6}, {7, 23}, {24, 280}, {281, 4377}, {4378, 69914}}
+	for i, t := range tiers {
+		if d >= t.lo && d <= t.hi {
+			w.bits(0, i+1)
+			w.bits(1, 1)
+			w.bits(uint64(d-t.lo), bitsRequired(t.lo, t.hi))
+			return
+		}
+	}
+	w.bits(0, 6)
+	w.bits(uint64(uint32(current)), 32)
+}
+
+// ---------------------------------------------------------------------------
+// measure. STANDARD.md makes a measure a BOUND: it must report a size
+// sufficient to serialize the message AT ANY STARTING BIT POSITION, and
+// exact-from-zero accounting is non-conforming precisely because it
+// under-counts every unaligned start.
+//
+// The corpus states a floor. This computes the true worst case — the maximum,
+// over every starting bit position, of the bits the message actually occupies —
+// and requires the corpus floor to be exactly it. That checks the floor from
+// the document rather than from either implementation's arithmetic, and it is
+// the check that would catch a corpus floor set to the exact-from-zero number.
+
+func stepExactBits(s *step, bitIndex int) int {
+	switch s.kind {
+	case stepBits:
+		return int(s.width)
+	case stepBool:
+		return 1
+	case stepUint128:
+		return 128
+	case stepAlign:
+		return (8 - (bitIndex % 8)) % 8
+	case stepInt, stepInt64, stepInt128:
+		return bitsRequiredBig(s.rangedSpan())
+	case stepFloat:
+		return 32
+	case stepDouble:
+		return 64
+	case stepCompressedFloat:
+		_, n := compressedFloatParams(s.fmin, s.fmax, s.fres)
+		return n
+	case stepBytes:
+		return (8-(bitIndex%8))%8 + 8*len(s.data)
+	case stepString:
+		n := bitsRequiredBig(big.NewInt(s.width - 1))
+		return n + (8-((bitIndex+n)%8))%8 + 8*len(s.data)
+	case stepWString:
+		return bitsRequiredBig(big.NewInt(s.width-1)) + 32*len(s.units)
+	case stepFixed:
+		rawLo, rawHi := s.rawBounds()
+		return bitsRequiredBig(new(big.Int).Sub(rawHi, rawLo))
+	case stepObject:
+		return 0
+	}
+	return 0
+}
+
+func worstCaseBits(steps []*step) int {
+	worst := 0
+	for start := 0; start < 8; start++ {
+		index := start
+		for _, s := range steps {
+			// an object contributes no bits of its own; the steps it wraps are
+			// already in this list and each is charged once
+			index += stepExactBits(s, index)
+		}
+		if index-start > worst {
+			worst = index - start
+		}
+	}
+	return worst
+}
+
+// ---------------------------------------------------------------------------
+// vector files
+
+type vector struct {
+	file        string
+	operation   string
+	name        string
+	params      map[string]string
+	stepText    []string
+	bytes       []byte
+	expectKind  string // "refused", "value", "bits"
+	expect      string
+	consumed    int64
+	hasCons     bool
+	measureMin  int64
+	hasMeasure  bool
+	writerCanon bool
+}
+
+func parseVectorFile(path string) ([]*vector, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var out []*vector
+	cur := &vector{file: path, params: map[string]string{}, expectKind: "value"}
+	flush := func() {
+		if cur.operation != "" {
+			out = append(out, cur)
+		}
+		cur = &vector{file: path, params: map[string]string{}, expectKind: "value"}
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		// STANDARD.md, "Lexical rules": a comment begins at the start of a line
+		// and nowhere else.
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		text := strings.TrimSpace(line)
+		if text == "" {
+			flush()
+			continue
+		}
+		key := text
+		value := ""
+		if i := strings.IndexByte(text, ' '); i >= 0 {
+			key, value = text[:i], strings.TrimSpace(text[i+1:])
+		}
+		switch key {
+		case "operation":
+			cur.operation = value
+		case "name":
+			cur.name = value
+		case "param":
+			eq := strings.IndexByte(value, '=')
+			if eq < 0 {
+				return nil, fmt.Errorf("%s: malformed param line %q", path, text)
+			}
+			pn := strings.TrimSpace(value[:eq])
+			pv := strings.TrimSpace(value[eq+1:])
+			if pn == "step" {
+				cur.stepText = append(cur.stepText, pv)
+			} else {
+				cur.params[pn] = pv
+			}
+		case "bytes":
+			b, err := parseHexBytes(value)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %v", path, err)
+			}
+			cur.bytes = b
+		case "expect":
+			if value == "refused" {
+				cur.expectKind = "refused"
+				break
+			}
+			eq := strings.IndexByte(value, '=')
+			if eq < 0 {
+				return nil, fmt.Errorf("%s: malformed expect line %q", path, text)
+			}
+			cur.expectKind = strings.TrimSpace(value[:eq])
+			cur.expect = strings.TrimSpace(value[eq+1:])
+			if cur.expectKind != "value" && cur.expectKind != "bits" {
+				return nil, fmt.Errorf("%s: unknown expect kind %q", path, cur.expectKind)
+			}
+		case "consumed":
+			n, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %v", path, err)
+			}
+			cur.consumed, cur.hasCons = n, true
+		case "measure_at_least":
+			n, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %v", path, err)
+			}
+			cur.measureMin, cur.hasMeasure = n, true
+		case "writer":
+			if value != "canonical" {
+				return nil, fmt.Errorf("%s: unknown writer mode %q", path, value)
+			}
+			cur.writerCanon = true
+		default:
+			return nil, fmt.Errorf("%s: unknown key %q", path, key)
+		}
+	}
+	flush()
+	return out, nil
+}
+
+func parseHexBytes(text string) ([]byte, error) {
+	var out []byte
+	for _, f := range strings.Fields(text) {
+		if len(f)%2 != 0 {
+			return nil, fmt.Errorf("malformed hexadecimal %q", f)
+		}
+		for i := 0; i < len(f); i += 2 {
+			v, err := strconv.ParseUint(f[i:i+2], 16, 8)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, byte(v))
+		}
+	}
+	return out, nil
+}
+
+// numbers are signed decimal or 0x hexadecimal, up to 128 bits wide
+func parseNumber(text string) (*big.Int, bool) {
+	v, ok := new(big.Int).SetString(strings.TrimSpace(text), 0)
+	return v, ok
+}
+
+// ---------------------------------------------------------------------------
+// building steps
+
+func buildStep(spec string, v *vector) (*step, error) {
+	words := strings.Fields(spec)
+	if len(words) == 0 {
+		return nil, fmt.Errorf("empty step")
+	}
+	s := &step{}
+	num := func(i int) int64 {
+		n, _ := parseNumber(words[i])
+		return n.Int64()
+	}
+	switch words[0] {
+	case "bits":
+		s.kind, s.width = stepBits, num(1)
+	case "bool":
+		s.kind = stepBool
+	case "align":
+		s.kind = stepAlign
+	case "object":
+		s.kind, s.width = stepObject, num(1)
+	case "float":
+		s.kind = stepFloat
+	case "bytes":
+		s.kind, s.width = stepBytes, num(1)
+	case "string":
+		s.kind, s.width = stepString, num(1)
+	case "wstring":
+		s.kind, s.width = stepWString, num(1)
+	case "int":
+		lo, _ := parseNumber(words[1])
+		hi, _ := parseNumber(words[2])
+		s.kind, s.lo, s.hi = stepInt, lo, hi
+	case "fixed":
+		lo, _ := parseNumber(words[3])
+		hi, _ := parseNumber(words[4])
+		s.kind, s.fractionBits, s.lo, s.hi = stepFixed, uint(num(2)), lo, hi
+	default:
+		return nil, fmt.Errorf("no runner for step %q", spec)
+	}
+	_ = v
+	return s, nil
+}
+
+func buildSteps(v *vector) ([]*step, error) {
+	if v.operation == "sequence" {
+		var out []*step
+		for _, spec := range v.stepText {
+			s, err := buildStep(spec, v)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, s)
+		}
+		if len(out) == 0 {
+			return nil, fmt.Errorf("a sequence with no steps")
+		}
+		return out, nil
+	}
+	if len(v.stepText) > 0 {
+		return nil, fmt.Errorf("steps are only meaningful on a sequence")
+	}
+
+	var out []*step
+	if p, ok := v.params["preceding_bits"]; ok {
+		n, valid := parseNumber(p)
+		if !valid {
+			return nil, fmt.Errorf("malformed preceding_bits")
+		}
+		if n.Sign() > 0 {
+			out = append(out, &step{kind: stepBits, width: n.Int64()})
+		}
+	}
+
+	s := &step{}
+	numParam := func(name string) (*big.Int, error) {
+		p, ok := v.params[name]
+		if !ok {
+			return nil, fmt.Errorf("missing parameter %q", name)
+		}
+		n, valid := parseNumber(p)
+		if !valid {
+			return nil, fmt.Errorf("malformed parameter %q", name)
+		}
+		return n, nil
+	}
+	floatParam := func(name string) (float32, error) {
+		p, ok := v.params[name]
+		if !ok {
+			return 0, fmt.Errorf("missing parameter %q", name)
+		}
+		f, err := strconv.ParseFloat(p, 32)
+		return float32(f), err
+	}
+	bounds := func() error {
+		lo, err := numParam("min")
+		if err != nil {
+			return err
+		}
+		hi, err := numParam("max")
+		if err != nil {
+			return err
+		}
+		s.lo, s.hi = lo, hi
+		return nil
+	}
+
+	switch v.operation {
+	case "bits":
+		n, err := numParam("bits")
+		if err != nil {
+			return nil, err
+		}
+		s.kind, s.width = stepBits, n.Int64()
+	case "bool":
+		s.kind = stepBool
+	case "uint128":
+		s.kind = stepUint128
+	case "align":
+		s.kind = stepAlign
+	case "int", "int64", "int128":
+		s.kind = map[string]stepKind{"int": stepInt, "int64": stepInt64, "int128": stepInt128}[v.operation]
+		if err := bounds(); err != nil {
+			return nil, err
+		}
+	case "int_relative":
+		n, err := numParam("previous")
+		if err != nil {
+			return nil, err
+		}
+		s.kind, s.previous = stepIntRelative, n.Int64()
+	case "float":
+		s.kind = stepFloat
+	case "double":
+		s.kind = stepDouble
+	case "compressed_float":
+		var err error
+		s.kind = stepCompressedFloat
+		if s.fmin, err = floatParam("min"); err != nil {
+			return nil, err
+		}
+		if s.fmax, err = floatParam("max"); err != nil {
+			return nil, err
+		}
+		if s.fres, err = floatParam("res"); err != nil {
+			return nil, err
+		}
+	case "bytes":
+		n, err := numParam("count")
+		if err != nil {
+			return nil, err
+		}
+		s.kind, s.width = stepBytes, n.Int64()
+	case "string", "wstring":
+		n, err := numParam("buffer_size")
+		if err != nil {
+			return nil, err
+		}
+		s.kind, s.width = stepString, n.Int64()
+		if v.operation == "wstring" {
+			s.kind = stepWString
+		}
+	case "fixed":
+		fb, err := numParam("fraction_bits")
+		if err != nil {
+			return nil, err
+		}
+		if _, err := numParam("integer_bits"); err != nil {
+			return nil, err
+		}
+		s.kind, s.fractionBits = stepFixed, uint(fb.Int64())
+		if err := bounds(); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("no runner for operation %q", v.operation)
+	}
+	return append(out, s), nil
+}
+
+// ---------------------------------------------------------------------------
+// rendering and comparison. Numeric values are compared as 128 bit two's
+// complement PATTERNS, which makes a hexadecimal expectation and its decimal
+// twin one expectation and keeps float, double and compressed_float away from
+// any value-space comparison — STANDARD.md requires those to be compared as bit
+// patterns, because NaN is unequal to itself and -0.0 equals 0.0.
+
+func stepPattern(s *step) (*big.Int, bool) {
+	switch s.kind {
+	case stepBits, stepUint128, stepFloat, stepDouble, stepCompressedFloat:
+		return toUnsigned128(s.bits), true
+	case stepInt, stepInt64, stepInt128, stepIntRelative, stepFixed:
+		return toUnsigned128(s.number), true
+	}
+	return nil, false
+}
+
+func renderStep(s *step) string {
+	if p, ok := stepPattern(s); ok {
+		return fmt.Sprintf("0x%032X", p)
+	}
+	switch s.kind {
+	case stepAlign, stepObject:
+		return "0"
+	case stepBool:
+		if s.flag {
+			return "true"
+		}
+		return "false"
+	case stepBytes, stepString:
+		parts := make([]string, len(s.data))
+		for i, c := range s.data {
+			parts[i] = fmt.Sprintf("%02X", c)
+		}
+		return strings.Join(parts, " ")
+	case stepWString:
+		parts := make([]string, len(s.units))
+		for i, u := range s.units {
+			parts[i] = fmt.Sprintf("%04X", u)
+		}
+		return strings.Join(parts, " ")
+	}
+	return "?"
+}
+
+func stepMatches(s *step, expected string) bool {
+	if p, ok := stepPattern(s); ok {
+		want, valid := parseNumber(expected)
+		if !valid {
+			return false
+		}
+		return p.Cmp(toUnsigned128(want)) == 0
+	}
+	return renderStep(s) == expected
+}
+
+// ---------------------------------------------------------------------------
+// running
+
+func runCorpusVector(c *checker, v *vector) {
+	c.n++
+	fail := func(format string, args ...interface{}) {
+		c.fails = append(c.fails, fmt.Sprintf("%s: %s [%s]", v.name, fmt.Sprintf(format, args...), v.file))
+	}
+
+	steps, err := buildSteps(v)
+	if err != nil {
+		fail("%v", err)
+		return
+	}
+
+	// STANDARD.md: "A harness presents every stream with the slack the contract
+	// requires." The slack is filled with a non-zero pattern, so a decode that
+	// depends on memory past the end cannot pass by reading zeros.
+	stream := append(append([]byte(nil), v.bytes...), make([]byte, 8)...)
+	for i := len(v.bytes); i < len(stream); i++ {
+		stream[i] = 0xA5
+	}
+	r := &BitReader{b: stream[:len(v.bytes)]}
+
+	failedStep, _ := decodeSteps(r, steps)
+
+	if v.expectKind == "refused" {
+		if failedStep < 0 {
+			fail("the decode succeeded, the corpus requires refusal")
+			return
+		}
+		// failure is terminal: every step after the failing one must fail too.
+		// This decoder has no stream object to latch, so the rule is enforced
+		// by construction — the position is not defined past a failure and the
+		// checker does not continue on it, which is one of the two shapes
+		// STANDARD.md admits.
+		return
+	}
+	if failedStep >= 0 {
+		fail("step %d was refused, the corpus requires the read to be accepted", failedStep+1)
+		return
+	}
+
+	entries := strings.Split(v.expect, "|")
+	for i := range entries {
+		entries[i] = strings.TrimSpace(entries[i])
+	}
+	offset := len(steps) - len(entries)
+	if offset < 0 {
+		fail("the expect list states more values than the vector has steps")
+		return
+	}
+	for i, want := range entries {
+		if want == "-" {
+			continue
+		}
+		if !stepMatches(steps[offset+i], want) {
+			fail("step %d decoded %s, the corpus states %s", offset+i+1, renderStep(steps[offset+i]), want)
+			return
+		}
+	}
+
+	if v.hasCons && int64(r.i) != v.consumed {
+		fail("consumed %d bits, the corpus states %d", r.i, v.consumed)
+		return
+	}
+
+	if v.writerCanon {
+		w := &BitWriter{}
+		if err := encodeSteps(w, steps); err != nil {
+			fail("%v", err)
+			return
+		}
+		got := w.flush()
+		if fmt.Sprintf("% X", got) != fmt.Sprintf("% X", v.bytes) {
+			fail("the writer emitted % X, the corpus states % X", got, v.bytes)
+			return
+		}
+	}
+
+	if v.hasMeasure {
+		// the corpus floor must be the true worst case over every starting bit
+		// position: a floor set to the exact-from-zero number is exactly the
+		// non-conforming accounting STANDARD.md names
+		if worst := int64(worstCaseBits(steps)); worst != v.measureMin {
+			fail("measure_at_least states %d, the document's worst case over every starting bit position is %d", v.measureMin, worst)
+		}
+	}
+}
+
+// runCorpus runs every vector in the corpus. With no arguments it walks the
+// repository's conformance/ directory; named files or directories replace it,
+// which is how the negative control in conformance-controls/ is run — the
+// control must turn this checker RED, and a run that skipped it would be
+// reporting green over a rule nobody checked.
+func runCorpus(c *checker, root string) {
+	var files []string
+	if args := os.Args[1:]; len(args) > 0 {
+		for _, arg := range args {
+			info, err := os.Stat(arg)
+			if err != nil {
+				c.n++
+				c.fails = append(c.fails, err.Error())
+				continue
+			}
+			if info.IsDir() {
+				found, _ := filepath.Glob(filepath.Join(arg, "*.txt"))
+				files = append(files, found...)
+			} else {
+				files = append(files, arg)
+			}
+		}
+		runCorpusFiles(c, files)
+		return
+	}
+
+	dir := filepath.Join(root, "conformance")
+	if _, err := os.Stat(dir); err != nil {
+		dir = filepath.Join(root, "..", "..", "conformance")
+	}
+	found, err := filepath.Glob(filepath.Join(dir, "*.txt"))
+	if err != nil || len(found) == 0 {
+		c.n++
+		c.fails = append(c.fails, "the corpus holds no vector files. The corpus is the conformance instrument; an empty one is a broken checkout, not a pass.")
+		return
+	}
+	runCorpusFiles(c, found)
+}
+
+func runCorpusFiles(c *checker, files []string) {
+	sort.Strings(files)
+	for _, f := range files {
+		vectors, err := parseVectorFile(f)
+		if err != nil {
+			c.n++
+			c.fails = append(c.fails, err.Error())
+			continue
+		}
+		for _, v := range vectors {
+			runCorpusVector(c, v)
+		}
+	}
+}
+
+// utf16 is imported for the boundary conversion an implementation with a 4 byte
+// wide character performs; the checker keeps the units it read, so the helper is
+// referenced here to state that the conversion is the platform's and not the
+// wire's.
+var _ = utf16.IsSurrogate

--- a/tools/conformance/corpus.go
+++ b/tools/conformance/corpus.go
@@ -27,7 +27,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"unicode/utf16"
 	"unicode/utf8"
 )
 
@@ -445,8 +444,7 @@ func encodeStep(w *BitWriter, s *step) error {
 		writeGroups(w, s.bits, 64)
 	case stepCompressedFloat:
 		f := math.Float32frombits(uint32(s.bits.Uint64()))
-		maxIntegerValue, n := compressedFloatParams(s.fmin, s.fmax, s.fres)
-		_ = maxIntegerValue
+		_, n := compressedFloatParams(s.fmin, s.fmax, s.fres)
 		w.bits(quantizeCompressedFloat(f, s.fmin, s.fmax, s.fres), n)
 	case stepBytes:
 		w.writeBytes(s.data)
@@ -688,7 +686,7 @@ func parseNumber(text string) (*big.Int, bool) {
 // ---------------------------------------------------------------------------
 // building steps
 
-func buildStep(spec string, v *vector) (*step, error) {
+func buildStep(spec string) (*step, error) {
 	words := strings.Fields(spec)
 	if len(words) == 0 {
 		return nil, fmt.Errorf("empty step")
@@ -726,7 +724,6 @@ func buildStep(spec string, v *vector) (*step, error) {
 	default:
 		return nil, fmt.Errorf("no runner for step %q", spec)
 	}
-	_ = v
 	return s, nil
 }
 
@@ -734,7 +731,7 @@ func buildSteps(v *vector) ([]*step, error) {
 	if v.operation == "sequence" {
 		var out []*step
 		for _, spec := range v.stepText {
-			s, err := buildStep(spec, v)
+			s, err := buildStep(spec)
 			if err != nil {
 				return nil, err
 			}
@@ -1065,9 +1062,3 @@ func runCorpusFiles(c *checker, files []string) {
 		}
 	}
 }
-
-// utf16 is imported for the boundary conversion an implementation with a 4 byte
-// wide character performs; the checker keeps the units it read, so the helper is
-// referenced here to state that the conversion is the platform's and not the
-// wire's.
-var _ = utf16.IsSurrogate

--- a/tools/conformance/verify_standard.go
+++ b/tools/conformance/verify_standard.go
@@ -813,6 +813,14 @@ func main() {
 	}
 	c.eq("doctored trailing bits: diagnostic flags the stream", trailingBits(doctored, db.i) != 0, true)
 
+	// ---- the shared corpus ------------------------------------------------
+	//
+	// The other half of this tool's job, and the half that is not about the
+	// library's own pinned emissions: every vector in conformance/, decoded,
+	// re-encoded and measured by the same document-derived machinery. See
+	// corpus.go. A corpus file this checker cannot drive FAILS.
+	runCorpus(c, root)
+
 	fmt.Printf("%d checks against STANDARD.md, %d failures\n", c.n, len(c.fails))
 	for _, f := range c.fails {
 		fmt.Println("  FAIL " + f)


### PR DESCRIPTION
The shared corpus covered two operations. It now covers every operation
STANDARD.md defines, with two negative controls that prove the gate responds.

**349 vectors, 18 files, one per covered operation.** Both gates run all of
them: `conformance.cpp` as the ctest target `conformance`, and the Go checker,
which is independent of `serialize.h`.

| file | vectors | file | vectors |
|---|---|---|---|
| `bits.txt` | 20 | `float.txt` | 18 |
| `bool.txt` | 5 | `double.txt` | 18 |
| `uint128.txt` | 7 | `compressed_float.txt` | 29 |
| `align.txt` | 10 | `object.txt` | 7 |
| `int.txt` | 26 | `bytes.txt` | 11 |
| `int64.txt` | 21 | `string.txt` | 38 |
| `int128.txt` | 19 | `wstring.txt` | 28 |
| `fixed.txt` | 34 | `sequence.txt` | 11 |
| `int_relative.txt` | 46 | `message.txt` | 1 |

Every vector is derived from the document's rules, never from an
implementation's output. `bits.txt` also covers the `uint8`/`uint16`/`uint32`/
`uint64` aliases, which the document makes aliases for exactly that operation.

## One vector per refusal rule, not one file per operation

Each rule below has a named vector, and each has an accepted twin one step
inside the same edge — usually sharing the refusal's bytes or its declaration —
so a reader that refuses on the declaration rather than on the decoded value
fails the twin.

| operation | refusal rule the page states | vector that pins it |
|---|---|---|
| `bits` | reading past the end | `bits-refuse-past-end-16-of-8`, twin `bits-accept-16-of-16` |
| `bool` | reading past the end | `bool-refuse-past-end-empty-stream` |
| `uint128` | reading past the end | `uint128-refuse-past-end-15-bytes` |
| `align` | padding bits must be zero | `align-refuse-one-non-zero-pad-bit`, `-four-`, `-seven-`, and `-only-the-highest-pad-bit-set` for a reader that stops early |
| `int` | decoded value outside `[min,max]` | `int-range-0-8-refuse-offset-one-past-the-span`, twin `int-range-0-8-costs-four-bits` |
| `int` | reading past the end | `int-refuse-past-end`, twin `int-accept-ten-bits-of-ten` |
| `int64` | offset past the span, computed unsigned | `int64-span-64-bits-refuse-offset-one-past-the-span`, twin `-accepts-its-maximum` |
| `int128` | offset past the span in the unsigned domain | `int128-128-bit-span-refuse-offset-one-past-the-span`, twin `-accepts-its-maximum` |
| `fixed` | offset past `raw_max - raw_min` | `fixed-q8-8-refuse-offset-one-past-the-raw-span` and the same at Q16.16, Q48.16, Q112.16, Q64.64 |
| `int_relative` | reconstruction outside the domain | `one-bit-refuse-past-domain` and `bounded-{3,5,9,13,17}-refuse-past-domain`, each twinned at the domain top on the same bytes |
| `int_relative` | reconstruction not greater than `previous` | `absolute-refuse-current-equal-to-previous`, `-below-previous` |
| `int_relative` | the absolute tier's 32 bits are unsigned | `absolute-refuse-top-bit-set`, twin `absolute-accept-domain-maximum` |
| `int_relative` | a bounded tier's own payload range | `bounded-{3,5,9,13,17}-refuse-payload-one-past-the-span`, each beside `-accept-high` |
| `float`, `double` | reading past the end | `float-refuse-past-end-24-of-32`, `double-refuse-past-end-56-of-64` |
| `compressed_float` | integer above `max_integer_value` | `-refuse-integer-one-past-max-integer-value`, in four declarations, each beside its accept boundary |
| `bytes` | non-zero alignment padding | `bytes-refuse-non-zero-align-padding`, twin `bytes-after-a-partial-byte` |
| `bytes` | reading past the end after the align | `bytes-refuse-past-end-after-the-align`, twin `bytes-accept-one-byte-after-the-align` |
| `string` | length past the buffer | `string-refuse-length-one-past-the-buffer`, twin `string-accepts-the-longest-length` |
| `string` | invalid UTF-8 | overlong, surrogate, above `10FFFF`, five-byte, truncated, lone continuation, `FE`/`FF` — 12 vectors, each beside the nearest well-formed sequence |
| `string` | interior NUL | first, middle and last byte separately, twin `string-accept-the-same-three-bytes-without-a-nul` |
| `wstring` | a group above `0xFFFF` | `wstring-refuse-group-one-above-ffff`, twin `wstring-accept-group-ffff` |
| `wstring` | an unpaired surrogate | both ends of both surrogate blocks alone, high-then-non-surrogate, low-first, high-final; twin `wstring-accept-surrogate-pair` |
| `wstring` | interior NUL | first, only and final group, twin `wstring-accept-two-basic-plane-groups` |
| Reader Obligations | failure is terminal | `sequence-refusal-is-terminal-after-bad-alignment`, `-after-a-range-refusal`, `-before-a-zero-bit-field`, `-after-a-string-refusal`, `object-refusal-propagates-out-of-the-nesting`; plus every refused vector, which the runner now follows with a further read |

Three rules have no vector and the files say why, in the rule's own words: a
span one less than a power of two admits no out-of-range offset (the full
`int32` range, `[0,7]`, `[0, 2^33-1]`, `[0, 16777215]` at resolution 1); an
align never reads past the end, because its padding always lies inside the byte
the preceding bits are in; and a `compressed_float` declaration whose poison is
in the declaration or the input value leaves the read path untouched, which the
document rules outright.

## Sequences, and what a single-operation record cannot say

`sequence.txt` and `object.txt` carry the interactions: alignment cost, which
depends on the bit index the previous operation left behind; a zero-bit field
between two wide ones, which must leave that index where it found it; the
narrow string aligning and the wide string not, in one stream; a nested object,
every vector twinned with the same operations unnested; and terminal failure,
built so a reader without the latch passes the failing step's successor.

`message.txt` is the message the Worked Example decodes: a `wstring`, the align
that follows it, and the Q8.8 field the align makes room for, 15 bytes the
document prints in full.

`measure_at_least` is new, and it is a floor rather than an equality because a
measure is a bound and not the packet size. Each floor is the true worst case
over every starting bit position, so the expected implementation's 7 bits per
alignment-performing operation passes, a tighter correct bound passes, and the
exact-from-zero accounting the document calls non-conforming falls below it.
`sequence-measure-worked-example` is the document's own `{ bits(8); align;
bits(8) }`: floor 23, where an exact-from-zero measure reports 16. The Go
checker computes the worst case independently and requires the corpus floor to
equal it.

## The controls

A gate nobody has seen go red is a claim, not a measurement. Three ctest
targets, all `WILL_FAIL`, so each passes exactly when the gate it guards goes
red.

**Control 1 — a corpus file whose operation has no runner.** Both gates must reject it rather than skip it.

```
running the conformance corpus
  FAIL control-a-runner-must-fail-on-an-operation-it-cannot-drive: no runner for parameter 'whatever' on operation 'no_such_operation' [conformance-controls/unknown-operation.txt]
1 vectors from 1 file(s): 0 writer checks, 0 measure checks, 1 failure(s)
this implementation and the shared corpus disagree. THE IMPLEMENTATION IS THE BUG.
```

```
93 checks against STANDARD.md, 1 failures
  FAIL control-a-runner-must-fail-on-an-operation-it-cannot-drive: no runner for operation "no_such_operation" [../../conformance-controls/unknown-operation.txt]
STANDARD.md and an implementation disagree. THE IMPLEMENTATION IS THE BUG.
exit status 1
```

**Control 2a — the align zero-padding rule deleted from a scratch copy of the reader.** Ten vectors across five files, and nothing else.

```
running the conformance corpus
  FAIL align-refuse-one-non-zero-pad-bit: the read succeeded, the corpus requires refusal [conformance/align.txt]
  FAIL align-refuse-four-non-zero-pad-bits: the read succeeded, the corpus requires refusal [conformance/align.txt]
  FAIL align-refuse-seven-non-zero-pad-bits: the read succeeded, the corpus requires refusal [conformance/align.txt]
  FAIL align-refuse-only-the-highest-pad-bit-set: the read succeeded, the corpus requires refusal [conformance/align.txt]
  FAIL align-refuse-only-the-lowest-pad-bit-set: the read succeeded, the corpus requires refusal [conformance/align.txt]
  FAIL bytes-zero-count-refuse-non-zero-align-padding: the read succeeded, the corpus requires refusal [conformance/bytes.txt]
  FAIL bytes-refuse-non-zero-align-padding: the read succeeded, the corpus requires refusal [conformance/bytes.txt]
  FAIL object-refusal-propagates-out-of-the-nesting: the read succeeded, the corpus requires refusal [conformance/object.txt]
  FAIL sequence-refusal-is-terminal-after-bad-alignment: the read succeeded, the corpus requires refusal [conformance/sequence.txt]
  FAIL string-refuse-non-zero-align-padding: the read succeeded, the corpus requires refusal [conformance/string.txt]
349 vectors from 18 file(s): 195 writer checks, 9 measure checks, 10 failure(s)
this implementation and the shared corpus disagree. THE IMPLEMENTATION IS THE BUG.
```

**Control 2b — the ranged int reconstruction sabotaged to drop `min`.** Twenty-one vectors.

```
running the conformance corpus
  FAIL int-negative-min-golden-field: step 1 decoded 0x0000000000000000000000000000003F, the corpus states -37 [conformance/int.txt]
  FAIL int-negative-min-accepts-its-minimum: step 1 decoded 0x00000000000000000000000000000000, the corpus states -100 [conformance/int.txt]
  FAIL int-negative-min-accepts-its-maximum: the read was refused, the corpus requires it to be accepted [conformance/int.txt]
  FAIL int-full-int32-range-golden-field: step 1 decoded 0x00000000000000000000000078A432EB, the corpus states -123456789 [conformance/int.txt]
  FAIL int-full-int32-range-minimum: step 1 decoded 0x00000000000000000000000000000000, the corpus states -2147483648 [conformance/int.txt]
  FAIL int-full-int32-range-maximum: step 1 decoded 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, the corpus states 2147483647 [conformance/int.txt]
  FAIL bounded-3-accept-low: the read was refused, the corpus requires it to be accepted [conformance/int_relative.txt]
  FAIL bounded-3-accept-high: step 1 decoded 0x00000000000000000000000000000068, the corpus states 106 [conformance/int_relative.txt]
  FAIL bounded-3-accept-at-domain-top: the read was refused, the corpus requires it to be accepted [conformance/int_relative.txt]
  ... 11 further FAIL lines
349 vectors from 18 file(s): 174 writer checks, 9 measure checks, 21 failure(s)
this implementation and the shared corpus disagree. THE IMPLEMENTATION IS THE BUG.
```

The sabotage is generated at configure time by replacing one line in a scratch
copy of the header, and a needle that stops matching is a `FATAL_ERROR` rather
than a silent no-op: a control that has quietly stopped sabotaging anything is
worse than no control.

## Findings

**Every `compressed_float` expectation reproduces from the page's formula in a
third arithmetic.** All nine decodes in that file were re-derived from the
document alone in plain IEEE-754 single precision — no `serialize.h`, no Go —
and every one matched, which is what makes them evidence rather than a
transcription of something that already agreed with itself.

**The ranged int's range rule is guarded twice.** `ReadStream::SerializeInteger`
rejects an offset past the span, and the `serialize_int` macro rejects the
decoded value again against `[min,max]`. Deleting either guard alone changes no
verdict, so no conformance vector can see it — which is why the second control
is aimed at the reconstruction instead. Not a defect against the page; the
behavior conforms. But Implementation Law says readers perform exactly the
refusal obligations of the standard "and nothing more", and this is one
comparison per ranged read on the hot path that no vector can justify. Left
alone here; worth a ruling.

**No disagreement between the page, the C++ implementation and the Go
checker.** Everything that went red in the first run was a defect in a vector I
had written, and each was fixed by re-deriving from the page: a hex-float
literal transcribed into a 23-bit field with 24 bits of significand; two
declarations whose span I claimed was 128 bits when the page's rule
(`bit length of raw_max - raw_min`) gives 127, `[0, 2^63-1]` in Q64.64 and
`[0, 2^127-1]` in `int128`; and a Q16.16 declaration whose raw bounds do not
fit its own 32-bit storage. The implementation was right in every case.

## Underdeterminations

Filed rather than worked around, and now named in STANDARD.md's remaining
silences with the reason each is open.

1. **The `fixed` rounding rule has no expressible vector.** The page requires
   "a conformance vector must pin a negative tie value that distinguishes the
   two rules", but the rounding happens where a value is quantized into a Q
   format or narrowed out of one, and no `serialize_fixed` call rounds — the
   page says so itself, "the wire itself never rounds" and "a rounding rule is
   not wire shape". No record whose input is a byte stream can reach it. It
   needs a record kind this format does not have: a narrowing record stating a
   raw value, a drop, and the result.

2. **The corpus has no writer record.** A vector's input is a stream, so it
   pins what a writer left on the wire but not the value a writer was handed.
   That reaches `compressed_float`'s discriminating band directly: the page
   requires the between-quanta inputs `0.005`, `0.025`, `0.105` and
   `9.995`, and none of them is statable here. Both clamp declarations' widths,
   accept boundaries and refusals are pinned, the non-zero-`min` decode is
   pinned bit exactly, and `8388608.0` — the fusion witness the page names — is
   pinned as a decode in each band, so the reader half is covered; the writer
   half still lives inline in the Go checker.

3. **The full 112-byte golden cannot ship without lifting bytes off the
   implementation.** The page prints 15 of its bytes and `message.txt` carries
   exactly those. The rest exist only as an array inside `serialize.h`, and a
   vector copied off the implementation it judges is the failure the corpus
   section opens by naming. Closing this means the document printing the rest.

4. **`wstring`'s decoded value is platform-shaped.** The corpus states UTF-16
   code units, which is the wire-level truth, and a 4-byte `wchar_t` runner
   compares after re-splitting a recombined code point. Both runners do this;
   the page could say it.

## Checks

Locally on macOS arm64, Debug and Release, and under asan + ubsan:

```
100% tests passed out of 8
Total Test time (real) =   0.51 sec
```

```
349 vectors from 18 file(s): 195 writer checks, 9 measure checks, 0 failure(s)
*** EVERY CONFORMANCE VECTOR PASSES ***
```

```
441 checks against STANDARD.md, 0 failures
Every pinned vector decodes from STANDARD.md alone.
```

Both C++03 legs pass too, including the one that makes the emulated 128-bit pair
the real storage type, which is where a degenerate wide range last diverged.

CI on the branch: every check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
