### PR TITLE
serialize 1.16.2: the family matrix pins the re-vendor commit, and three silences close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - os: windows-2025
             cmake_args: -A x64
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7
 
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_args }}
@@ -43,7 +43,7 @@ jobs:
       matrix:
         build_type: [Debug, Release]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7
 
       - name: Install s390x cross toolchain and qemu
         run: |
@@ -71,7 +71,7 @@ jobs:
     name: fuzz (libFuzzer)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7
 
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DSERIALIZE_FUZZ=ON -DCMAKE_CXX_COMPILER=clang++
@@ -86,7 +86,7 @@ jobs:
     name: asan + ubsan
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7
 
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer"
@@ -110,7 +110,7 @@ jobs:
     name: pre-C++11 consumer (clang -std=c++03)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7
 
       # -ffp-contract=off, not -ffast-math: this binary runs the golden and conformance
       # vectors, and those pin exact bytes and decoded bit patterns. Same rationale as
@@ -139,7 +139,7 @@ jobs:
     name: STANDARD.md conformance
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7
 
       # Checks the wire-format specification against the implementation. The
       # checker parses artifacts the real library produces using ONLY what

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -120,7 +120,7 @@ jobs:
           (github.event.issue.pull_request != null &&
           (github.event.comment.body == 'I have read the CAA and I hereby sign it, assigning copyright in my contributions to Más Bandwidth LLC.' ||
           github.event.comment.body == 'recheck'))
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08   # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7
 
       # the corpus is cached across runs so fuzzing is cumulative: each night
       # starts from the most recent corpus and saves the evolved one
       - name: Restore corpus
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9   # v6
         with:
           path: corpus
           key: fuzz-corpus-${{ github.run_id }}
@@ -41,14 +41,14 @@ jobs:
 
       - name: Save corpus
         if: always()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9   # v6
         with:
           path: corpus
           key: fuzz-corpus-${{ github.run_id }}
 
       - name: Upload crash reproducers
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # v7
         with:
           name: fuzz-crashes
           path: |

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -15,7 +15,7 @@ jobs:
     name: version consistency
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7
 
       - name: Check versions
         run: |
@@ -61,7 +61,7 @@ jobs:
     if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/heads/')
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7
         with:
           fetch-depth: 0          # tags and full history: the whole job is a comparison against the newest tag
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,20 @@ performance work here must not relearn:
   with CONFIGURE_DEPENDS so an added or removed file re-runs it, and an empty directory is a
   configure error. It is deliberately not generated from this code: a suite that regenerates its
   own expectations proves only that the library agrees with itself.
+- Three ctest targets are NEGATIVE CONTROLS, inverted with `WILL_FAIL`, and they exist because a
+  gate nobody has seen go red is a claim rather than a measurement:
+  `conformance-control-unknown-operation` proves the runner fails a vector whose operation it
+  cannot drive, and `conformance-control-align-padding` and the two
+  `conformance-control-ranged-*` targets build a scratch copy of the header with one line of a
+  refusal rule deleted and require the corpus to go red on exactly the vectors that pin it. A
+  needle that stops matching is a configure error, never a silent no-op. A rule guarded twice
+  cannot be controlled this way, which is why the read side range rule lives in exactly one
+  place at each width.
+- The whole 112-byte golden message is printed in STANDARD.md and carried in
+  `conformance/message.txt`. Its bytes come from the corpus encoder in `tools/conformance`,
+  which is written from the document, and the same tool requires that encoder, the page's byte
+  block and `golden_wire_bytes` to agree byte for byte. An implementation's output never
+  becomes the page's or the corpus's source.
 - The write side debug assertions are tested by [asserts.cpp](asserts.cpp), the ctest target
   `asserts`. It defines `serialize_assert` itself, so an assertion firing is an observable result
   rather than a process death and the target runs in Release too. A macro that narrows the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,12 +156,13 @@ performance work here must not relearn:
 - Three ctest targets are NEGATIVE CONTROLS, inverted with `WILL_FAIL`, and they exist because a
   gate nobody has seen go red is a claim rather than a measurement:
   `conformance-control-unknown-operation` proves the runner fails a vector whose operation it
-  cannot drive, and `conformance-control-align-padding` and the two
-  `conformance-control-ranged-*` targets build a scratch copy of the header with one line of a
-  refusal rule deleted and require the corpus to go red on exactly the vectors that pin it. A
-  needle that stops matching is a configure error, never a silent no-op. A rule guarded twice
-  cannot be controlled this way, which is why the read side range rule lives in exactly one
-  place at each width.
+  cannot drive, and the four `conformance-control-*` sabotage targets each build a scratch copy
+  of the header with one line of a refusal rule deleted and require the corpus to go red on
+  exactly the vectors that pin it: the align zero-padding check, the ranged int's
+  reconstruction, the ranged int's range check, and the failure state consult in the degenerate
+  fixed point field. A needle that stops matching is a configure error, never a silent no-op. A
+  rule guarded twice cannot be controlled this way, which is why the read side range rule lives
+  in exactly one place at each width.
 - The whole 112-byte golden message is printed in STANDARD.md and carried in
   `conformance/message.txt`. Its bytes come from the corpus encoder in `tools/conformance`,
   which is written from the document, and the same tool requires that encoder, the page's byte

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ if(SERIALIZE_BUILD_TESTS)
     # quietly stopped sabotaging anything is worse than no control at all. conformance.cpp is
     # copied alongside the sabotaged header because it includes "serialize.h" with quotes, which
     # resolves against the including file's own directory first.
-    set(SERIALIZE_CONTROL_NAMES align-padding ranged-reconstruction ranged-range)
+    set(SERIALIZE_CONTROL_NAMES align-padding ranged-reconstruction ranged-range fixed-degenerate-terminal)
     set(SERIALIZE_CONTROL_NEEDLE_align-padding
         "                if ( value != 0 )")
     set(SERIALIZE_CONTROL_RULE_align-padding
@@ -178,6 +178,14 @@ if(SERIALIZE_BUILD_TESTS)
         "            if ( unsigned_value > uint32_t(max) - uint32_t(min) )")
     set(SERIALIZE_CONTROL_RULE_ranged-range
         "a ranged int whose offset is past the span is refused")
+    # The degenerate fixed point field, which consumes no bits and would otherwise always
+    # succeed. The needle appears in both FixedPointSerializer specializations and both are
+    # sabotaged, which is what the rule needs: a zero bit field is zero bits whatever operation
+    # declares it and whatever storage width carries it.
+    set(SERIALIZE_CONTROL_NEEDLE_fixed-degenerate-terminal
+        "                if ( !stream.SerializeInteger( degenerate, 0, 0 ) )")
+    set(SERIALIZE_CONTROL_RULE_fixed-degenerate-terminal
+        "every read consults the failure state, zero bit reads included")
     # each replacement keeps the sabotaged line compiling warning-free: the padding is at most
     # seven bits, so comparing it against 0xFFFFFFFF is a condition that never holds while still
     # reading the variable the deleted rule read
@@ -189,6 +197,10 @@ if(SERIALIZE_BUILD_TESTS)
     # the sabotaged condition never holds while still reading every variable the deleted rule read
     set(SERIALIZE_CONTROL_PATCH_ranged-range
         "            if ( uint64_t(unsigned_value) > uint64_t( uint32_t(max) - uint32_t(min) ) + 0xFFFFFFFFull ) // NEGATIVE CONTROL: this rule is deleted on purpose")
