### PR TITLE
ci: the consumer path from the published package

### DIFF
--- a/.github/workflows/consumer.yml
+++ b/.github/workflows/consumer.yml
@@ -1,0 +1,231 @@
+# The consumer path: the library as an outside user actually gets it.
+#
+# Every other job in this repository builds the working tree. That proves the
+# code is right and proves nothing about distribution, which is what a consumer
+# depends on. A formula can sit at a version behind the newest tag, install a
+# header that says it is something else, or stop resolving through
+# find_package, with every in-repo check still green.
+#
+# So this job never builds the working tree. It installs serialize from
+# homebrew/core, then configures a fresh CMake project in a temporary directory
+# outside the checkout that finds the installed package the documented way,
+# encodes a three field message, decodes it, and checks the bytes against a
+# literal written here rather than recomputed by the code under test.
+#
+# The byte literal is the family's, not this implementation's: the same three
+# values encode to the same four bytes in every port, so a change to it is a
+# wire change and belongs in STANDARD.md first.
+name: consumer
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  schedule:
+    # nightly, because homebrew/core can move without a push to this
+    # repository: a formula bump shows up here the following morning
+    - cron: "41 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  consumer:
+    name: consumer
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_ENV_HINTS: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Consume the published formula
+        run: |
+          set -u
+          status=0
+
+          if ! command -v brew >/dev/null 2>&1; then
+            if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+              eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+            else
+              echo "::error::Homebrew is not available on this runner, so the consumer path cannot be checked"
+              exit 1
+            fi
+          fi
+
+          # the version this repository claims, from the header that ships
+          repo=$(sed -n 's/^#define SERIALIZE_VERSION "\(.*\)"/\1/p' serialize.h | head -1)
+          if [ -z "$repo" ]; then
+            echo "::error::could not read SERIALIZE_VERSION out of serialize.h"
+            exit 1
+          fi
+
+          # the version homebrew/core actually serves, from the index rather
+          # than from whatever tap the runner image happens to carry
+          published=$(curl -fsS https://formulae.brew.sh/api/formula/serialize.json \
+            | jq -r '.versions.stable')
+
+          echo "repository: $repo"
+          echo "formula:    ${published:-none}"
+
+          if [ -z "$published" ] || [ "$published" = "null" ]; then
+            echo "::error::homebrew/core serves no version of serialize. There is no consumer path to check"
+            exit 1
+          fi
+
+          brew update --quiet
+          brew install serialize
+          installed=$(brew list --versions serialize | awk '{print $2}')
+          prefix=$(brew --prefix serialize)
+          echo "installed:  $installed at $prefix"
+
+          if [ "$installed" != "$published" ]; then
+            echo "::error::this runner's Homebrew installed $installed while homebrew/core serves $published. The tap on the image is behind the index"
+            status=1
+          fi
+
+          # a fresh consumer, outside the checkout, finding the installed
+          # package the way BUILDING.md tells a user to
+          consumer="$RUNNER_TEMP/consumer"
+          rm -rf "$consumer"
+          mkdir -p "$consumer"
+
+          cat > "$consumer/CMakeLists.txt" <<'CMAKE'
+          cmake_minimum_required(VERSION 3.16)
+          project(consumer LANGUAGES CXX)
+          find_package(serialize CONFIG REQUIRED)
+          add_executable(consumer main.cpp)
+          target_link_libraries(consumer PRIVATE serialize::serialize)
+          CMAKE
+
+          cat > "$consumer/main.cpp" <<'CPP'
+          // A consumer of the published formula: the include and the CMake target
+          // are the ones BUILDING.md documents, and nothing here comes from the
+          // repository this job checked out.
+          #include <serialize.h>
+
+          #include <cstdio>
+          #include <cstring>
+
+          struct Message
+          {
+              bool alive;
+              int health;
+              uint16_t sequence;
+
+              // three fields, one function, read and write from the same source
+              template <typename Stream> bool Serialize( Stream & stream )
+              {
+                  serialize_bool( stream, alive );
+                  serialize_int( stream, health, 0, 1000 );
+                  serialize_uint16( stream, sequence );
+                  return true;
+              }
+          };
+
+          int main()
+          {
+              // 1 bit + 10 bits + 16 bits = 27 bits, four bytes on the wire
+              const uint8_t want[4] = { 121, 149, 132, 0 };
+
+              printf( "SERIALIZE_VERSION %s\n", SERIALIZE_VERSION );
+
+              uint8_t buffer[64];
+              memset( buffer, 0, sizeof( buffer ) );
+
+              Message input;
+              input.alive = true;
+              input.health = 700;
+              input.sequence = 4242;
+
+              serialize::WriteStream writeStream( buffer, sizeof( buffer ) );
+              if ( !input.Serialize( writeStream ) )
+              {
+                  printf( "write failed\n" );
+                  return 1;
+              }
+              writeStream.Flush();
+
+              const int bytesWritten = (int) writeStream.GetBytesProcessed();
+              printf( "encoded %d bytes:", bytesWritten );
+              for ( int i = 0; i < bytesWritten; i++ )
+              {
+                  printf( " %d", buffer[i] );
+              }
+              printf( "\n" );
+
+              if ( bytesWritten != 4 || memcmp( buffer, want, 4 ) != 0 )
+              {
+                  printf( "wrong bytes: want %d %d %d %d\n", want[0], want[1], want[2], want[3] );
+                  return 1;
+              }
+
+              Message output;
+              memset( &output, 0, sizeof( output ) );
+              serialize::ReadStream readStream( buffer, bytesWritten );
+              if ( !output.Serialize( readStream ) )
+              {
+                  printf( "read failed\n" );
+                  return 1;
+              }
+              if ( !output.alive || output.health != 700 || output.sequence != 4242 )
+              {
+                  printf( "wrong values: %d %d %d\n", (int) output.alive, output.health, (int) output.sequence );
+                  return 1;
+              }
+              printf( "decoded %d %d %d\n", (int) output.alive, output.health, (int) output.sequence );
+              return 0;
+          }
+          CPP
+
+          cmake -S "$consumer" -B "$consumer/build" -DCMAKE_PREFIX_PATH="$prefix" \
+            -DCMAKE_BUILD_TYPE=Release > "$consumer/configure.log" 2>&1 || {
+              echo "::error::find_package(serialize CONFIG REQUIRED) failed against the installed formula"
+              cat "$consumer/configure.log"
+              exit 1
+            }
+          cmake --build "$consumer/build" --config Release
+
+          if "$consumer/build/consumer" | tee "$consumer/run.log"; then
+            :
+          else
+            echo "::error::the consumer program failed against the formula at $installed"
+            status=1
+          fi
+
+          # the compatibility check. The formula installs serialize.h and the
+          # CMake package config, so the version the package states is the
+          # constant in the header a consumer actually compiles against
+          package_version=$(sed -n 's/^SERIALIZE_VERSION \(.*\)$/\1/p' "$consumer/run.log" | head -1)
+          echo "version constant in the installed header: ${package_version:-unknown}"
+          if [ -n "$package_version" ] && [ "$package_version" != "$repo" ]; then
+            echo "::error::version mismatch: the installed serialize.h states $package_version and this repository states $repo"
+            status=1
+          fi
+
+          {
+            echo "## Consumer path"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| formula | \`homebrew/core/serialize\` |"
+            echo "| version here | \`$repo\` |"
+            echo "| version in homebrew/core | \`$published\` |"
+            echo "| version installed on this runner | \`$installed\` |"
+            echo "| version constant in the installed header | \`${package_version:-unknown}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # the drift gate. A repository ahead of the formula is a release that
+          # exists here and nowhere a consumer can reach
+          if [ "$repo" != "$published" ] && \
+             [ "$(printf '%s\n%s\n' "$published" "$repo" | sort -V | tail -n1)" = "$repo" ]; then
+            echo "::error::published version drift: this repository is at $repo and homebrew/core serves $published. Bump the formula before the consumer path can be checked against $repo"
+            status=1
+          fi
+
+          exit "$status"

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -29,7 +29,7 @@ serialize is in `homebrew/core`, so no tap is needed:
 brew install serialize
 ```
 
-The published formula is at version 1.16.0. It installs `serialize.h` and the CMake package config, so both `#include <serialize.h>` and `find_package(serialize CONFIG)` work out of the box.
+The formula installs `serialize.h` and the CMake package config, so both `#include <serialize.h>` and `find_package(serialize CONFIG)` work out of the box. The `consumer` CI job builds a fresh CMake project outside this repository against the installed formula, on every push and every night, and fails while homebrew/core is behind this repository, naming both versions. At the time of writing it is failing: the formula serves 1.16.0 and this repository is at 1.16.2.
 
 ## Using serialize in your project
 
@@ -38,7 +38,7 @@ serialize is a single header. The simplest thing is to copy `serialize.h` into y
 If you use CMake, you can consume it as a target instead — via FetchContent:
 
     include(FetchContent)
-    FetchContent_Declare(serialize GIT_REPOSITORY https://github.com/mas-bandwidth/serialize.git GIT_TAG v1.16.0)
+    FetchContent_Declare(serialize GIT_REPOSITORY https://github.com/mas-bandwidth/serialize.git GIT_TAG v1.16.2)
     FetchContent_MakeAvailable(serialize)
     target_link_libraries(your_target PRIVATE serialize::serialize)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ It has the following features:
 * Alignment support so you can align your bitstream to a byte boundary whenever you want
 * Optional template-based serialization so you can write one function that handles both read and write
 
+# Installing
+
+serialize is in `homebrew/core`, so no tap is needed:
+
+```
+brew install serialize
+```
+
+That installs `serialize.h` and the CMake package config, so both `#include <serialize.h>` and `find_package(serialize CONFIG)` work. It is a single header, so copying `serialize.h` into your project works just as well. [BUILDING.md](BUILDING.md) covers building the tests, CMake consumption and the version claims.
+
 # Usage
 
 You can use the bitpacker directly:


### PR DESCRIPTION
Item six of the production bar: a real consumer path for every distribution claim.

## What is published

**serialize is in `homebrew/core` at 1.16.0.** This repository is at 1.16.2. That was found by reading the index rather than the README, and it is the second published package in the family after the Go module proxy and crates.io.

`homebrew/core/serialize` is the only index that serves this library. There is no vcpkg port and no Conan recipe under any name, checked directly.

So the consumer job below is **expected to be red on merge**, for the right reason: the newest thing `brew install serialize` gives anyone is two patch releases behind this repository. It goes green when the formula is bumped to 1.16.2.

## The job

`consumer` never builds the working tree. It:

1. reads `SERIALIZE_VERSION` out of `serialize.h`, the version that ships
2. asks `formulae.brew.sh` what homebrew/core serves, rather than trusting whatever tap the runner image carries, and fails if the runner's installed version disagrees with the index
3. `brew install serialize`
4. writes a fresh CMake project in `$RUNNER_TEMP/consumer`, outside the checkout, that finds the installed package the way BUILDING.md tells a user to: `find_package(serialize CONFIG REQUIRED)` and `target_link_libraries(consumer PRIVATE serialize::serialize)`
5. encodes a three field message (a bool, an int in `[0,1000]`, a `uint16_t`), checks the four bytes against the literal `121 149 132 0` written into the program rather than recomputed by the code under test, and decodes it back
6. runs the family compatibility check: `SERIALIZE_VERSION` in the header a consumer actually compiles against must equal this repository's
7. gates on drift: a repository ahead of the formula fails with a message naming both versions

It runs on push, on pull requests, on `v*` tags, and nightly. Nightly matters because homebrew/core moves when the formula is bumped, with no push here to trigger anything.

The byte literal is the family's rather than this implementation's. The same three values were run through the Rust port against the published crate and the Go port against the published module, and both produce `121 149 132 0`, so a change to it here is a wire change and belongs in `STANDARD.md` first.

## Verification

Compile capacity in this session belongs to another builder, so no C++ was built locally. The parts that do not need a compiler were run against the live index:

| check | result |
|---|---|
| version out of `serialize.h` | `1.16.2` |
| `versions.stable` from `formulae.brew.sh` | `1.16.0` |
| drift gate, published 1.16.0 against repo 1.16.2 | fires |
| drift gate, published 1.16.2 against repo 1.16.2 | silent |
| drift gate, published 1.17.0 against repo 1.16.2 | silent, a formula ahead of the repository is not this job's failure |
| `SERIALIZE_VERSION` extraction from the program's output | `1.16.0` from a simulated run |

The compile and the round trip are verified by this PR's own CI run, which is where they belong.

## Documentation

The README had no install section while the library was installable with one command, so a reader had to open BUILDING.md to find the only published consumer path. It has one now.

BUILDING.md said "The published formula is at version 1.16.0", a number that has to be edited by hand to stay true. It now states the gap as it stands and names the job that keeps it honest, and the `FetchContent` example pins v1.16.2 rather than v1.16.0.