### PR TITLE
serialize 1.17.0: ReadStream::InitializePadded, and ReadBytes through the bulk copy

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -29,7 +29,7 @@ serialize is in `homebrew/core`, so no tap is needed:
 brew install serialize
 ```
 
-The formula installs `serialize.h` and the CMake package config, so both `#include <serialize.h>` and `find_package(serialize CONFIG)` work out of the box. The `consumer` CI job builds a fresh CMake project outside this repository against the installed formula, on every push and every night, and fails while homebrew/core is behind this repository, naming both versions. At the time of writing it is failing: the formula serves 1.16.0 and this repository is at 1.16.2.
+The formula installs `serialize.h` and the CMake package config, so both `#include <serialize.h>` and `find_package(serialize CONFIG)` work out of the box. The `consumer` CI job builds a fresh CMake project outside this repository against the installed formula, on every push and every night, and fails while homebrew/core is behind this repository, naming both versions. At the time of writing it is failing: the formula serves 1.16.0 and this repository is at 1.17.0.
 
 ## Using serialize in your project
 
@@ -38,7 +38,7 @@ serialize is a single header. The simplest thing is to copy `serialize.h` into y
 If you use CMake, you can consume it as a target instead — via FetchContent:
 
     include(FetchContent)
-    FetchContent_Declare(serialize GIT_REPOSITORY https://github.com/mas-bandwidth/serialize.git GIT_TAG v1.16.2)
+    FetchContent_Declare(serialize GIT_REPOSITORY https://github.com/mas-bandwidth/serialize.git GIT_TAG v1.17.0)
     FetchContent_MakeAvailable(serialize)
     target_link_libraries(your_target PRIVATE serialize::serialize)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(CMAKE_TARGET_MESSAGES OFF)
 endif()
 
-project(serialize VERSION 1.16.2 LANGUAGES CXX)
+project(serialize VERSION 1.17.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -9,7 +9,7 @@ These are the releases that carry format version 1.1:
 
 | runtime | language | release |
 |---|---|---|
-| [serialize](https://github.com/mas-bandwidth/serialize) | C++ | `v1.16.2` |
+| [serialize](https://github.com/mas-bandwidth/serialize) | C++ | `v1.17.0` |
 | [serialize.c](https://github.com/mas-bandwidth/serialize.c) | C | `v1.9.2` |
 | [serialize.cs](https://github.com/mas-bandwidth/serialize.cs) | C# | `v1.9.1` |
 | [serialize.go](https://github.com/mas-bandwidth/serialize.go) | Go | `v1.15.1` |

--- a/COMPATIBILITY.txt
+++ b/COMPATIBILITY.txt
@@ -28,9 +28,9 @@ corpus_commit 39cc8543bb502b83cff5046a2f865ab1ab530cb7
 runtime serialize
 language C++
 repository mas-bandwidth/serialize
-release v1.16.2
+release v1.17.0
 version_file CMakeLists.txt
-version_pattern project(serialize VERSION 1.16.2 LANGUAGES CXX)
+version_pattern project(serialize VERSION 1.17.0 LANGUAGES CXX)
 
 runtime serialize.c
 language C

--- a/serialize.h
+++ b/serialize.h
@@ -35,9 +35,9 @@
 /** @file */
 
 #define SERIALIZE_VERSION_MAJOR 1
-#define SERIALIZE_VERSION_MINOR 16
-#define SERIALIZE_VERSION_PATCH 2
-#define SERIALIZE_VERSION "1.16.2"
+#define SERIALIZE_VERSION_MINOR 17
+#define SERIALIZE_VERSION_PATCH 0
+#define SERIALIZE_VERSION "1.17.0"
 
 #if defined(_MSC_VER)
 #define serialize_restrict __restrict


### PR DESCRIPTION
The version bump for #122 and #123, on its own. InitializePadded is a new exported entry point, so a minor bump; the five version sites move together (serialize.h, CMakeLists.txt, COMPATIBILITY.txt and .md, BUILDING.md). No code change.