+    # a refused read leaves its destination unwritten, so the added conjunct is false exactly
+    # when the deleted rule would have fired, and the sabotaged line still reads both operands
+    set(SERIALIZE_CONTROL_PATCH_fixed-degenerate-terminal
+        "                if ( !stream.SerializeInteger( degenerate, 0, 0 ) && degenerate != 0 ) // NEGATIVE CONTROL: this rule is deleted on purpose")
 
     file(READ ${CMAKE_CURRENT_SOURCE_DIR}/serialize.h SERIALIZE_HEADER_TEXT)
     foreach(control ${SERIALIZE_CONTROL_NAMES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(CMAKE_TARGET_MESSAGES OFF)
 endif()
 
-project(serialize VERSION 1.16.1 LANGUAGES CXX)
+project(serialize VERSION 1.16.2 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
@@ -161,21 +161,23 @@ if(SERIALIZE_BUILD_TESTS)
     # quietly stopped sabotaging anything is worse than no control at all. conformance.cpp is
     # copied alongside the sabotaged header because it includes "serialize.h" with quotes, which
     # resolves against the including file's own directory first.
-    set(SERIALIZE_CONTROL_NAMES align-padding ranged-reconstruction)
+    set(SERIALIZE_CONTROL_NAMES align-padding ranged-reconstruction ranged-range)
     set(SERIALIZE_CONTROL_NEEDLE_align-padding
         "                if ( value != 0 )")
     set(SERIALIZE_CONTROL_RULE_align-padding
         "readers must verify that the alignment padding bits are zero")
-    # Deliberately the RECONSTRUCTION and not the range check beside it. The ranged int's range
-    # rule is guarded twice — once in ReadStream::SerializeInteger against the offset, and again
-    # in the serialize_int macro against the decoded value — so deleting either guard alone
-    # changes no verdict and no vector can see it. A control aimed there would report green while
-    # proving nothing, which is the failure these controls exist to prevent. Dropping min from the
-    # reconstruction is a single line with no second guard behind it.
+    # Two controls over the ranged int, one per rule, because the two rules fail differently: the
+    # reconstruction decides what an accepted offset means, and the range check decides which
+    # offsets are accepted at all. Each is a single line with no second guard behind it, so
+    # deleting it changes the verdict on exactly the vectors that pin it.
     set(SERIALIZE_CONTROL_NEEDLE_ranged-reconstruction
         "            value = int32_t( unsigned_value + uint32_t(min) );")
     set(SERIALIZE_CONTROL_RULE_ranged-reconstruction
         "a ranged int decodes to its offset plus min")
+    set(SERIALIZE_CONTROL_NEEDLE_ranged-range
+        "            if ( unsigned_value > uint32_t(max) - uint32_t(min) )")
+    set(SERIALIZE_CONTROL_RULE_ranged-range
+        "a ranged int whose offset is past the span is refused")
     # each replacement keeps the sabotaged line compiling warning-free: the padding is at most
     # seven bits, so comparing it against 0xFFFFFFFF is a condition that never holds while still
     # reading the variable the deleted rule read
@@ -183,6 +185,10 @@ if(SERIALIZE_BUILD_TESTS)
         "                if ( value == 0xFFFFFFFF ) // NEGATIVE CONTROL: this rule is deleted on purpose")
     set(SERIALIZE_CONTROL_PATCH_ranged-reconstruction
         "            value = int32_t( unsigned_value ); // NEGATIVE CONTROL: min is dropped on purpose")
+    # the widened right hand side is at least 0xFFFFFFFF and the offset is at most 0xFFFFFFFF, so
+    # the sabotaged condition never holds while still reading every variable the deleted rule read
+    set(SERIALIZE_CONTROL_PATCH_ranged-range
+        "            if ( uint64_t(unsigned_value) > uint64_t( uint32_t(max) - uint32_t(min) ) + 0xFFFFFFFFull ) // NEGATIVE CONTROL: this rule is deleted on purpose")
 
     file(READ ${CMAKE_CURRENT_SOURCE_DIR}/serialize.h SERIALIZE_HEADER_TEXT)
     foreach(control ${SERIALIZE_CONTROL_NAMES})

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -9,15 +9,15 @@ These are the releases that carry format version 1.1:
 
 | runtime | language | release |
 |---|---|---|
-| [serialize](https://github.com/mas-bandwidth/serialize) | C++ | `v1.16.1` |
-| [serialize.c](https://github.com/mas-bandwidth/serialize.c) | C | `v1.9.1` |
-| [serialize.cs](https://github.com/mas-bandwidth/serialize.cs) | C# | `v1.9.0` |
-| [serialize.go](https://github.com/mas-bandwidth/serialize.go) | Go | `v1.15.0` |
-| [serialize.rs](https://github.com/mas-bandwidth/serialize.rs) | Rust | `v2.3.0` |
-| [serialize.js](https://github.com/mas-bandwidth/serialize.js) | JavaScript | `v1.4.0` |
-| [serialize.dart](https://github.com/mas-bandwidth/serialize.dart) | Dart | `v1.1.0` |
-| [serialize.java](https://github.com/mas-bandwidth/serialize.java) | Java | `v1.1.0` |
-| [serialize.elixir](https://github.com/mas-bandwidth/serialize.elixir) | Elixir | `v1.1.0` |
+| [serialize](https://github.com/mas-bandwidth/serialize) | C++ | `v1.16.2` |
+| [serialize.c](https://github.com/mas-bandwidth/serialize.c) | C | `v1.9.2` |
+| [serialize.cs](https://github.com/mas-bandwidth/serialize.cs) | C# | `v1.9.1` |
+| [serialize.go](https://github.com/mas-bandwidth/serialize.go) | Go | `v1.15.1` |
+| [serialize.rs](https://github.com/mas-bandwidth/serialize.rs) | Rust | `v2.3.2` |
+| [serialize.js](https://github.com/mas-bandwidth/serialize.js) | JavaScript | `v1.4.2` |
+| [serialize.dart](https://github.com/mas-bandwidth/serialize.dart) | Dart | `v1.1.2` |
+| [serialize.java](https://github.com/mas-bandwidth/serialize.java) | Java | `v1.1.2` |
+| [serialize.elixir](https://github.com/mas-bandwidth/serialize.elixir) | Elixir | `v1.1.2` |
 
 The library versions differ across the family and always will: they count each
 implementation's own releases. The format version is the only number that says
@@ -28,8 +28,8 @@ whether two endpoints can talk to each other.
 Every release above vendors the standard and the corpus from one commit of this
 repository:
 
-    standard_commit  7e42c0fda9c734a323af5c5f79efab82191ca294
-    corpus_commit    7e42c0fda9c734a323af5c5f79efab82191ca294
+    standard_commit  7e0515e952f3373d001ec1899adf9dffb823e1c5
+    corpus_commit    7e0515e952f3373d001ec1899adf9dffb823e1c5
 
 The pin names a commit and never a branch. `main` moves, so a claim proved
 against `main` is a claim about whatever `main` happened to be that morning. The

--- a/COMPATIBILITY.txt
+++ b/COMPATIBILITY.txt
@@ -18,8 +18,8 @@
 # separate records, and each line is a key and its value.
 
 format_version 1.1
-standard_commit 7e42c0fda9c734a323af5c5f79efab82191ca294
-corpus_commit 7e42c0fda9c734a323af5c5f79efab82191ca294
+standard_commit 7e0515e952f3373d001ec1899adf9dffb823e1c5
+corpus_commit 7e0515e952f3373d001ec1899adf9dffb823e1c5
 
 # The C++ implementation is this repository, so it vendors nothing: it is where STANDARD.md
 # and conformance/ live. Its row is checked against the working checkout rather than against
@@ -28,23 +28,23 @@ corpus_commit 7e42c0fda9c734a323af5c5f79efab82191ca294
 runtime serialize
 language C++
 repository mas-bandwidth/serialize
-release v1.16.1
+release v1.16.2
 version_file CMakeLists.txt
-version_pattern project(serialize VERSION 1.16.1 LANGUAGES CXX)
+version_pattern project(serialize VERSION 1.16.2 LANGUAGES CXX)
 
 runtime serialize.c
 language C
 repository mas-bandwidth/serialize.c
-release v1.9.1
+release v1.9.2
 version_file serialize.h
-version_pattern #define SERIALIZE_VERSION "1.9.1"
+version_pattern #define SERIALIZE_VERSION "1.9.2"
 
 runtime serialize.cs
 language C#
 repository mas-bandwidth/serialize.cs
-release v1.9.0
+release v1.9.1
 version_file src/Serialize.csproj
-version_pattern <Version>1.9.0</Version>
+version_pattern <Version>1.9.1</Version>
 
 # serialize.go carries no version string: a Go module's version is its tag, and duplicating
 # it in a file would only create a second place for it to be wrong. The row's release is
@@ -53,41 +53,41 @@ version_pattern <Version>1.9.0</Version>
 runtime serialize.go
 language Go
 repository mas-bandwidth/serialize.go
-release v1.15.0
+release v1.15.1
 version_file -
 version_pattern -
 
 runtime serialize.rs
 language Rust
 repository mas-bandwidth/serialize.rs
-release v2.3.0
+release v2.3.2
 version_file Cargo.toml
-version_pattern version = "2.3.0"
+version_pattern version = "2.3.2"
 
 runtime serialize.js
 language JavaScript
 repository mas-bandwidth/serialize.js
-release v1.4.0
+release v1.4.2
 version_file package.json
-version_pattern "version": "1.4.0"
+version_pattern "version": "1.4.2"
 
 runtime serialize.dart
 language Dart
 repository mas-bandwidth/serialize.dart
-release v1.1.0
+release v1.1.2
 version_file pubspec.yaml
-version_pattern version: 1.1.0
+version_pattern version: 1.1.2
 
 runtime serialize.java
 language Java
 repository mas-bandwidth/serialize.java
-release v1.1.0
+release v1.1.2
 version_file src/serialize/SerializeUtil.java
-version_pattern public static final String VERSION = "1.1.0";
+version_pattern public static final String VERSION = "1.1.2";
 
 runtime serialize.elixir
 language Elixir
 repository mas-bandwidth/serialize.elixir
-release v1.1.0
+release v1.1.2
 version_file mix.exs
-version_pattern version: "1.1.0"
+version_pattern version: "1.1.2"

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1089,7 +1089,7 @@ operations are:
 | `string.txt` | `string` | valid UTF-8 accepted, and invalid UTF-8, an interior NUL and an out-of-range length refused |
 | `wstring.txt` | `wstring` | no alignment anywhere, a surrogate pair accepted, and an unpaired surrogate, a group above `0xFFFF` and a zero group refused |
 | `object.txt` | `object` | that it adds no bytes of its own, each vector twinned with the same operations unnested |
-| `sequence.txt` | sequences of operations | alignment after an odd width, a zero-bit field between wide ones, terminal failure, and the measure floor |
+| `sequence.txt` | sequences of operations | alignment after an odd width, a zero-bit field between wide ones, terminal failure before a zero-bit ranged field and before a zero-bit fixed point one, and the measure floor |
 | `message.txt` | the Worked Example's message | three operations across an alignment boundary, and the whole 112-byte golden message, byte for byte |
 
 Adding a file here is how a rule becomes a family obligation, and the table

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -693,6 +693,75 @@ bits — four 32-bit groups). A decoder that assembles the groups in the wrong
 order, or puts the remainder anywhere but the most significant position,
 decodes the wrong values here.
 
+### The whole message
+
+The fields above are three of the message's twenty-eight operations. Here is all
+of it, in the step spelling the shared corpus uses, with the value each operation
+carries. `conformance/message.txt` states the same message as a vector, so every
+implementation in the family runs it.
+
+| # | operation | value |
+|---|---|---|
+| 1 | `bits 4` | 13 |
+| 2 | `bits 11` | 1445 |
+| 3 | `bits 24` | 11259375 |
+| 4 | `bits 32` | 3735928559 (`0xDEADBEEF`) |
+| 5 | `int -100 100` | -37 |
+| 6 | `int -2147483648 2147483647` | -123456789 |
+| 7 | `bool` | true |
+| 8 | `float` | 3.1415926 (`0x40490FDA`) |
+| 9 | `compressed_float 0 10 0.01` | 5.0 (`0x40A00000`) |
+| 10 | `double` | 1/3 (`0x3FD5555555555555`) |
+| 11 | `bits 8` | 127 |
+| 12 | `bits 16` | 4660 |
+| 13 | `bits 32` | 305419896 |
+| 14 | `bits 64` | 1311768467463790320 |
+| 15 | `int_relative 100` | 101 |
+| 16 | `int_relative 100` | 2100 |
+| 17 | `align` | - |
+| 18 | `bytes 7` | `DE AD BE EF CA FE 01` |
+| 19 | `string 16` | `golden` |
+| 20 | `wstring 8` | `043C 0438 0440` |
+| 21 | `align` | - |
+| 22 | `fixed 8 8 -100 100` | -832 |
+| 23 | `fixed 16 16 -2000 2000` | 80904192 |
+| 24 | `fixed 48 16 -100000 100000` | -3559993401 |
+| 25 | `fixed 16 16 0 30000` | 1966079999 |
+| 26 | `align` | - |
+| 27 | `fixed 112 16 -144115188075855872 144115188075855872` | -6472691358699745 |
+| 28 | `fixed 64 64 -9223372036854775808 9223372036854775807` | 1512366075204170930115394234220888865 |
+
+A `-` marks an operation that produces no value of its own. A value written as a
+hexadecimal pattern is stated that way because it is compared as a bit pattern
+rather than as a number, which is what `float`, `double` and `compressed_float`
+require. The `fixed` values are raw scaled integers, not
+real units, because that is what the operation carries.
+
+The whole message is 112 bytes:
+
+    0x5D 0xDA 0xF7 0xE6 0xD5 0x77 0xDF 0x56 0xEF 0x9F 0x75 0x19
+    0x52 0xBC 0xDA 0x0F 0x49 0x40 0xF4 0x55 0x55 0x55 0x55 0x55
+    0x55 0x55 0xFF 0xFC 0xD1 0x48 0xE0 0x59 0xD1 0x48 0xC0 0x7B
+    0xF3 0x6A 0xE2 0x59 0xD1 0x48 0x84 0xB7 0x06 0xDE 0xAD 0xBE
+    0xEF 0xCA 0xFE 0x01 0x06 0x67 0x6F 0x6C 0x64 0x65 0x6E 0xE3
+    0x21 0x00 0x00 0xC0 0x21 0x00 0x00 0x00 0x22 0x00 0x00 0x00
+    0xC0 0x60 0x00 0x80 0xA2 0x7C 0xFC 0xEC 0x26 0xCB 0xFF 0xFF
+    0x4B 0x1D 0x1F 0xEF 0xD2 0x1A 0x1F 0x01 0xE9 0xFF 0xFF 0x09
+    0x19 0x2A 0x3B 0x4C 0x5D 0x6E 0x7F 0x78 0x6F 0x5E 0x4D 0x3C
+    0x2B 0x1A 0x09 0x04
+
+It occupies 891 bits, so the final byte carries three bits of message and five bits
+of zero padding, which is the writer obligation under Reader Obligations. A
+conforming measure reports at least 895 bits for it, four more than the stream
+occupies from an aligned start, because the three aligns, the byte block and the
+string each cost more from some other starting position.
+
+These bytes are not copied out of an implementation. They are produced by encoding
+the fields above with a writer written from this document alone, in
+`tools/conformance`, and they are printed here because that writer, this byte block
+and the C++ implementation's pinned emission agree byte for byte, which the same
+tool checks on every run.
+
 ## Read-only and write-only forms
 
 Every operation above has `read_` and `write_` variants — `read_string`,
@@ -1021,7 +1090,7 @@ operations are:
 | `wstring.txt` | `wstring` | no alignment anywhere, a surrogate pair accepted, and an unpaired surrogate, a group above `0xFFFF` and a zero group refused |
 | `object.txt` | `object` | that it adds no bytes of its own, each vector twinned with the same operations unnested |
 | `sequence.txt` | sequences of operations | alignment after an odd width, a zero-bit field between wide ones, terminal failure, and the measure floor |
-| `message.txt` | the Worked Example's message | three operations across an alignment boundary, byte for byte |
+| `message.txt` | the Worked Example's message | three operations across an alignment boundary, and the whole 112-byte golden message, byte for byte |
 
 Adding a file here is how a rule becomes a family obligation, and the table
 above moves with the directory.
@@ -1051,7 +1120,6 @@ vector would pin. The tie-break sentence above stands until this list is empty.
 |---|---|---|
 | `fixed` | a negative tie value, which separates half away from zero from an arithmetic shift | the rounding happens where a value is quantized into a Q format or narrowed out of one, and no `serialize_fixed` call rounds: the wire round trip is exact, this document says as much, and no record whose input is a byte stream can reach the rule. It needs a record shape this format does not have |
 | `compressed_float` | the between-quanta writer inputs, and the fusion witness as a WRITE | a vector's input is a stream, so it can pin what a writer left on the wire but not the value a writer was handed. Both clamp declarations' widths, boundaries and refusals are pinned, and `8388608.0` is pinned as a decode in each of them; the writer inputs need a record shape this format does not have |
-| Worked Example | the whole 112-byte golden message | this document prints 15 of its bytes and `message.txt` carries exactly those. The rest exist only inside an implementation, and a vector copied off the implementation it judges is the failure this section opens by naming |
 
 **The vector format.** A vector file is text. `#` begins a comment, blank lines
 separate records, and each record is `key` and value, one per line:
@@ -1082,7 +1150,11 @@ produces for that value.
 **Values are typed by the operation's table.** A `param` takes the type its own
 section gives that parameter, so `min` and `max` under `fixed` are whole real
 units, `buffer_size` under `string` is a byte count, and `res` under
-`compressed_float` is a `float32`.
+`compressed_float` is a `float32`. A `wstring` value is stated as the transmitted
+UTF-16 **code units**, four hexadecimal digits each, because that is what the
+groups carry. A runtime whose `wchar_t` is wider recombines surrogate pairs into
+code points on read, so its runner splits them again before comparing, and both
+platforms are held to the same units and the same bytes.
 
 **Lexical rules.** `#` begins a comment at the start of a line and nowhere
 else, numbers are written as signed decimal or as `0x` hexadecimal, and a
@@ -1093,7 +1165,9 @@ is how `float` and `double` vectors are stated.
 **A sequence vector states more than one operation.** Its `operation` is
 `sequence`, its steps are `param step = ` lines in order, and `expect value`
 lists one entry per step separated by ` | `, with `-` for a step that produces
-no value of its own. Sequences carry what a single-operation record cannot:
+no value of its own. There is one step spelling per operation this document
+defines, listed at the head of `conformance/sequence.txt`, so any message the
+format can carry can be stated as a sequence, the golden message included. Sequences carry what a single-operation record cannot:
 alignment cost, which depends on the bit index the previous operation left
 behind; a zero-bit field, which must leave that index exactly where it found
 it; a nested `object`, spelled `object <n>` to wrap the next `n` steps; and

--- a/conformance.cpp
+++ b/conformance.cpp
@@ -82,7 +82,7 @@ const int MaxBytes = 256;
 const int MaxSlack = 8;                 // the buffer contract: at least 8 bytes past the data
 const uint8_t SlackFill = 0xA5;         // non-zero, so a read that strays past the end is visible
 const int MaxParams = 8;
-const int MaxSteps = 8;
+const int MaxSteps = 48;                // the golden message is 28 operations long
 
 enum ExpectKind
 {
@@ -455,13 +455,17 @@ enum FixedDeclaration
     FIXED_Q32_0_0_5,
     FIXED_Q16_16_7_7,
     FIXED_Q16_16_M32768_32767,
+    FIXED_Q16_16_M2000_2000,
+    FIXED_Q16_16_0_30000,
     FIXED_Q48_16_0_131072,
+    FIXED_Q48_16_M100000_100000,
     FIXED_Q112_16_M9_M9,
     FIXED_Q112_16_0_2P58,
     FIXED_Q112_16_M2P57_2P57,
     FIXED_Q64_64_0_0,
     FIXED_Q64_64_3_3,
-    FIXED_Q64_64_0_INT64MAX
+    FIXED_Q64_64_0_INT64MAX,
+    FIXED_Q64_64_FULL_INT64
 };
 
 static FixedDeclaration fixed_declaration( int64_t integerBits, int64_t fractionBits, serialize::int128_t min, serialize::int128_t max )
@@ -473,13 +477,17 @@ static FixedDeclaration fixed_declaration( int64_t integerBits, int64_t fraction
     if ( integerBits == 32  && fractionBits == 0  && min == 0    && max == 5 )       return FIXED_Q32_0_0_5;
     if ( integerBits == 16  && fractionBits == 16 && min == 7    && max == 7 )       return FIXED_Q16_16_7_7;
     if ( integerBits == 16  && fractionBits == 16 && min == -32768 && max == 32767 ) return FIXED_Q16_16_M32768_32767;
+    if ( integerBits == 16  && fractionBits == 16 && min == -2000 && max == 2000 )   return FIXED_Q16_16_M2000_2000;
+    if ( integerBits == 16  && fractionBits == 16 && min == 0    && max == 30000 )   return FIXED_Q16_16_0_30000;
     if ( integerBits == 48  && fractionBits == 16 && min == 0    && max == 131072 )  return FIXED_Q48_16_0_131072;
+    if ( integerBits == 48  && fractionBits == 16 && min == -100000 && max == 100000 ) return FIXED_Q48_16_M100000_100000;
     if ( integerBits == 112 && fractionBits == 16 && min == -9   && max == -9 )      return FIXED_Q112_16_M9_M9;
     if ( integerBits == 112 && fractionBits == 16 && min == 0    && max == two58 )   return FIXED_Q112_16_0_2P58;
     if ( integerBits == 112 && fractionBits == 16 && min == -two57 && max == two57 ) return FIXED_Q112_16_M2P57_2P57;
     if ( integerBits == 64  && fractionBits == 64 && min == 0    && max == 0 )       return FIXED_Q64_64_0_0;
     if ( integerBits == 64  && fractionBits == 64 && min == 3    && max == 3 )       return FIXED_Q64_64_3_3;
     if ( integerBits == 64  && fractionBits == 64 && min == 0    && max == serialize::int128_t( 9223372036854775807LL ) ) return FIXED_Q64_64_0_INT64MAX;
+    if ( integerBits == 64  && fractionBits == 64 && min == serialize::int128_t( INT64_MIN ) && max == serialize::int128_t( 9223372036854775807LL ) ) return FIXED_Q64_64_FULL_INT64;
     return FIXED_NONE;
 }
 
@@ -526,10 +534,31 @@ static bool run_fixed_declaration( Stream & stream, FixedDeclaration declaration
             raw = serialize::int128_t( (int64_t) value );
             return true;
         }
+        case FIXED_Q16_16_M2000_2000:
+        {
+            int32_t value = (int32_t) (int64_t) raw;
+            if ( !op_fixed<16, 16, -2000, 2000, int32_t>( stream, value ) ) return false;
+            raw = serialize::int128_t( (int64_t) value );
+            return true;
+        }
+        case FIXED_Q16_16_0_30000:
+        {
+            int32_t value = (int32_t) (int64_t) raw;
+            if ( !op_fixed<16, 16, 0, 30000, int32_t>( stream, value ) ) return false;
+            raw = serialize::int128_t( (int64_t) value );
+            return true;
+        }
         case FIXED_Q48_16_0_131072:
         {
             int64_t value = (int64_t) raw;
             if ( !op_fixed<48, 16, 0, 131072, int64_t>( stream, value ) ) return false;
+            raw = serialize::int128_t( value );
+            return true;
+        }
+        case FIXED_Q48_16_M100000_100000:
+        {
+            int64_t value = (int64_t) raw;
+            if ( !op_fixed<48, 16, -100000, 100000, int64_t>( stream, value ) ) return false;
             raw = serialize::int128_t( value );
             return true;
         }
@@ -572,6 +601,13 @@ static bool run_fixed_declaration( Stream & stream, FixedDeclaration declaration
         {
             serialize::int128_t value = raw;
             if ( !op_fixed<64, 64, 0, 9223372036854775807LL, serialize::int128_t>( stream, value ) ) return false;
+            raw = value;
+            return true;
+        }
+        case FIXED_Q64_64_FULL_INT64:
+        {
+            serialize::int128_t value = raw;
+            if ( !op_fixed<64, 64, INT64_MIN, 9223372036854775807LL, serialize::int128_t>( stream, value ) ) return false;
             raw = value;
             return true;
         }
@@ -876,6 +912,34 @@ static bool step_from_words( const Vector & vector, const char * text, Step & st
         step.kind = STEP_FLOAT;
         return true;
     }
+    if ( strcmp( words[0], "double" ) == 0 && numWords == 1 )
+    {
+        step.kind = STEP_DOUBLE;
+        return true;
+    }
+    if ( strcmp( words[0], "uint128" ) == 0 && numWords == 1 )
+    {
+        step.kind = STEP_UINT128;
+        return true;
+    }
+    if ( strcmp( words[0], "int_relative" ) == 0 && numWords == 2 && parse_number( words[1], a ) )
+    {
+        step.kind = STEP_INT_RELATIVE;
+        step.previous = (int32_t) (int64_t) a;
+        return true;
+    }
+    if ( strcmp( words[0], "compressed_float" ) == 0 && numWords == 4 )
+    {
+        char * end = NULL;
+        step.fmin = (float) strtod( words[1], &end );
+        if ( end == words[1] || *end != '\0' ) return false;
+        step.fmax = (float) strtod( words[2], &end );
+        if ( end == words[2] || *end != '\0' ) return false;
+        step.fres = (float) strtod( words[3], &end );
+        if ( end == words[3] || *end != '\0' ) return false;
+        step.kind = STEP_COMPRESSED_FLOAT;
+        return true;
+    }
     if ( strcmp( words[0], "bytes" ) == 0 && numWords == 2 && parse_number( words[1], a ) )
     {
         step.kind = STEP_BYTES;
@@ -894,9 +958,10 @@ static bool step_from_words( const Vector & vector, const char * text, Step & st
         step.width = (int64_t) a;
         return true;
     }
-    if ( strcmp( words[0], "int" ) == 0 && numWords == 3 && parse_number( words[1], a ) && parse_number( words[2], b ) )
+    if ( ( strcmp( words[0], "int" ) == 0 || strcmp( words[0], "int64" ) == 0 || strcmp( words[0], "int128" ) == 0 )
+         && numWords == 3 && parse_number( words[1], a ) && parse_number( words[2], b ) )
     {
-        step.kind = STEP_INT;
+        step.kind = strcmp( words[0], "int" ) == 0 ? STEP_INT : ( strcmp( words[0], "int64" ) == 0 ? STEP_INT64 : STEP_INT128 );
         step.min = a;
         step.max = b;
         return true;

--- a/conformance/message.txt
+++ b/conformance/message.txt
@@ -22,15 +22,13 @@
 # corpus where three different operations meet across an alignment boundary
 # with a byte-for-byte expectation the page prints in full.
 #
-# It is a FRAGMENT of the 112-byte golden and not the whole of it, deliberately.
-# The remaining fields' bytes appear nowhere in STANDARD.md; they exist only as
-# an array inside serialize.h, and lifting them here would put an
-# implementation's output into the corpus, which is the one thing the corpus
-# must never contain — "no checker reimplements the codec and then checks that
-# reimplementation against itself", and a vector copied off the implementation
-# it is meant to judge is the same failure wearing a different coat. Shipping
-# the full golden needs the document to print the rest of its bytes; that is
-# filed as an underdetermination rather than worked around here.
+# The first record below is that fragment. The second is the whole 112-byte
+# message, whose bytes STANDARD.md now prints in full. Those bytes are not
+# copied off an implementation: they are produced by encoding the message's
+# fields with a writer written from the document alone, in tools/conformance,
+# and they are carried here only because that writer and the C++ writer's
+# pinned emission agree byte for byte. A vector copied off the implementation
+# it is meant to judge would be the failure this corpus exists to prevent.
 #
 # The wide string ends at bit 99, three bits into byte 12, so the align pads
 # the remaining five bits of that byte — which is why the document's 13-byte
@@ -45,4 +43,56 @@ bytes E3 21 00 00 C0 21 00 00 00 22 00 00 00 C0 60
 expect value = 043C 0438 0440 | - | -832
 consumed 120
 measure_at_least 122
+writer canonical
+
+# The whole golden message, every operation this format defines meeting every
+# other one in a single stream: all four raw bit widths, a narrow and a full
+# range ranged int, a bool, a float, a quantized compressed float, a double,
+# four unsigned widths, both interesting tiers of the relative integer ladder,
+# a byte block, a narrow string, a wide string, and six fixed point fields
+# across three storage widths and three alignment boundaries.
+#
+# It ends at bit 891, three bits into byte 111, so the final byte carries five
+# bits of zero padding: the writer obligation, pinned by writer = canonical
+# over the whole stream.
+#
+# The measure floor is the true worst case over every starting bit position,
+# which is four bits above the 891 this stream occupies from an aligned start,
+# because the three aligns, the bytes and the string each cost more from some
+# other start than they cost from this one.
+
+operation sequence
+name message-golden-whole
+param step = bits 4
+param step = bits 11
+param step = bits 24
+param step = bits 32
+param step = int -100 100
+param step = int -2147483648 2147483647
+param step = bool
+param step = float
+param step = compressed_float 0 10 0.01
+param step = double
+param step = bits 8
+param step = bits 16
+param step = bits 32
+param step = bits 64
+param step = int_relative 100
+param step = int_relative 100
+param step = align
+param step = bytes 7
+param step = string 16
+param step = wstring 8
+param step = align
+param step = fixed 8 8 -100 100
+param step = fixed 16 16 -2000 2000
+param step = fixed 48 16 -100000 100000
+param step = fixed 16 16 0 30000
+param step = align
+param step = fixed 112 16 -144115188075855872 144115188075855872
+param step = fixed 64 64 -9223372036854775808 9223372036854775807
+bytes 5D DA F7 E6 D5 77 DF 56 EF 9F 75 19 52 BC DA 0F 49 40 F4 55 55 55 55 55 55 55 FF FC D1 48 E0 59 D1 48 C0 7B F3 6A E2 59 D1 48 84 B7 06 DE AD BE EF CA FE 01 06 67 6F 6C 64 65 6E E3 21 00 00 C0 21 00 00 00 22 00 00 00 C0 60 00 80 A2 7C FC EC 26 CB FF FF 4B 1D 1F EF D2 1A 1F 01 E9 FF FF 09 19 2A 3B 4C 5D 6E 7F 78 6F 5E 4D 3C 2B 1A 09 04
+expect value = 13 | 1445 | 11259375 | 3735928559 | -37 | -123456789 | true | 0x40490FDA | 0x40A00000 | 0x3FD5555555555555 | 127 | 4660 | 305419896 | 1311768467463790320 | 101 | 2100 | - | DE AD BE EF CA FE 01 | 67 6F 6C 64 65 6E | 043C 0438 0440 | - | -832 | 80904192 | -3559993401 | 1966079999 | - | -6472691358699745 | 1512366075204170930115394234220888865
+consumed 891
+measure_at_least 895
 writer canonical

--- a/conformance/sequence.txt
+++ b/conformance/sequence.txt
@@ -16,9 +16,16 @@
 #
 #     bits <n>                                       bool
 #     align                                          float
-#     bytes <count>                                  int <min> <max>
-#     string <buffer_size>                           wstring <buffer_size>
+#     bytes <count>                                  double
+#     string <buffer_size>                           uint128
+#     wstring <buffer_size>                          int <min> <max>
+#     int64 <min> <max>                              int128 <min> <max>
+#     int_relative <previous>
+#     compressed_float <min> <max> <res>
 #     fixed <integer_bits> <fraction_bits> <min> <max>
+#
+# There is one spelling per operation, so any message this format can carry can
+# be written as a sequence, the golden message in message.txt included.
 #
 # `expect value` lists one entry per step in order, separated by ` | `, with
 # `-` for a step that produces no value of its own. `consumed` is the total

--- a/conformance/sequence.txt
+++ b/conformance/sequence.txt
@@ -195,6 +195,20 @@ param step = int 7 7
 bytes FF
 expect refused
 
+# The same vector with a degenerate FIXED POINT field as the successor. The two
+# are twins on purpose: a zero-bit field is zero bits whatever operation
+# declares it, so an implementation whose ranged int consults the failure state
+# before its degenerate case while its fixed point path returns early passes
+# the vector above and fails this one. Every read consults the failure state
+# before it does anything else, zero-bit reads included.
+
+operation sequence
+name sequence-refusal-is-terminal-before-a-zero-bit-fixed-field
+param step = bits 16
+param step = fixed 16 16 7 7
+bytes FF
+expect refused
+
 # Terminal failure inside a composite: the string's payload runs past the end,
 # and the wstring after it must refuse rather than resynchronize.
 

--- a/serialize.h
+++ b/serialize.h
@@ -36,8 +36,8 @@
 
 #define SERIALIZE_VERSION_MAJOR 1
 #define SERIALIZE_VERSION_MINOR 16
-#define SERIALIZE_VERSION_PATCH 1
-#define SERIALIZE_VERSION "1.16.1"
+#define SERIALIZE_VERSION_PATCH 2
+#define SERIALIZE_VERSION "1.16.2"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict
@@ -1977,6 +1977,7 @@ namespace serialize
                 return true;
             }
             uint32_t unsigned_value = m_reader.ReadBits( bits );
+            // the read side range rule, and the ONLY place it lives at this width: the offset is compared against the span in the unsigned domain, which cannot overflow on hostile input, and the value formed from an accepted offset is in [min,max] by construction. A second check on the decoded value behind this one is unreachable, and a rule guarded twice is a rule no negative control can measure
             if ( unsigned_value > uint32_t(max) - uint32_t(min) )
                 return Fail();
             // add in the unsigned domain: unsigned_value + min overflows signed arithmetic when the range is wider than 2^31
@@ -2016,6 +2017,7 @@ namespace serialize
                 const uint32_t hi = m_reader.ReadBits( bits - 32 );
                 unsigned_value = ( uint64_t(hi) << 32 ) | lo;
             }
+            // the read side range rule at this width, and the only place it lives. See SerializeInteger
             if ( unsigned_value > uint64_t(max) - uint64_t(min) )
                 return Fail();
             // add in the unsigned domain: unsigned_value + min overflows signed arithmetic when the range is wider than 2^63
@@ -2071,6 +2073,7 @@ namespace serialize
                 group3 = m_reader.ReadBits( bits - 96 );
             }
             const uint128_t unsigned_value = ( uint128_t( group3 ) << 96 ) | ( uint128_t( group2 ) << 64 ) | ( uint128_t( group1 ) << 32 ) | uint128_t( group0 );
+            // the read side range rule at this width, and the only place it lives. See SerializeInteger
             if ( unsigned_value > uint128_t(max) - uint128_t(min) )
                 return Fail();
             // add in the unsigned domain: unsigned_value + min overflows signed arithmetic when the range is wider than 2^127
@@ -2384,11 +2387,6 @@ namespace serialize
             }                                                           \
             if ( Stream::IsReading )                                    \
             {                                                           \
-                if ( int64_t(int32_value) < int64_t(min) ||             \
-                     int64_t(int32_value) > int64_t(max) )              \
-                {                                                       \
-                    return serialize::serialize_fail( stream );         \
-                }                                                       \
                 value = int32_value;                                    \
                 serialize_assert( int64_t(value) == int32_value );      \
             }                                                           \
@@ -2423,11 +2421,6 @@ namespace serialize
             }                                                           \
             if ( Stream::IsReading )                                    \
             {                                                           \
-                if ( int64_value < int64_t(min) ||                      \
-                     int64_value > int64_t(max) )                       \
-                {                                                       \
-                    return serialize::serialize_fail( stream );         \
-                }                                                       \
                 value = int64_value;                                    \
                 serialize_assert( int64_t(value) == int64_value );      \
             }                                                           \
@@ -2465,11 +2458,6 @@ namespace serialize
             }                                                                                       \
             if ( Stream::IsReading )                                                                \
             {                                                                                       \
-                if ( int128_value < serialize::int128_t(min) ||                                     \
-                     int128_value > serialize::int128_t(max) )                                      \
-                {                                                                                   \
-                    return serialize::serialize_fail( stream );                                     \
-                }                                                                                   \
                 value = int128_value;                                                               \
                 serialize_assert( serialize::int128_t(value) == int128_value );                     \
             }                                                                                       \
@@ -3883,10 +3871,6 @@ namespace serialize
             {                                                                               \
                 return false;                                                               \
             }                                                                               \
-            if ( int32_value < int32_t(min) || int32_value > int32_t(max) )                 \
-            {                                                                               \
-                return serialize::serialize_fail( stream );                                 \
-            }                                                                               \
             value = int32_value;                                                            \
             serialize_assert( int64_t(value) == int64_t(int32_value) );                     \
         } while (0)
@@ -3900,10 +3884,6 @@ namespace serialize
             {                                                                               \
                 return false;                                                               \
             }                                                                               \
-            if ( int64_value < int64_t(min) || int64_value > int64_t(max) )                 \
-            {                                                                               \
-                return serialize::serialize_fail( stream );                                 \
-            }                                                                               \
             value = int64_value;                                                            \
             serialize_assert( int64_t(value) == int64_value );                              \
         } while (0)
@@ -3916,11 +3896,6 @@ namespace serialize
             if ( !stream.SerializeInteger128( int128_value, min, max ) )                    \
             {                                                                               \
                 return false;                                                               \
-            }                                                                               \
-            if ( int128_value < serialize::int128_t(min) ||                                 \
-                 int128_value > serialize::int128_t(max) )                                  \
-            {                                                                               \
-                return serialize::serialize_fail( stream );                                 \
             }                                                                               \
             value = int128_value;                                                           \
             serialize_assert( serialize::int128_t(value) == int128_value );                 \

--- a/serialize.h
+++ b/serialize.h
@@ -3584,7 +3584,13 @@ namespace serialize
 
             if ( MinUnits == MaxUnits )
             {
-                // degenerate range: the value IS the range, nothing to send (STANDARD.md: min == max costs zero bits, on every storage width)
+                // degenerate range: the value IS the range, nothing to send (STANDARD.md: min == max costs zero bits, on every storage width).
+                // the zero bit field still goes through the stream, as a degenerate ranged integer, because every read consults the failure state before it does anything else: a fixed point field on a stream that has already failed must refuse, exactly as a degenerate serialize_int does. On write and on measure this costs nothing and emits nothing
+                int32_t degenerate = 0;
+                if ( !stream.SerializeInteger( degenerate, 0, 0 ) )
+                {
+                    return false;
+                }
                 if ( Stream::IsWriting )
                 {
                     serialize_assert( uint64_t( value ) == raw_min );       // all checking is performed by debug asserts on write
@@ -3681,7 +3687,13 @@ namespace serialize
             {
                 // degenerate range: the value IS the range, nothing to send. the wide path must agree
                 // with the narrow path here — FractionalBits of zeros is NOT a degenerate encoding
-                // (STANDARD.md: min == max costs zero bits, on every storage width)
+                // (STANDARD.md: min == max costs zero bits, on every storage width) — and it must
+                // consult the failure state through the stream for the same reason the narrow path does
+                int32_t degenerate = 0;
+                if ( !stream.SerializeInteger( degenerate, 0, 0 ) )
+                {
+                    return false;
+                }
                 if ( Stream::IsWriting )
                 {
                     serialize_assert( Unsigned( value ) == raw_min );       // all checking is performed by debug asserts on write

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -19,6 +19,19 @@ and refuses exactly what the document says every implementation in the family
 must, vector for vector. [conformance.cpp](../../conformance.cpp) runs the corpus
 as the ctest target `conformance`. Neither replaces the other.
 
+## The whole golden message
+
+STANDARD.md prints the message's 112 bytes and `conformance/message.txt` carries
+them as a vector. Neither is copied out of `serialize.h`. The steps and values are
+stated in [golden_message.go](golden_message.go), encoded by the corpus encoder in
+[corpus.go](corpus.go), which is written from the document, and three things must
+then agree byte for byte: that encoding, the block the page prints, and the
+library's pinned `golden_wire_bytes`. Any one of them drifting turns this tool red.
+
+Set `SERIALIZE_PRINT_GOLDEN=1` to print the encoding, its bit count and its measure
+floor, which is how the page's block and the vector are written when the message
+changes.
+
 Standard-library Go only, no compiler for the C++ needed: `golden_wire_bytes`,
 `golden_uint128_bytes`, `golden_int128_bytes`, `pinned_bytes` and the expected
 values are read out of `serialize.h` as data. Exit 0 means the document and the

--- a/tools/conformance/corpus.go
+++ b/tools/conformance/corpus.go
@@ -466,6 +466,25 @@ func encodeStep(w *BitWriter, s *step) error {
 	return nil
 }
 
+// relativeTiers is STANDARD.md's ladder, in order. The writer takes the first tier
+// the difference fits, and that encoding is the canonical one.
+var relativeTiers = []struct{ lo, hi int64 }{{2, 6}, {7, 23}, {24, 280}, {281, 4377}, {4378, 69914}}
+
+// relativeBits is the width of the encoding encodeRelative emits, which the measure
+// charges exactly: nothing in this operation depends on the bit position it starts at.
+func relativeBits(prev, current int64) int {
+	d := current - prev
+	if d == 1 {
+		return 1
+	}
+	for i, t := range relativeTiers {
+		if d >= t.lo && d <= t.hi {
+			return i + 1 + 1 + bitsRequired(t.lo, t.hi)
+		}
+	}
+	return 6 + 32
+}
+
 // encodeRelative emits the FIRST tier the difference fits, which is the
 // canonical encoding STANDARD.md's ladder defines.
 func encodeRelative(w *BitWriter, prev, current int64) {
@@ -474,8 +493,7 @@ func encodeRelative(w *BitWriter, prev, current int64) {
 		w.bits(1, 1)
 		return
 	}
-	tiers := []struct{ lo, hi int64 }{{2, 6}, {7, 23}, {24, 280}, {281, 4377}, {4378, 69914}}
-	for i, t := range tiers {
+	for i, t := range relativeTiers {
 		if d >= t.lo && d <= t.hi {
 			w.bits(0, i+1)
 			w.bits(1, 1)
@@ -518,6 +536,8 @@ func stepExactBits(s *step, bitIndex int) int {
 	case stepCompressedFloat:
 		_, n := compressedFloatParams(s.fmin, s.fmax, s.fres)
 		return n
+	case stepIntRelative:
+		return relativeBits(s.previous, s.number.Int64())
 	case stepBytes:
 		return (8-(bitIndex%8))%8 + 8*len(s.data)
 	case stepString:
@@ -713,10 +733,30 @@ func buildStep(spec string) (*step, error) {
 		s.kind, s.width = stepString, num(1)
 	case "wstring":
 		s.kind, s.width = stepWString, num(1)
-	case "int":
+	case "double":
+		s.kind = stepDouble
+	case "uint128":
+		s.kind = stepUint128
+	case "int", "int64", "int128":
 		lo, _ := parseNumber(words[1])
 		hi, _ := parseNumber(words[2])
-		s.kind, s.lo, s.hi = stepInt, lo, hi
+		s.lo, s.hi = lo, hi
+		switch words[0] {
+		case "int":
+			s.kind = stepInt
+		case "int64":
+			s.kind = stepInt64
+		default:
+			s.kind = stepInt128
+		}
+	case "int_relative":
+		s.kind, s.previous = stepIntRelative, num(1)
+	case "compressed_float":
+		f := func(i int) float32 {
+			v, _ := strconv.ParseFloat(words[i], 32)
+			return float32(v)
+		}
+		s.kind, s.fmin, s.fmax, s.fres = stepCompressedFloat, f(1), f(2), f(3)
 	case "fixed":
 		lo, _ := parseNumber(words[3])
 		hi, _ := parseNumber(words[4])

--- a/tools/conformance/golden_message.go
+++ b/tools/conformance/golden_message.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// The golden message, as a step list built from STANDARD.md's rules alone.
+//
+// STANDARD.md's Worked Example prints this message's 112 bytes, and this is where that
+// claim is proved. The steps below are the operation sequence and the values, and the
+// bytes come out of the corpus encoder in corpus.go, which is written from the document
+// and knows nothing about serialize.h. Three things are then required to agree: the bytes
+// the document's own encoder produces, the bytes the C++ writer emitted, which the library
+// pins as golden_wire_bytes, and the bytes the page prints. A page byte that no longer
+// matches is a page that has drifted, and an encoder byte that no longer matches the pin
+// is a disagreement between the document and the implementation.
+//
+// conformance/message.txt carries the same message as a vector, so every implementation in
+// the family runs it.
+
+func goldenMessageSteps() []*step {
+	n := big.NewInt
+	bits := func(width int64, value *big.Int) *step {
+		return &step{kind: stepBits, width: width, bits: value}
+	}
+	ranged := func(lo, hi, value *big.Int) *step {
+		return &step{kind: stepInt, lo: lo, hi: hi, number: value}
+	}
+	fixed := func(fractionBits uint, lo, hi, raw *big.Int) *step {
+		return &step{kind: stepFixed, fractionBits: fractionBits, lo: lo, hi: hi, number: raw}
+	}
+	pow2 := func(e uint) *big.Int { return new(big.Int).Lsh(n(1), e) }
+	neg := func(v *big.Int) *big.Int { return new(big.Int).Neg(v) }
+
+	q16_16 := n(1234*65536 + 32768)
+	q48_16 := neg(n(54321*65536 + 12345))
+	q16_16u := n(29999*65536 + 65535)
+	q112_16 := neg(new(big.Int).Add(new(big.Int).Mul(n(98765432109), n(65536)), n(4321)))
+	q64_64 := new(big.Int).Add(new(big.Int).Lsh(mustHex("0123456789ABCDEF"), 64), mustHex("0FEDCBA987654321"))
+
+	return []*step{
+		bits(4, n(13)),
+		bits(11, n(1445)),
+		bits(24, n(11259375)),
+		bits(32, mustHex("DEADBEEF")),
+		ranged(n(-100), n(100), n(-37)),
+		ranged(neg(pow2(31)), new(big.Int).Sub(pow2(31), n(1)), n(-123456789)),
+		{kind: stepBool, flag: true},
+		{kind: stepFloat, bits: n(int64(math.Float32bits(3.1415926)))},
+		{kind: stepCompressedFloat, fmin: 0, fmax: 10, fres: 0.01,
+			bits: n(int64(math.Float32bits(5.0)))},
+		{kind: stepDouble, bits: new(big.Int).SetUint64(math.Float64bits(1.0 / 3.0))},
+		bits(8, mustHex("7F")),
+		bits(16, mustHex("1234")),
+		bits(32, mustHex("12345678")),
+		bits(64, mustHex("123456789ABCDEF0")),
+		{kind: stepIntRelative, previous: 100, number: n(101)},
+		{kind: stepIntRelative, previous: 100, number: n(2100)},
+		{kind: stepAlign},
+		{kind: stepBytes, width: 7, data: []byte{0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0x01}},
+		{kind: stepString, width: 16, data: []byte("golden")},
+		{kind: stepWString, width: 8, units: []uint16{0x043C, 0x0438, 0x0440}},
+		{kind: stepAlign},
+		fixed(8, n(-100), n(100), n(-832)),
+		fixed(16, n(-2000), n(2000), q16_16),
+		fixed(16, n(-100000), n(100000), q48_16),
+		fixed(16, n(0), n(30000), q16_16u),
+		{kind: stepAlign},
+		fixed(16, neg(pow2(57)), pow2(57), q112_16),
+		fixed(64, neg(pow2(63)), new(big.Int).Sub(pow2(63), n(1)), q64_64),
+	}
+}
+
+func mustHex(text string) *big.Int {
+	v, ok := new(big.Int).SetString(text, 16)
+	if !ok {
+		panic("not hexadecimal: " + text)
+	}
+	return v
+}
+
+// formatGoldenBytes renders the message the way STANDARD.md prints it, twelve bytes to a
+// line under a four space indent. SERIALIZE_PRINT_GOLDEN emits it, which is how the page's
+// block is written when the message changes.
+func formatGoldenBytes(data []byte) string {
+	var out strings.Builder
+	for i, b := range data {
+		switch {
+		case i%12 == 0:
+			if i > 0 {
+				out.WriteString("\n")
+			}
+			out.WriteString("    ")
+		default:
+			out.WriteString(" ")
+		}
+		fmt.Fprintf(&out, "0x%02X", b)
+	}
+	return out.String()
+}
+
+// goldenBytesFromStandard reads the byte block STANDARD.md prints under the marker line,
+// exactly as hexArray reads a byte array out of serialize.h. The page is a source of
+// bytes here, not prose: if it drifts, this goes red.
+var goldenPageMarker = "The whole message is 112 bytes:"
+
+func goldenBytesFromStandard(path string) ([]byte, error) {
+	text, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(text), "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.Contains(line, goldenPageMarker) {
+			start = i + 1
+			break
+		}
+	}
+	if start < 0 {
+		return nil, fmt.Errorf("STANDARD.md does not carry the line %q, so the page's golden bytes cannot be found", goldenPageMarker)
+	}
+	pair := regexp.MustCompile(`0x([0-9A-Fa-f]{2})`)
+	var out []byte
+	seen := false
+	for _, line := range lines[start:] {
+		if strings.TrimSpace(line) == "" {
+			if seen {
+				break
+			}
+			continue
+		}
+		if !strings.HasPrefix(line, "    ") {
+			break
+		}
+		matches := pair.FindAllStringSubmatch(line, -1)
+		if len(matches) == 0 {
+			break
+		}
+		seen = true
+		for _, m := range matches {
+			out = append(out, byte(mustHex(m[1]).Int64()))
+		}
+	}
+	if !seen {
+		return nil, fmt.Errorf("STANDARD.md carries the marker line but no byte block under it")
+	}
+	return out, nil
+}
+
+func checkGoldenMessage(c *checker, standardPath string, pinned []byte) {
+	steps := goldenMessageSteps()
+
+	w := &BitWriter{}
+	for _, s := range steps {
+		if err := encodeStep(w, s); err != nil {
+			c.err("golden message encode", err)
+			return
+		}
+	}
+	consumed := w.i
+	encoded := w.flush()
+
+	c.eq("golden message: the document's own encoder reproduces the C++ writer's 112 bytes",
+		fmt.Sprintf("%X", encoded), fmt.Sprintf("%X", pinned))
+
+	if os.Getenv("SERIALIZE_PRINT_GOLDEN") != "" {
+		parts := make([]string, 0, len(steps))
+		for _, st := range steps {
+			switch st.kind {
+			case stepAlign:
+				parts = append(parts, "-")
+			case stepFloat, stepDouble, stepCompressedFloat, stepBits:
+				parts = append(parts, fmt.Sprintf("0x%X", st.bits))
+			case stepInt, stepInt64, stepInt128, stepIntRelative, stepFixed:
+				parts = append(parts, st.number.String())
+			default:
+				parts = append(parts, renderStep(st))
+			}
+		}
+		fmt.Printf("expect value = %s\n", strings.Join(parts, " | "))
+		fmt.Printf("golden message, %d bytes, %d bits consumed, measure floor %d:\n%s\n",
+			len(encoded), consumed, worstCaseBits(steps), formatGoldenBytes(encoded))
+	}
+
+	page, err := goldenBytesFromStandard(standardPath)
+	if c.err("golden message: STANDARD.md byte block", err) {
+		return
+	}
+	c.eq("golden message: STANDARD.md prints the bytes the encoder produces",
+		fmt.Sprintf("%X", page), fmt.Sprintf("%X", encoded))
+
+}

--- a/tools/conformance/verify_standard.go
+++ b/tools/conformance/verify_standard.go
@@ -512,6 +512,10 @@ func main() {
 	// checked: a check that cannot fail is not a check.)
 	c.eq("golden_wire_bytes trailing bits are zero (writer obligation)", trailingBits(data, r.i), uint8(0))
 
+	// The whole 112 bytes, encoded from the document's rules and compared against both the
+	// pinned emission and the block STANDARD.md prints. See golden_message.go.
+	checkGoldenMessage(c, filepath.Join(filepath.Dir(header), "STANDARD.md"), data)
+
 	// STANDARD.md, 'uint128': 128 raw bits, low 64-bit half first, each half as
 	// serialize_bits( half, 64 ). Verified against the library's additive pin.
 	if ub, err := hexArray(header, "golden_uint128_bytes"); !c.err("golden_uint128_bytes", err) {


### PR DESCRIPTION
Moves the family matrix onto the commit the family just re-vendored, closes three of the standard's silences, and gives the ranged int's range rule one home so a negative control can measure it.

## The family matrix

`standard_commit` and `corpus_commit` move to `7e0515e952f3373d001ec1899adf9dffb823e1c5`, which is the commit every port's re-vendor PR vendors, and each row moves to the patch version its port carries:

| runtime | release | version file today |
|---|---|---|
| serialize | `v1.16.2` | this PR bumps `CMakeLists.txt` and `serialize.h` |
| serialize.c | `v1.9.2` | merged |
| serialize.cs | `v1.9.1` | PR open |
| serialize.go | `v1.15.1` | merged, no version file: a Go module's version is its tag |
| serialize.rs | `v2.3.2` | PR open |
| serialize.js | `v1.4.2` | merged |
| serialize.dart | `v1.1.2` | merged |
| serialize.java | `v1.1.2` | PR open |
| serialize.elixir | `v1.1.2` | merged |

**The `family matrix` job is RED on this PR and will stay red until the release set is cut.** It clones each row's release and diffs what that release vendors, and none of those tags exists yet. That is the gate working rather than failing: it goes green as the tags land. This repository's own row is checked against the working checkout, which is why its version bump can be proved before it is tagged.

Every action in every workflow is now pinned by commit rather than by tag. `family-matrix.yml` already did this and the argument it makes requires it: a job whose whole subject is the difference between a pin and a moving target is not in a position to pin its own actions by tag.

## The ranged int's range rule has one home

It was guarded twice: in `ReadStream::SerializeInteger` against the decoded offset, and again in the `serialize_int` macro against the decoded value. Deleting either guard alone changed no verdict, so no vector could see either one, and a control aimed at either would have reported green while proving nothing.

The stream guard stays and the macro's check goes, at all three widths and in the read-only twins as well: `serialize_int`, `serialize_int64`, `serialize_int128`, `read_int`, `read_int64`, `read_int128`. All six were unreachable. The offset check refuses everything outside the span and forms the value from an accepted offset, which is in `[min,max]` by construction. `serialize_int_compile_time` already had the single-guard shape, which is what the rest now match.

`conformance-control-ranged-range` is the new `WILL_FAIL` target and it deletes the stream guard. **Before this change that same sabotage left the corpus completely green**, which is the whole argument for making the change:

```
$ # HEAD~, stream guard deleted, macro check still present
349 vectors from 18 file(s): 195 writer checks, 9 measure checks, 0 failure(s)

*** EVERY CONFORMANCE VECTOR PASSES ***
```

After it, the same sabotage reddens **17 vectors** and nothing else:

```
  FAIL int-range-0-8-refuse-offset-one-past-the-span: the read succeeded, the corpus requires refusal [conformance/int.txt]
  FAIL int-range-0-8-refuse-offset-fifteen: the read succeeded, the corpus requires refusal [conformance/int.txt]
  FAIL int-range-0-2-refuse-offset-three: the read succeeded, the corpus requires refusal [conformance/int.txt]
  FAIL int-negative-min-refuse-offset-one-past-the-span: the read succeeded, the corpus requires refusal [conformance/int.txt]
  FAIL int-negative-min-refuse-offset-all-ones: the read succeeded, the corpus requires refusal [conformance/int.txt]
  FAIL int-span-31-bits-refuse-offset-one-past-the-span: the read succeeded, the corpus requires refusal [conformance/int.txt]
  FAIL bounded-3-refuse-payload-one-past-the-span: the read succeeded, the corpus requires refusal [conformance/int_relative.txt]
  FAIL bounded-3-refuse-payload-all-three-bits: the read succeeded, the corpus requires refusal [conformance/int_relative.txt]
  FAIL bounded-5-refuse-payload-one-past-the-span: the read succeeded, the corpus requires refusal [conformance/int_relative.txt]
  FAIL bounded-5-refuse-payload-all-five-bits: the read succeeded, the corpus requires refusal [conformance/int_relative.txt]
  FAIL bounded-9-refuse-payload-one-past-the-span: the read succeeded, the corpus requires refusal [conformance/int_relative.txt]
  FAIL bounded-9-refuse-payload-all-nine-bits: the read succeeded, the corpus requires refusal [conformance/int_relative.txt]
  FAIL bounded-13-refuse-payload-one-past-the-span: the read succeeded, the corpus requires refusal [conformance/int_relative.txt]
  FAIL bounded-13-refuse-payload-all-thirteen-bits: the read succeeded, the corpus requires refusal [conformance/int_relative.txt]
  FAIL bounded-17-refuse-payload-one-past-the-span: the read succeeded, the corpus requires refusal [conformance/int_relative.txt]
  FAIL bounded-17-refuse-payload-all-seventeen-bits: the read succeeded, the corpus requires refusal [conformance/int_relative.txt]
  FAIL sequence-refusal-is-terminal-after-a-range-refusal: the read succeeded, the corpus requires refusal [conformance/sequence.txt]
```

The ten `int_relative` lines are the load bearing part: each bounded tier's payload is a ranged int, so the guard reaches further than its own file.

## A degenerate fixed point field consults the failure state

Reader Obligations: "Every read consults the failure state before it does anything else, zero-bit reads included, so a degenerate ranged read, an `align` on an already aligned stream, a `bytes` call of zero count and `object` all refuse on a stream that has already failed."

`ReadStream::SerializeInteger` holds that by ordering its past-end check ahead of its degenerate case, so a poisoned position refuses a zero bit read. Both `FixedPointSerializer` specializations returned `true` from the degenerate branch without touching the stream at all, so `serialize_fixed` over `min == max` **succeeded on a stream that had already refused**. Both now take the zero bit field through the stream as the degenerate ranged integer it is, so the rule has one implementation instead of two.

The corpus could not see this, because its only terminal-failure-before-a-zero-bit-field vector used a ranged int. `conformance/sequence.txt` now carries the fixed point twin, and `conformance-control-fixed-degenerate-terminal` deletes the consult again:

```
  FAIL sequence-refusal-is-terminal-before-a-zero-bit-fixed-field: step 2 succeeded after step 1 was refused; failure must be terminal [conformance/sequence.txt]
351 vectors from 18 file(s): 196 writer checks, 10 measure checks, 1 failure(s)
```

One vector, exactly the one that pins the rule.

*(Found by the agent porting this round into serialize.elixir, reading the standard against the reference.)*

## The whole golden message

STANDARD.md printed 15 of the golden message's 112 bytes and called the rest a remaining silence, because the only place the other 97 existed was an array inside `serialize.h`, and a vector copied off the implementation it judges is the failure the corpus section opens by naming.

The page now prints all 112, together with the twenty-eight operations and the value each carries, and `conformance/message.txt` carries the message as a vector: 891 bits consumed, a measure floor of 895, `writer = canonical` over the whole stream.

**The provenance is the point.** The bytes are produced by encoding the message's fields with the corpus encoder in `tools/conformance`, which is written from the document and knows nothing about `serialize.h`. Three things must then agree byte for byte, and the tool checks all three on every run: that encoding, the block the page prints, which the tool reads back out of `STANDARD.md` the way it reads a byte array out of the header, and the library's pinned `golden_wire_bytes`. Any one of them drifting turns the tool red.

Carrying the golden as a sequence needed the step vocabulary to cover every operation, so `double`, `uint128`, `int64`, `int128`, `int_relative` and `compressed_float` gain spellings, and the corpus states that there is one spelling per operation. Teaching the Go checker's measure the `int_relative` width found it charging **zero bits** for that operation, which no vector could see until a sequence contained one.

## The wstring value rule

The page now states what a `wstring` vector's value is: the transmitted UTF-16 code units, four hexadecimal digits each, and a runtime whose `wchar_t` is wider recombines surrogate pairs on read and splits them again in its runner, so both platforms owe the same units and the same bytes. That was true of the corpus and stated only in a corpus file's header.

## What remains silent

Two rows, both needing a record shape whose input is a value rather than a stream: the fixed point rounding tie, and the `compressed_float` writer inputs with the fusion witness as a write.

## What this means for the ports

The corpus grows by two vectors here, the whole golden message and the degenerate fixed point twin, so **every port re-vendors `conformance/` once more at the release set: 351 vectors in 18 files**, up from the 349 they carry now. Their runners will also need the six new sequence step spellings and a step budget above 28, since a runner that cannot drive a vector must fail rather than skip it. That is the designed behavior and it will be loud.

Nothing about that blocks this PR. The pin here names `7e0515e`, which is what the current releases vendor, and the pin moves again when the next round does.

## A family-wide consequence the ports hit, and what it says about this repository

Several ports' `interop` jobs built the reference's **corpus runner** from `SERIALIZE_TAG`, the pinned release, while vendoring `conformance/` from upstream `main`. A runner from an older release has no code for an operation the corpus grew after that release, and the standard requires it to FAIL rather than skip such a vector, so that pairing goes red by construction at every corpus expansion. It did: the `v1.16.0` runner reported **759 failures** over the 349 vectors, every one of them "no runner for this operation".

The ports fixed it by separating the two subjects rather than by moving the pin. `SERIALIZE_TAG` still governs the **wire exchange**, so "compatible with C++" means the same thing in every port, and the **corpus runner** is built from the commit the corpus comes from, because a corpus and a runner that can drive it are one artifact. Worth stating here because this repository is where both halves live: `conformance.cpp` and `conformance/` move together, and anything that pairs one with the other's release is red by construction.

## A note on the reference checkout

While this round ran, `~/rowan-working/serialize` sat on this unpushed branch, so its working tree's `STANDARD.md` and `conformance/` were already ahead of the reference commit. A port copying from the working tree rather than from `git archive <commit>` would have vendored the wrong bytes and failed spec-sync and corpus-sync, which compare against upstream `main`. The branch is pushed now so at least it is visible.

## Verified locally

- `ctest`: **10/10 pass in Debug and in Release**, including all five negative controls.
- `conformance`: **351 vectors from 18 files, 196 writer checks, 10 measure checks, 0 failures.**
- `tools/conformance`: **445 checks against STANDARD.md, 0 failures**, and it rejects the unknown-operation control.
- Both `test-fp-contract-on` and `test-fp-contract-fast` pass, which is where the compressed float discipline has teeth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
