### PR TITLE
The family matrix pins the commit the family actually vendors

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -13,7 +13,7 @@ These are the releases that carry format version 1.1:
 | [serialize.c](https://github.com/mas-bandwidth/serialize.c) | C | `v1.9.2` |
 | [serialize.cs](https://github.com/mas-bandwidth/serialize.cs) | C# | `v1.9.1` |
 | [serialize.go](https://github.com/mas-bandwidth/serialize.go) | Go | `v1.15.1` |
-| [serialize.rs](https://github.com/mas-bandwidth/serialize.rs) | Rust | `v2.3.2` |
+| [serialize.rs](https://github.com/mas-bandwidth/serialize.rs) | Rust | `v2.4.0` |
 | [serialize.js](https://github.com/mas-bandwidth/serialize.js) | JavaScript | `v1.4.2` |
 | [serialize.dart](https://github.com/mas-bandwidth/serialize.dart) | Dart | `v1.1.2` |
 | [serialize.java](https://github.com/mas-bandwidth/serialize.java) | Java | `v1.1.2` |
@@ -28,8 +28,8 @@ whether two endpoints can talk to each other.
 Every release above vendors the standard and the corpus from one commit of this
 repository:
 
-    standard_commit  7e0515e952f3373d001ec1899adf9dffb823e1c5
-    corpus_commit    7e0515e952f3373d001ec1899adf9dffb823e1c5
+    standard_commit  39cc8543bb502b83cff5046a2f865ab1ab530cb7
+    corpus_commit    39cc8543bb502b83cff5046a2f865ab1ab530cb7
 
 The pin names a commit and never a branch. `main` moves, so a claim proved
 against `main` is a claim about whatever `main` happened to be that morning. The

--- a/COMPATIBILITY.txt
+++ b/COMPATIBILITY.txt
@@ -18,8 +18,8 @@
 # separate records, and each line is a key and its value.
 
 format_version 1.1
-standard_commit 7e0515e952f3373d001ec1899adf9dffb823e1c5
-corpus_commit 7e0515e952f3373d001ec1899adf9dffb823e1c5
+standard_commit 39cc8543bb502b83cff5046a2f865ab1ab530cb7
+corpus_commit 39cc8543bb502b83cff5046a2f865ab1ab530cb7
 
 # The C++ implementation is this repository, so it vendors nothing: it is where STANDARD.md
 # and conformance/ live. Its row is checked against the working checkout rather than against
@@ -60,9 +60,9 @@ version_pattern -
 runtime serialize.rs
 language Rust
 repository mas-bandwidth/serialize.rs
-release v2.3.2
+release v2.4.0
 version_file Cargo.toml
-version_pattern version = "2.3.2"
+version_pattern version = "2.4.0"
 
 runtime serialize.js
 language JavaScript


### PR DESCRIPTION
`standard_commit` and `corpus_commit` named 7e0515e9, the commit before the one that amended STANDARD.md and grew the corpus to 351 vectors. Every release the matrix lists vendors 39cc8543, so the pin named a commit whose STANDARD.md is not the one those releases carry, and the file contradicted itself: the release it ships in has 39cc8543's standard. Both pins now name 39cc8543bb502b83cff5046a2f865ab1ab530cb7, and COMPATIBILITY.md carries the same two lines.

The Rust row moves to v2.4.0. `Stream::refuse_if_failed` is new public API since v2.3.0, the newest release on crates.io, so that port's release is a minor and not the patch this row named.

The other eight rows already name the versions their repositories carry.

**The `family matrix` job is red on this PR, and will be until the family is tagged.** Every row is checked out at its release tag, and none of the nine tags exist yet: this is the release that creates them. It is already red on `main` for the same reason. It goes green once the tags are cut, and that green on `main` is the proof, not this one.